### PR TITLE
feat: add a toggle to show only feats the character has the prerequisites

### DIFF
--- a/frontend/src/common/operations/ability_block/GiveFeatOperation.tsx
+++ b/frontend/src/common/operations/ability_block/GiveFeatOperation.tsx
@@ -1,13 +1,22 @@
+import { characterState } from '@atoms/characterAtoms';
 import { SelectContentButton } from '@common/select/SelectContent';
-import { AbilityBlock } from '@typing/content';
-import { OperationWrapper } from '../Operations';
 import { prereqFilterOption } from '@common/select/filters';
+import { AbilityBlock } from '@typing/content';
+import { useRecoilValue } from 'recoil';
+import { OperationWrapper } from '../Operations';
 
 export function GiveFeatOperation(props: {
   selectedId: number;
   onSelect: (option: AbilityBlock) => void;
   onRemove: () => void;
 }) {
+  const character = useRecoilValue(characterState);
+  const DETECT_PREREQUS = character?.options?.auto_detect_prerequisites ?? false;
+  const filterOptions = DETECT_PREREQUS ? {
+    options: [
+      prereqFilterOption,
+    ],
+  } : undefined;
   return (
     <OperationWrapper onRemove={props.onRemove} title='Give Feat'>
       <SelectContentButton<AbilityBlock>
@@ -19,11 +28,7 @@ export function GiveFeatOperation(props: {
         options={{
           abilityBlockType: 'feat',
           showButton: false,
-          filterOptions: {
-            options: [
-              prereqFilterOption,
-            ],
-          },
+          filterOptions,
         }}
       />
     </OperationWrapper>

--- a/frontend/src/common/operations/ability_block/GiveFeatOperation.tsx
+++ b/frontend/src/common/operations/ability_block/GiveFeatOperation.tsx
@@ -1,6 +1,7 @@
 import { SelectContentButton } from '@common/select/SelectContent';
 import { AbilityBlock } from '@typing/content';
 import { OperationWrapper } from '../Operations';
+import { prereqFilterOption } from '@common/select/filters';
 
 export function GiveFeatOperation(props: {
   selectedId: number;
@@ -18,6 +19,11 @@ export function GiveFeatOperation(props: {
         options={{
           abilityBlockType: 'feat',
           showButton: false,
+          filterOptions: {
+            options: [
+              prereqFilterOption,
+            ],
+          },
         }}
       />
     </OperationWrapper>

--- a/frontend/src/common/select/SelectContent.tsx
+++ b/frontend/src/common/select/SelectContent.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable react-refresh/only-export-components */
+import { characterState } from '@atoms/characterAtoms';
 import { drawerState } from '@atoms/navAtoms';
 import { ActionSymbol } from '@common/Actions';
 import { BuyItemButton } from '@common/BuyItemButton';
@@ -6,6 +7,7 @@ import TraitsDisplay from '@common/TraitsDisplay';
 import { fetchContentAll, fetchContentById, fetchContentSources } from '@content/content-store';
 import { isActionCost } from '@content/content-utils';
 import { GenericData } from '@drawers/types/GenericDrawer';
+import { isItemArchaic } from '@items/inv-utils';
 import {
   ActionIcon,
   Avatar,
@@ -27,6 +29,7 @@ import {
   Popover,
   ScrollArea,
   Stack,
+  Switch,
   Tabs,
   Text,
   TextInput,
@@ -38,8 +41,9 @@ import {
 } from '@mantine/core';
 import { useDebouncedState, useDidUpdate, useHover, useMediaQuery } from '@mantine/hooks';
 import { ContextModalProps, modals, openContextModal } from '@mantine/modals';
+import { getAdjustedAncestryOperations } from '@operations/operation-controller';
+import { ObjectWithUUID } from '@operations/operation-utils';
 import {
-  IconArrowNarrowRight,
   IconCheck,
   IconChevronDown,
   IconCircleDotFilled,
@@ -47,19 +51,21 @@ import {
   IconDots,
   IconFilter,
   IconQuestionMark,
-  IconReplace,
   IconSearch,
   IconTransform,
   IconTrash,
   IconX,
-  IconZoomCheck,
-  IconZoomScan,
+  IconZoomCheck
 } from '@tabler/icons-react';
 import { useQuery } from '@tanstack/react-query';
+import { DrawerType } from '@typing/index';
 import { ExtendedProficiencyType, ProficiencyType, VariableListStr, VariableProf } from '@typing/variables';
+import { phoneQuery } from '@utils/mobile-responsive';
 import { pluralize, toLabel } from '@utils/strings';
+import { hasTraitType } from '@utils/traits';
 import { getStatBlockDisplay, getStatDisplay } from '@variables/initial-stats-display';
 import { meetsPrerequisites } from '@variables/prereq-detection';
+import { getFinalProfValue } from '@variables/variable-display';
 import {
   getAllAncestryTraitVariables,
   getAllArchetypeTraitVariables,
@@ -91,14 +97,6 @@ import {
   Trait,
   VersatileHeritage,
 } from '../../typing/content';
-import { characterState } from '@atoms/characterAtoms';
-import { DrawerType } from '@typing/index';
-import { hasTraitType } from '@utils/traits';
-import { ObjectWithUUID } from '@operations/operation-utils';
-import { isItemArchaic } from '@items/inv-utils';
-import { getAdjustedAncestryOperations } from '@operations/operation-controller';
-import { phoneQuery } from '@utils/mobile-responsive';
-import { getFinalProfValue } from '@variables/variable-display';
 
 interface FilterOptions {
   options: {
@@ -393,7 +391,7 @@ export default function SelectContentModal({
     queryFn: async ({ queryKey }) => {
       // @ts-ignore
       // eslint-disable-next-line
-      const [_key, {}] = queryKey;
+      const [_key, { }] = queryKey;
       return await fetchContentSources();
     },
     enabled: !!innerProps.options?.groupBySource && !innerProps.options?.overrideOptions,
@@ -615,7 +613,7 @@ export default function SelectContentModal({
   }, [versHeritageData]);
 
   return (
-    <Box style={{ position: 'relative', height: isClassFeat || isHeritage ? 490 : 455 }}>
+    <Box style={{ position: 'relative', height: isClassFeat || isHeritage ? 530 : 490 }}>
       <Transition mounted={openedDrawer} transition='slide-right'>
         {(styles) => (
           <Box
@@ -733,9 +731,9 @@ export default function SelectContentModal({
                   onClick={
                     innerProps.onClick
                       ? (option) => {
-                          innerProps.onClick!(option);
-                          context.closeModal(id);
-                        }
+                        innerProps.onClick!(option);
+                        context.closeModal(id);
+                      }
                       : undefined
                   }
                   filterFn={getMergedFilterFn()}
@@ -758,15 +756,15 @@ export default function SelectContentModal({
                   onClick={
                     innerProps.onClick
                       ? (option) => {
-                          innerProps.onClick!({
-                            ...option,
-                            // Need this for selection ops to work correctly
-                            // since we're not using the override options
-                            _select_uuid: `${option.id}`,
-                            _content_type: 'ability-block',
-                          } satisfies ObjectWithUUID);
-                          context.closeModal(id);
-                        }
+                        innerProps.onClick!({
+                          ...option,
+                          // Need this for selection ops to work correctly
+                          // since we're not using the override options
+                          _select_uuid: `${option.id}`,
+                          _content_type: 'ability-block',
+                        } satisfies ObjectWithUUID);
+                        context.closeModal(id);
+                      }
                       : undefined
                   }
                   filterFn={(option) =>
@@ -794,15 +792,15 @@ export default function SelectContentModal({
                   onClick={
                     innerProps.onClick
                       ? (option) => {
-                          innerProps.onClick!({
-                            ...option,
-                            // Need this for selection ops to work correctly
-                            // since we're not using the override options
-                            _select_uuid: `${option.id}`,
-                            _content_type: 'ability-block',
-                          } satisfies ObjectWithUUID);
-                          context.closeModal(id);
-                        }
+                        innerProps.onClick!({
+                          ...option,
+                          // Need this for selection ops to work correctly
+                          // since we're not using the override options
+                          _select_uuid: `${option.id}`,
+                          _content_type: 'ability-block',
+                        } satisfies ObjectWithUUID);
+                        context.closeModal(id);
+                      }
                       : undefined
                   }
                   filterFn={(option) =>
@@ -838,9 +836,9 @@ export default function SelectContentModal({
                   onClick={
                     innerProps.onClick
                       ? (option) => {
-                          innerProps.onClick!(option);
-                          context.closeModal(id);
-                        }
+                        innerProps.onClick!(option);
+                        context.closeModal(id);
+                      }
                       : undefined
                   }
                   filterFn={(option) =>
@@ -865,15 +863,15 @@ export default function SelectContentModal({
                   onClick={
                     innerProps.onClick
                       ? (option) => {
-                          innerProps.onClick!({
-                            ...option,
-                            // Need this for selection ops to work correctly
-                            // since we're not using the override options
-                            _select_uuid: `${option.id}`,
-                            _content_type: 'ability-block',
-                          } satisfies ObjectWithUUID);
-                          context.closeModal(id);
-                        }
+                        innerProps.onClick!({
+                          ...option,
+                          // Need this for selection ops to work correctly
+                          // since we're not using the override options
+                          _select_uuid: `${option.id}`,
+                          _content_type: 'ability-block',
+                        } satisfies ObjectWithUUID);
+                        context.closeModal(id);
+                      }
                       : undefined
                   }
                   filterFn={(option) => !!versHeritageData?.versHeritages.find((v) => v.heritage_id === option.id)}
@@ -900,9 +898,9 @@ export default function SelectContentModal({
               onClick={
                 innerProps.onClick
                   ? (option) => {
-                      innerProps.onClick!(option);
-                      context.closeModal(id);
-                    }
+                    innerProps.onClick!(option);
+                    context.closeModal(id);
+                  }
                   : undefined
               }
               filterFn={getMergedFilterFn()}
@@ -1003,6 +1001,19 @@ function SelectionOptions(props: {
     options = options.filter((option) => !featIds.includes(option.id) || option.meta_data?.can_select_multiple_times);
   }
 
+  const shouldShowPrereqSwitch = props.type === 'ability-block' && props.abilityBlockType === 'feat';
+
+  // Filter out prerequisites
+  const [showPrereqOnly, onPrereqChange] = useState(true);
+  if (shouldShowPrereqSwitch) {
+    if (showPrereqOnly) {
+      options = options.filter((feat) => {
+        const prereqMet = meetsPrerequisites('CHARACTER', feat.prerequisites);
+        return prereqMet.result !== 'NOT';
+      })
+    }
+  }
+
   // Filter out already selected languages
   if (
     props.overrideOptions &&
@@ -1049,18 +1060,30 @@ function SelectionOptions(props: {
     return a.name.localeCompare(b.name);
   });
 
+
+
   return (
-    <SelectionOptionsInner
-      options={filteredOptions}
-      type={props.type}
-      skillAdjustment={props.skillAdjustment}
-      abilityBlockType={props.abilityBlockType}
-      isLoading={isFetching || !options}
-      onClick={props.onClick}
-      selectedId={props.selectedId}
-      showButton={props.showButton}
-      includeOptions={props.includeOptions}
-    />
+    <>
+      {
+        shouldShowPrereqSwitch &&
+        <Switch
+          checked={showPrereqOnly}
+          onChange={() => { onPrereqChange(!showPrereqOnly) }}
+          label="Show only prerequisites met"
+        />
+      }
+      <SelectionOptionsInner
+        options={filteredOptions}
+        type={props.type}
+        skillAdjustment={props.skillAdjustment}
+        abilityBlockType={props.abilityBlockType}
+        isLoading={isFetching || !options}
+        onClick={props.onClick}
+        selectedId={props.selectedId}
+        showButton={props.showButton}
+        includeOptions={props.includeOptions}
+      />
+    </>
   );
 }
 
@@ -1119,7 +1142,7 @@ export function SelectionOptionsInner(props: {
             type={props.type}
             skillAdjustment={props.skillAdjustment}
             abilityBlockType={props.abilityBlockType}
-            onClick={props.onClick ? props.onClick : () => {}}
+            onClick={props.onClick ? props.onClick : () => { }}
             selectedId={props.selectedId}
             showButton={props.showButton}
             includeOptions={props.includeOptions}
@@ -2230,9 +2253,9 @@ export function ClassSelectionOption(props: {
     attributes.length > 0
       ? attributes[0]
       : {
-          ui: null,
-          operation: null,
-        };
+        ui: null,
+        operation: null,
+      };
 
   const openConfirmModal = () =>
     modals.openConfirmModal({
@@ -2242,7 +2265,7 @@ export function ClassSelectionOption(props: {
         <Text size='sm'>Are you sure you want to change your class? Any previous class selections will be erased.</Text>
       ),
       labels: { confirm: 'Confirm', cancel: 'Cancel' },
-      onCancel: () => {},
+      onCancel: () => { },
       onConfirm: () => props.onClick(props.class_),
     });
 
@@ -2371,7 +2394,7 @@ export function AncestrySelectionOption(props: {
         </Text>
       ),
       labels: { confirm: 'Confirm', cancel: 'Cancel' },
-      onCancel: () => {},
+      onCancel: () => { },
       onConfirm: () => props.onClick(props.ancestry),
     });
 
@@ -2499,7 +2522,7 @@ export function BackgroundSelectionOption(props: {
         </Text>
       ),
       labels: { confirm: 'Confirm', cancel: 'Cancel' },
-      onCancel: () => {},
+      onCancel: () => { },
       onConfirm: () => props.onClick(props.background),
     });
 
@@ -2607,16 +2630,16 @@ export function ItemSelectionOption(props: {
       onClick={
         props.onClick
           ? () =>
-              openDrawer({
-                type: 'item',
-                data: {
-                  id: props.item.id,
-                  onSelect:
-                    props.showButton || props.showButton === undefined ? () => props.onClick?.(props.item) : undefined,
-                },
-                extra: { addToHistory: true },
-              })
-          : () => {}
+            openDrawer({
+              type: 'item',
+              data: {
+                id: props.item.id,
+                onSelect:
+                  props.showButton || props.showButton === undefined ? () => props.onClick?.(props.item) : undefined,
+              },
+              extra: { addToHistory: true },
+            })
+          : () => { }
       }
       level={props.item.level}
       buttonOverride={
@@ -2694,16 +2717,16 @@ export function SpellSelectionOption(props: {
       onClick={
         props.onClick
           ? () =>
-              openDrawer({
-                type: 'spell',
-                data: {
-                  id: props.spell.id,
-                  onSelect:
-                    props.showButton || props.showButton === undefined ? () => props.onClick?.(props.spell) : undefined,
-                },
-                extra: { addToHistory: true },
-              })
-          : () => {}
+            openDrawer({
+              type: 'spell',
+              data: {
+                id: props.spell.id,
+                onSelect:
+                  props.showButton || props.showButton === undefined ? () => props.onClick?.(props.spell) : undefined,
+              },
+              extra: { addToHistory: true },
+            })
+          : () => { }
       }
       buttonTitle='Select'
       disableButton={props.selected}

--- a/frontend/src/common/select/filters.ts
+++ b/frontend/src/common/select/filters.ts
@@ -24,7 +24,6 @@ export const prereqFilterOption: FilterOption = {
   key: 'prereq',
   filterFn: (option: Record<string, any>) => {
     const prereqMet = meetsPrerequisites('CHARACTER', (option as AbilityBlock).prerequisites);
-    console.log('prereqMet', prereqMet);
     return prereqMet.result !== 'NOT';
   },
 }

--- a/frontend/src/common/select/filters.ts
+++ b/frontend/src/common/select/filters.ts
@@ -1,0 +1,30 @@
+import { AbilityBlock } from "@typing/content";
+import { meetsPrerequisites } from "@variables/prereq-detection";
+
+export interface FilterOption {
+  title: string;
+  type: 'MULTI-SELECT' | 'SELECT' | 'TRAITS-SELECT' | 'TEXT-INPUT' | 'NUMBER-INPUT' | 'CHECKBOX';
+  key: string;
+  options?: string[] | { label: string; value: string }[];
+  filterFn?: (option: Record<string, any>) => boolean;
+}
+
+export interface FilterOptions {
+  options: FilterOption[];
+}
+
+export interface SelectedFilter {
+  filter: FilterOption;
+  value: any;
+}
+
+export const prereqFilterOption: FilterOption = {
+  title: "Only prerequisites met",
+  type: 'CHECKBOX',
+  key: 'prereq',
+  filterFn: (option: Record<string, any>) => {
+    const prereqMet = meetsPrerequisites('CHARACTER', (option as AbilityBlock).prerequisites);
+    console.log('prereqMet', prereqMet);
+    return prereqMet.result !== 'NOT';
+  },
+}

--- a/frontend/src/pages/character_builder/CharBuilderCreation.tsx
+++ b/frontend/src/pages/character_builder/CharBuilderCreation.tsx
@@ -2064,7 +2064,12 @@ function OperationResultSelector(props: {
   level?: number;
   onChange: (path: string, value: string) => void;
 }) {
+  const character = useRecoilValue(characterState);
   const showPrereqFilter = () => {
+    const DETECT_PREREQUS = character?.options?.auto_detect_prerequisites ?? false;
+    if (!DETECT_PREREQUS) {
+      return false;
+    }
     if ((props.result?.selection?.options ?? []).length == 0) {
       return false;
     }

--- a/frontend/src/pages/character_builder/CharBuilderCreation.tsx
+++ b/frontend/src/pages/character_builder/CharBuilderCreation.tsx
@@ -5,6 +5,7 @@ import { CharacterInfo } from '@common/CharacterInfo';
 import RichText from '@common/RichText';
 import ResultWrapper from '@common/operations/results/ResultWrapper';
 import { SelectContentButton, selectContent } from '@common/select/SelectContent';
+import { prereqFilterOption } from '@common/select/filters';
 import { ICON_BG_COLOR_HOVER } from '@constants/data';
 import { fetchContentPackage, fetchContentSources } from '@content/content-store';
 import { getIconFromContentType } from '@content/content-utils';
@@ -22,12 +23,11 @@ import {
   Group,
   ScrollArea,
   Stack,
-  Tabs,
   Text,
   Title,
-  useMantineTheme,
+  useMantineTheme
 } from '@mantine/core';
-import { useDebouncedValue, useElementSize, useHover, useInterval, useMergedRef } from '@mantine/hooks';
+import { useElementSize, useHover, useInterval, useMergedRef } from '@mantine/hooks';
 import { getChoiceCounts } from '@operations/choice-count-tracker';
 import { executeCharacterOperations } from '@operations/operation-controller';
 import { OperationResult } from '@operations/operation-runner';
@@ -40,7 +40,6 @@ import { OperationResultPackage, OperationSelect } from '@typing/operations';
 import { VariableListStr, VariableProf } from '@typing/variables';
 import { displayResistWeak } from '@utils/resist-weaks';
 import { isCharacterBuilderMobile } from '@utils/screen-sizes';
-import { hasTraitType } from '@utils/traits';
 import { displayAttributeValue, displayFinalHealthValue, displayFinalProfValue } from '@variables/variable-display';
 import { getAllSkillVariables, getVariable } from '@variables/variable-manager';
 import { variableToLabel } from '@variables/variable-utils';
@@ -1518,15 +1517,15 @@ function AncestryAccordionItem(props: {
   let ancestryOperationResults = props.operationResults?.ancestryResults ?? [];
   const ancestryInitialOverviewDisplay = props.ancestry
     ? convertAncestryOperationsIntoUI(
-        props.ancestry,
-        physicalFeatures,
-        senses,
-        languages,
-        'READ/WRITE',
-        props.operationResults?.ancestryResults ?? [],
-        [character, setCharacter],
-        openDrawer
-      )
+      props.ancestry,
+      physicalFeatures,
+      senses,
+      languages,
+      'READ/WRITE',
+      props.operationResults?.ancestryResults ?? [],
+      [character, setCharacter],
+      openDrawer
+    )
     : null;
   if (ancestryInitialOverviewDisplay) {
     // Filter out operation results that are already displayed in the ancestry overview
@@ -1632,12 +1631,12 @@ function BackgroundAccordionItem(props: {
   let backgroundOperationResults = props.operationResults?.backgroundResults ?? [];
   const backgroundInitialOverviewDisplay = props.background
     ? convertBackgroundOperationsIntoUI(
-        props.background,
-        'READ/WRITE',
-        props.operationResults?.backgroundResults ?? [],
-        [character, setCharacter],
-        openDrawer
-      )
+      props.background,
+      'READ/WRITE',
+      props.operationResults?.backgroundResults ?? [],
+      [character, setCharacter],
+      openDrawer
+    )
     : null;
   if (backgroundInitialOverviewDisplay) {
     // Filter out operation results that are already displayed in the background overview
@@ -1741,12 +1740,12 @@ function ClassAccordionItem(props: {
     (props.isClass2 ? props.operationResults?.class2Results : props.operationResults?.classResults) ?? [];
   const classInitialOverviewDisplay = props.class_
     ? convertClassOperationsIntoUI(
-        props.class_,
-        'READ/WRITE',
-        (props.isClass2 ? props.operationResults?.class2Results : props.operationResults?.classResults) ?? [],
-        [character, setCharacter],
-        props.isClass2
-      )
+      props.class_,
+      'READ/WRITE',
+      (props.isClass2 ? props.operationResults?.class2Results : props.operationResults?.classResults) ?? [],
+      [character, setCharacter],
+      props.isClass2
+    )
     : null;
   if (classInitialOverviewDisplay) {
     // Filter out operation results that are already displayed in the class overview
@@ -2065,6 +2064,16 @@ function OperationResultSelector(props: {
   level?: number;
   onChange: (path: string, value: string) => void;
 }) {
+  const showPrereqFilter = () => {
+    if ((props.result?.selection?.options ?? []).length == 0) {
+      return false;
+    }
+    return props.result?.selection?.options[0]._content_type === 'ability-block' && props.result?.selection?.options[0].type === 'feat'
+  }
+  let filterOptions = undefined;
+  if (showPrereqFilter()) {
+    filterOptions = { options: [prereqFilterOption] };
+  }
   return (
     <SelectContentButton
       type={
@@ -2088,6 +2097,7 @@ function OperationResultSelector(props: {
         abilityBlockType:
           (props.result?.selection?.options ?? []).length > 0 ? props.result?.selection?.options[0].type : undefined,
         skillAdjustment: props.result?.selection?.skillAdjustment,
+        filterOptions,
       }}
     />
   );


### PR DESCRIPTION
## Proposed changes

Add a toggle switch in feat modals that show only the entries the character has the required prerequisites.

## Types of changes

What types of changes does your code introduce to Wanderer's Guide?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Screenshots

[prereq-filter.webm](https://github.com/wanderers-guide/wanderers-guide/assets/7662987/89335341-a64a-4c24-b55e-e6a47539ff41)
