### PR TITLE
fix: show quantity for items when qty = 1

### DIFF
--- a/frontend/src/process/items/inv-utils.tsx
+++ b/frontend/src/process/items/inv-utils.tsx
@@ -9,7 +9,6 @@ import { getTraitIdByType, hasTraitType } from '@utils/traits';
 import { getFinalAcValue, getFinalVariableValue } from '@variables/variable-display';
 import { getVariable } from '@variables/variable-manager';
 import { labelToVariable } from '@variables/variable-utils';
-import { color } from 'framer-motion';
 import * as _ from 'lodash-es';
 import { SetterOrUpdater } from 'recoil';
 
@@ -168,9 +167,9 @@ export function addExtraItems(items: Item[], character: Character, setCharacter:
             ...item,
             meta_data: item.meta_data
               ? {
-                  ...item.meta_data,
-                  base_item_content: baseItem,
-                }
+                ...item.meta_data,
+                base_item_content: baseItem,
+              }
               : undefined,
           },
           is_formula: false,
@@ -417,7 +416,19 @@ export function isItemWithPropertyRunes(item: Item) {
  * @returns - Whether the item is consumable
  */
 export function isItemWithQuantity(item: Item) {
-  return hasTraitType('CONSUMABLE', item.traits) || (item.meta_data?.quantity && item.meta_data.quantity > 1);
+  const nonConsumableItemFns = [
+    isItemWeapon,
+    isItemArmor,
+    isItemShield,
+    isItemContainer,
+    isItemInvestable,
+  ]
+  for (const nonConsumableFn of nonConsumableItemFns) {
+    if (nonConsumableFn(item)) {
+      return false;
+    }
+  }
+  return hasTraitType('CONSUMABLE', item.traits) || (item.meta_data?.quantity && item.meta_data.quantity > 0);
 }
 
 /**


### PR DESCRIPTION
Fixes #57 

## Proposed changes

Show the quantity for all items that doesn't fall in the weapon, armor, shield, container and invested categories.

## Types of changes

What types of changes does your code introduce to Wanderer's Guide?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Screenshots

![image](https://github.com/wanderers-guide/wanderers-guide/assets/7662987/a50bd68d-4712-4298-9a34-c7bd504a5d2a)
