### PR TITLE
fix: clumsy affects STR attacks

### DIFF
--- a/frontend/src/process/items/weapon-handler.ts
+++ b/frontend/src/process/items/weapon-handler.ts
@@ -137,7 +137,9 @@ function getMeleeAttackBonus(id: StoreID, item: Item) {
   const parts = new Map<string, number>();
   parts.set('This is your proficiency bonus with this weapon.', profData.total);
 
-  if (hasFinesse && dexMod > strMod) {
+  const usesDex = hasFinesse && dexMod > strMod;
+
+  if (usesDex) {
     parts.set(
       'This is your Dexterity modifier. Because this weapon has the finesse trait, you can use your Dexterity modifier instead of Strength on attack rolls.',
       dexMod
@@ -157,11 +159,11 @@ function getMeleeAttackBonus(id: StoreID, item: Item) {
     parts.set('This is a bonus you receive to all attack rolls.', attackBonus);
   }
 
-  if (dexAttackBonus) {
+  if (dexAttackBonus && usesDex) {
     parts.set('This is a bonus you receive to Dexterity-based attack rolls.', dexAttackBonus);
   }
 
-  if (strAttackBonus) {
+  if (strAttackBonus && !usesDex) {
     parts.set('This is a bonus you receive to Strength-based attack rolls.', strAttackBonus);
   }
 


### PR DESCRIPTION
## Proposed changes

Update the `getMeleeAttackBonus` function with the boolean `usesDex` variable to determine if the weapon uses the DEX or STR modifier for an attack. Attacks that use the STR modifier don't add the `dexAttackBonus` to its parts breakdown.

## Types of changes

What types of changes does your code introduce to Wanderer's Guide?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)