### PR TITLE
Create simple money class

### DIFF
--- a/frontend/src/modals/CreateSocietyAdventureEntryModal.tsx
+++ b/frontend/src/modals/CreateSocietyAdventureEntryModal.tsx
@@ -37,10 +37,7 @@ import { convertToGp } from '@items/currency-handler';
 import { selectCondition } from '@pages/character_sheet/sections/ConditionSection';
 import { modals } from '@mantine/modals';
 import { isItemVisible } from '@content/content-hidden';
-
-export function getGpGained(entry: SocietyAdventureEntry) {
-  return (entry.items_total_sell ?? 0) / 2 - (entry.items_total_buy ?? 0) + (entry.items_total_extra ?? 0);
-}
+import { getGpGained } from '@utils/money';
 
 export function CreateSocietyAdventureEntryModal(props: {
   opened: boolean;
@@ -372,7 +369,7 @@ export function CreateSocietyAdventureEntryModal(props: {
                 label='GP Gained'
                 placeholder='Result'
                 readOnly
-                value={getGpGained(form.values)}
+                value={getGpGained(form.values).value}
                 style={{
                   whiteSpace: 'nowrap',
                 }}

--- a/frontend/src/pages/character_sheet/panels/DetailsPanel.tsx
+++ b/frontend/src/pages/character_sheet/panels/DetailsPanel.tsx
@@ -47,8 +47,9 @@ import { useMutation } from '@tanstack/react-query';
 import { JSendResponse } from '@typing/requests';
 import { useState } from 'react';
 import { getCachedPublicUser, getPublicUser } from '@auth/user-manager';
-import { CreateSocietyAdventureEntryModal, getGpGained } from '@modals/CreateSocietyAdventureEntryModal';
+import { CreateSocietyAdventureEntryModal } from '@modals/CreateSocietyAdventureEntryModal';
 import _ from 'lodash-es';
+import { Money, getGpGained } from '@utils/money';
 
 const SECTION_WIDTH = 280;
 
@@ -983,12 +984,12 @@ function OrgPlaySection(props: { setDebouncedInfo: (info: any) => void }) {
             <Center>
               <Badge size='lg' variant='light'>
                 <Text fz='sm'>
-                  {Math.round(
+                  {
                     (character?.details?.info?.organized_play_adventures ?? []).reduce(
-                      (acc, a) => acc + getGpGained(a),
-                      0
-                    ) * 100
-                  ) / 100}
+                      (acc, a) => acc.add(getGpGained(a)),
+                      new Money(0)
+                    ).value
+                  }
                 </Text>
               </Badge>
             </Center>
@@ -1069,7 +1070,7 @@ function OrgPlaySection(props: { setDebouncedInfo: (info: any) => void }) {
                   <Stack gap={0}>
                     <Text ta='center'>+GP</Text>
                     <Text ta='center' fw={600}>
-                      {getGpGained(adventure)}
+                      {getGpGained(adventure).value}
                     </Text>
                   </Stack>
                   <Stack gap={0}>

--- a/frontend/src/utils/money.ts
+++ b/frontend/src/utils/money.ts
@@ -1,0 +1,43 @@
+import { SocietyAdventureEntry } from '@typing/content';
+
+/*
+ * Helper class for handline money values (immutable)
+ */
+export class Money {
+  scale = 100;
+  _value: number = 0;
+
+  constructor(value: number, scale?: boolean) {
+    if (scale === true || scale === undefined) {
+      value = Math.round(value / this.scale);
+    }
+    this._value = value;
+  }
+
+  get value(): number {
+    return this._value * this.scale;
+  }
+
+  add(delta: Money): Money {
+    return new Money(this._value + delta._value, false);
+  }
+
+  subtract(delta: Money): Money {
+    return new Money(this._value - delta._value, false);
+  }
+
+  divideBy(delta: number): Money {
+    return new Money(Math.round(this._value / delta), false);
+  }
+
+  multiplyBy(delta: number): Money {
+    return new Money(this._value * delta, false);
+  }
+}
+
+export function getGpGained(entry: SocietyAdventureEntry) {
+  const sold = new Money(entry.items_total_sell ?? 0).divideBy(2);
+  const bought = new Money(entry.items_total_buy ?? 0);
+  const extra = new Money(entry.items_total_extra ?? 0);
+  return sold.subtract(bought).add(extra);
+}

--- a/frontend/src/utils/money.ts
+++ b/frontend/src/utils/money.ts
@@ -9,13 +9,14 @@ export class Money {
 
   constructor(value: number, scale?: boolean) {
     if (scale === true || scale === undefined) {
-      value = Math.round(value / this.scale);
+      this._value = value * this.scale;
+    } else {
+      this._value = value;
     }
-    this._value = value;
   }
 
   get value(): number {
-    return this._value * this.scale;
+    return this._value / this.scale;
   }
 
   add(delta: Money): Money {


### PR DESCRIPTION
Moved getGpGained to utilities to enable fast refresh

## Proposed changes

Fix floating point errors involving money from org play adventures.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Further comments

Created the simple Money class to avoid floating point arithmetic errors. Also moved getGpGained helper function into the utilities files to enable fast refresh for the CreateSocietyAdventureEntryModal file.