### PR TITLE
feat: `confirmHealth` uses tempHp before applying damage

### DIFF
--- a/frontend/src/pages/character_sheet/living-entity-utils.ts
+++ b/frontend/src/pages/character_sheet/living-entity-utils.ts
@@ -13,32 +13,48 @@ export function confirmHealth(
   setEntity: SetterOrUpdater<LivingEntity | null>
 ) {
   const maxHealth = getFinalHealthValue(id);
+  const currentHp = entity.hp_current ?? 0;
+  const currentTempHp = entity.hp_temp ?? 0;
+  const currentTotalHp = currentHp + currentTempHp;
 
-  let result = -1;
+  let hpResult = -1;
   try {
-    result = evaluate(hp);
+    hpResult = evaluate(hp);
   } catch (e) {
-    result = parseInt(hp);
+    hpResult = parseInt(hp);
   }
-  if (isNaN(result)) result = 0;
-  result = Math.floor(result);
-  if (result < 0) result = 0;
-  if (result > maxHealth) result = maxHealth;
+  if (isNaN(hpResult)) hpResult = 0;
 
-  if (result === entity.hp_current) return;
-
-  if (maxHealth === 0) return;
-
-  let newConditions = _.cloneDeep(entity.details?.conditions ?? []);
+  let newHp = Math.min(currentHp, maxHealth);
+  let newTempHp = currentTempHp;
+  if (hpResult > currentTotalHp) {
+    // Healing
+    // Temp hp don't heal, so add to the current hp until max
+    newHp = Math.min(currentHp + hpResult, maxHealth);
+  } else {
+    // Damage
+    const damage = currentHp - hpResult;
+    // Remove from temp hp first
+    newTempHp = currentTempHp - damage;
+    // Then remove from current hp
+    if (newTempHp < 0) {
+      newHp = Math.max(currentHp + newTempHp, 0);
+      newTempHp = 0;
+    }
+  }
+  
+  if (newHp === currentHp && newTempHp === currentTempHp) return;
+  
   // Add dying condition
-  if (result === 0 && entity.hp_current > 0 && !newConditions.find((c) => c.name === 'Dying')) {
+  let newConditions = _.cloneDeep(entity.details?.conditions ?? []);
+  if (newHp === 0 && currentHp > 0 && !newConditions.find((c) => c.name === 'Dying')) {
     const dying = getConditionByName('Dying')!;
     const wounded = newConditions.find((c) => c.name === 'Wounded');
     if (wounded) {
       dying.value = 1 + wounded.value!;
     }
     newConditions.push(dying);
-  } else if (result > 0 && entity.hp_current === 0) {
+  } else if (newHp > 0 && currentHp === 0) {
     // Remove dying condition
     newConditions = newConditions.filter((c) => c.name !== 'Dying');
     // Increase wounded condition
@@ -54,7 +70,8 @@ export function confirmHealth(
     if (!c) return c;
     return {
       ...c,
-      hp_current: result,
+      hp_current: newHp,
+      hp_temp: newTempHp,
       details: {
         ...c.details,
         conditions: newConditions,
@@ -65,7 +82,7 @@ export function confirmHealth(
       },
     };
   });
-  return result;
+  return newHp;
 }
 
 export function confirmExperience(exp: string, entity: LivingEntity, setEntity: SetterOrUpdater<LivingEntity | null>) {


### PR DESCRIPTION
## Proposed changes

When applying damage to a character, the `confirmHealth` method now uses the temporary health.

Related: #119 (not a modal, but gets the job done)

## Types of changes

What types of changes does your code introduce to Wanderer's Guide?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)