### PR TITLE
fix: prepared spell casting

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -32,3 +32,4 @@ bun.lockb
 
 # Test data
 public_user.csv
+cypress/screenshots

--- a/frontend/cypress/e2e/characters/preparedCaster.cy.ts
+++ b/frontend/cypress/e2e/characters/preparedCaster.cy.ts
@@ -1,0 +1,77 @@
+describe('Character builder', () => {
+  before(() => {
+    cy.login(Cypress.env('TEST_EMAIL'), Cypress.env('TEST_PASSWORD'));
+    cy.visit('/characters');
+    cy.get('.tabler-icon-user-plus').click();
+    cy.location('pathname').should('include', '/builder');
+
+    cy.get('input[placeholder="Unknown Wanderer"]').type('Wizard 1');
+    cy.get('button[aria-label="Next Page"]').click();
+    cy.wait(500);
+    cy.contains('Select an ancestry, background, and class to get started.').should('exist');
+
+    cy.buildABC('Elf', 'Acolyte', 'Wizard');
+
+    // Finished!
+    cy.get('button[aria-label="Next Page"]').click();
+    cy.location('pathname').should('include', '/sheet');
+  });
+
+  after(() => {
+    cy.get('button').contains('User Name').click({force: true});
+    cy.get('div.mantine-Menu-dropdown').contains('Characters').click();
+    cy.location('pathname').should('eq', '/characters');
+
+    const removeCharacter = ($el: HTMLElement) => {
+      cy.wrap($el).as('btn');
+      cy.get('@btn').click();
+      cy.contains('Delete Character').click();
+      cy.get('button').contains('Delete').click();
+    };
+
+    cy.get('button[aria-label="Options"]').each(removeCharacter);
+  });
+
+  it('should cast only one prepared spell', () => {
+    cy.contains("Spells").click();
+
+    cy.get('[data-wg-name="prepared-wizard"]').as("preparedSpells");
+    cy.get('@preparedSpells').contains("Manage").click();
+
+    // Add charm to list
+    cy.contains("Add Spell").click();
+    cy.get("div.mantine-Modal-body").get('input[placeholder="Search spells"]').last().type("Charm");
+    cy.wait(300); // Wait to filter
+    cy.contains("Select").click();
+
+    // Prepare charm twice
+    cy.get('[data-wg-name="rank-1"]').contains("Select Spell").first().click();
+    cy.get('input[placeholder="Search spells"]').last().type("Charm");
+    cy.wait(300); // Wait to filter
+    cy.get('div.mantine-Group-root').contains("Select").click();
+    cy.get('[data-wg-name="rank-1"]').contains("Select Spell").first().click();
+    cy.get('input[placeholder="Search spells"]').last().type("Charm");
+    cy.wait(300); // Wait to filter
+    cy.get('div.mantine-Group-root').contains("Select").click();
+    cy.get('button.mantine-Modal-close').last().click();
+
+    // Cast charm
+    cy.get('[data-wg-name="rank-group-1"]').as("rank1");
+    cy.get('@rank1').click();
+    cy.get('@rank1').contains('Charm').first().click();
+    cy.contains('Cast Spell 1').click();
+    cy.get('@rank1').find("div.mantine-Accordion-content").find("button").eq(0).contains("Charm").should('have.css', 'text-decoration').and('include', 'line-through');
+    cy.get('@rank1').find("div.mantine-Accordion-content").find("button").eq(1).contains('Charm').last().should('have.css', 'text-decoration').and('not.include', 'line-through');
+
+    // Cast charm again
+    cy.get('@rank1').find("div.mantine-Accordion-content").find("button").eq(1).click();
+    cy.contains('Cast Spell 1').click();
+    cy.get('@rank1').find("div.mantine-Accordion-content").find("button").eq(1).contains("Charm").should('have.css', 'text-decoration').and('include', 'line-through');
+
+    // Recover one cast
+    cy.get('@rank1').contains('Charm').first().click();
+    cy.contains('Recover Spell 1').click();
+    cy.get('@rank1').find("div.mantine-Accordion-content").find("button").eq(0).contains("Charm").should('have.css', 'text-decoration').and('not.include', 'line-through');
+    cy.get('@rank1').find("div.mantine-Accordion-content").find("button").eq(1).contains('Charm').last().should('have.css', 'text-decoration').and('include', 'line-through');
+  });
+});

--- a/frontend/src/modals/ManageSpellsModal.tsx
+++ b/frontend/src/modals/ManageSpellsModal.tsx
@@ -172,7 +172,7 @@ const SlotsSection = (props: { slots: Record<string, SpellSlot[]>; spells?: Spel
     <ScrollArea pr={14} h={`calc(min(80dvh, ${EDIT_MODAL_HEIGHT}px))`} scrollbars='y'>
       <Stack gap={10}>
         {Object.keys(props.slots).map((rank, index) => (
-          <Box key={index}>
+          <Box key={index} data-wg-name={`rank-${rank}`}>
             <Text size='md' pl={5}>
               {rank === '0' ? 'Cantrips' : `${rankNumber(parseInt(rank))}`}
             </Text>

--- a/frontend/src/pages/character_sheet/panels/SpellsPanel.tsx
+++ b/frontend/src/pages/character_sheet/panels/SpellsPanel.tsx
@@ -123,6 +123,7 @@ export default function SpellsPanel(props: { panelHeight: number; panelWidth: nu
         <ScrollArea h={props.panelHeight - 50} scrollbars='y'>
           {charData && (
             <Accordion
+              data-wg-name='spells-accordion'
               variant='separated'
               multiple
               defaultValue={[
@@ -445,7 +446,7 @@ function SpellList(props: {
     }
 
     return (
-      <Accordion.Item value={props.index}>
+      <Accordion.Item value={props.index} data-wg-name={props.index.toLowerCase()}>
         <Accordion.Control>
           <Group wrap='nowrap' justify='space-between' gap={0}>
             <Text c='gray.5' fw={700} fz='sm'>
@@ -505,7 +506,7 @@ function SpellList(props: {
                     slots[rank].length > 0 && props.hasFilters ? slots[rank].find((s) => s.spell) : true
                   )
                   .map((rank, index) => (
-                    <Accordion.Item key={index} value={`rank-group-${index}`}>
+                    <Accordion.Item key={index} value={`rank-group-${index}`} data-wg-name={`rank-group-${index}`}>
                       <Accordion.Control>
                         <Group wrap='nowrap' justify='space-between' gap={0}>
                           <Text c='gray.5' fw={700} fz='sm'>


### PR DESCRIPTION
Fixes #49

## Proposed changes

Fixed the problem when a prepared caster cast a spell with a duplicate entry in a rank. Before, all duplicate spells in a rank would be cast. Now, only one is cast.

## Types of changes

What types of changes does your code introduce to Wanderer's Guide?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Screenshots

[prepared-spells.webm](https://github.com/wanderers-guide/wanderers-guide/assets/7662987/6fbcce4a-d6e2-437e-a550-cd356494a5e6)

## Further comments

The user experience for spellcasters has some friction in it. It could be nice to rethink it to be more smooth.