### PR TITLE
Update organized play adventures to show event code when available

### DIFF
--- a/frontend/src/pages/character_sheet/panels/DetailsPanel.tsx
+++ b/frontend/src/pages/character_sheet/panels/DetailsPanel.tsx
@@ -1031,7 +1031,13 @@ function OrgPlaySection(props: { setDebouncedInfo: (info: any) => void }) {
             <Accordion.Item value={`${index}`} key={index}>
               <Accordion.Control>
                 <Group wrap='nowrap' justify='space-between' pr='xs'>
-                  <Text fz='md'>{adventure.name}</Text>
+                  {adventure.event_code !== '' ? (
+                    <Text fz='md'>
+                      {adventure.event_code}: {adventure.name}
+                    </Text>
+                  ) : (
+                    <Text fz='md'>{adventure.name}</Text>
+                  )}
                   <Button
                     size='compact-xs'
                     variant='light'


### PR DESCRIPTION
## Proposed changes

Since most organized play sessions are referenced by code it would be convenient to display the event code in the list of organized play sessions.

## Types of changes

What types of changes does your code introduce to Wanderer's Guide?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Screenshots
![image](https://github.com/wanderers-guide/wanderers-guide/assets/16946799/f2f3d622-161f-4b29-b748-772d7ec13e4f)

## Further comments

This would help players track replays much more easily since they can look up their previous sessions by the code number instead of having to open every session to check the number.