### PR TITLE
Add damage breakdown view to attacks

### DIFF
--- a/frontend/src/drawers/types/StatWeaponDrawer.tsx
+++ b/frontend/src/drawers/types/StatWeaponDrawer.tsx
@@ -51,6 +51,39 @@ export function StatWeaponDrawerContent(props: { data: { item: Item } }) {
             </Group>
           </Accordion.Panel>
         </Accordion.Item>
+
+        <Accordion.Item value='damage-breakdown'>
+          <Accordion.Control icon={<IconMathSymbols size='1rem' />}>Damage Breakdown</Accordion.Control>
+          <Accordion.Panel>
+            <Group gap={8} align='center'>
+              <Text c='gray.5' span>
+                {stats.damage.dice}
+                {stats.damage.die} + {stats.damage.bonus.total} {stats.damage.damageType}
+                {/* {stats.damage.extra ? `+ ${stats.damage.extra}` : ''} */}
+              </Text>
+              =
+              <Text c='gray.5' span>
+                {stats.damage.dice}
+                {stats.damage.die} {stats.damage.damageType} +
+              </Text>
+              {[...stats.damage.bonus.parts.keys()].map((part, index) => (
+                <Group gap={8} align='center' key={index}>
+                  <HoverCard shadow='md' openDelay={250} width={230} position='bottom' zIndex={10000} withArrow>
+                    <HoverCard.Target>
+                      <Kbd style={{ cursor: 'pointer' }}>{stats.damage.bonus.parts.get(part)}</Kbd>
+                    </HoverCard.Target>
+                    <HoverCard.Dropdown py={5} px={10}>
+                      <Text c='gray.0' size='xs'>
+                        {part}
+                      </Text>
+                    </HoverCard.Dropdown>
+                  </HoverCard>
+                  {index < [...stats.damage.bonus.parts.keys()].length - 1 ? '+' : ''}
+                </Group>
+              ))}
+            </Group>
+          </Accordion.Panel>
+        </Accordion.Item>
       </Accordion>
     </Box>
   );


### PR DESCRIPTION
## Proposed changes

Adds a damage breakdown next to the attack breakdown on the weapon drawer.

## Types of changes

What types of changes does your code introduce to Wanderer's Guide?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Screenshots

![image](https://github.com/user-attachments/assets/f24a56f3-a4c2-4731-98c0-f1140f8c6808)

## Further comments

This is a small change and will likely need extra work in the future for handling special damage types on bonuses.