### PR TITLE
Show feat selections

### DIFF
--- a/frontend/src/common/select/SelectContent.tsx
+++ b/frontend/src/common/select/SelectContent.tsx
@@ -43,7 +43,7 @@ import {
 import { useDebouncedState, useDidUpdate, useHover, useMediaQuery } from '@mantine/hooks';
 import { ContextModalProps, modals, openContextModal } from '@mantine/modals';
 import { getAdjustedAncestryOperations } from '@operations/operation-controller';
-import { ObjectWithUUID, getSelectedOption } from '@operations/operation-utils';
+import { ObjectWithUUID, getSelectedCustomOption } from '@operations/operation-utils';
 import {
   IconCheck,
   IconChevronDown,
@@ -2094,7 +2094,7 @@ export function ClassFeatureSelectionOption(props: {
   // Find first selected option
   let selectedOption: OperationSelectOptionCustom | null = null;
   for (const op of props.classFeature.operations ?? []) {
-    const option = getSelectedOption(character, op);
+    const option = getSelectedCustomOption(character, op);
     if (option) {
       selectedOption = option;
       break;

--- a/frontend/src/drawers/types/ActionDrawer.tsx
+++ b/frontend/src/drawers/types/ActionDrawer.tsx
@@ -9,11 +9,18 @@ import { fetchContentById } from '@content/content-store';
 import ShowInjectedText from '@drawers/ShowInjectedText';
 import ShowOperationsButton from '@drawers/ShowOperationsButton';
 import { Title, Text, Image, Loader, Group, Divider, Stack, Box, Flex, List, Anchor, Button } from '@mantine/core';
-import { getSelectedOption } from '@operations/operation-utils';
+import {
+  determineFilteredSelectionList,
+  getSelectedCustomOption,
+  getSelectedOption,
+  ObjectWithUUID,
+} from '@operations/operation-utils';
 import { useQuery } from '@tanstack/react-query';
 import { AbilityBlock } from '@typing/content';
-import { Operation, OperationSelect, OperationSelectOptionCustom } from '@typing/operations';
+import { Operation, OperationSelect, OperationSelectFilters, OperationSelectOptionCustom } from '@typing/operations';
 import { toLabel } from '@utils/strings';
+import { instanceOfOperationSelectOptionCustom } from '@utils/type-fixing';
+import { useEffect, useState } from 'react';
 import { useRecoilState, useRecoilValue } from 'recoil';
 
 export function ActionDrawerTitle(props: { data: { id?: number; action?: AbilityBlock; onSelect?: () => void } }) {
@@ -197,48 +204,93 @@ export function ActionDrawerContent(props: { data: { id?: number; action?: Abili
 }
 
 export function DisplayOperationSelectionOptions(props: { operations?: Operation[] | undefined }) {
-  const [_drawer, openDrawer] = useRecoilState(drawerState);
-  const character = useRecoilValue(characterState);
-
   const operations = (props.operations ?? []).filter(
-    (op) => op.type === 'select' && (op as OperationSelect).data.optionType === 'CUSTOM'
+    (op) => op.type === 'select' && ['CUSTOM', 'ABILITY_BLOCK'].includes(op.data.optionType)
   ) as OperationSelect[];
   if (operations.length === 0) return null;
 
   return (
     <Box>
       <Divider mt={5} />
-      <Stack gap='sm'>
-        {operations.map((op, index) => (
-          <Box key={index} pt={5}>
-            <Text fz='md' fw={600}>
-              {op.data.title ?? 'Select an Option'}
-            </Text>
-            <List>
-              {((op.data.optionsPredefined ?? []) as OperationSelectOptionCustom[]).map((option, index) => (
-                <List.Item key={index}>
-                  <Anchor
-                    onClick={() => {
-                      openDrawer({
-                        type: 'generic',
-                        data: {
-                          title: option.title,
-                          description: option.description,
-                          operations: option.operations,
-                        },
-                        extra: { addToHistory: true },
-                      });
-                    }}
-                  >
-                    {option.title}
-                  </Anchor>
-                  {getSelectedOption(character, op)?.id === option.id ? ' (Selected)' : ''}
-                </List.Item>
-              ))}
-            </List>
-          </Box>
+      <Stack gap='sm'>{operations.map(DisplayOperationSelection)}</Stack>
+    </Box>
+  );
+}
+
+export function DisplayOperationSelection(op: OperationSelect, index: number) {
+  const [_drawer, openDrawer] = useRecoilState(drawerState);
+  const character = useRecoilValue(characterState);
+
+  const [options, setOptions] = useState([] as OperationSelectOptionCustom[] | ObjectWithUUID[]);
+  useEffect(() => {
+    // React advises to declare the async function directly inside useEffect
+    async function getOptions() {
+      if (op.data.modeType === 'PREDEFINED') {
+        setOptions((op.data.optionsPredefined ?? []) as OperationSelectOptionCustom[]);
+      } else {
+        setOptions(
+          await determineFilteredSelectionList(
+            op.data.optionType,
+            op.id,
+            (op.data.optionsFilters ?? []) as OperationSelectFilters
+          )
+        );
+      }
+    }
+    getOptions();
+  }, [op]);
+
+  const [selectedOption, setSelectedOption] = useState(null as OperationSelectOptionCustom | ObjectWithUUID | null);
+  useEffect(() => {
+    async function getSelection() {
+      setSelectedOption(await getSelectedOption(character, op));
+    }
+    getSelection();
+  });
+  const selectedId = instanceOfOperationSelectOptionCustom(selectedOption)
+    ? selectedOption.id
+    : selectedOption?._select_uuid;
+  console.log(selectedOption);
+
+  return (
+    <Box key={index} pt={5}>
+      <Text fz='md' fw={600}>
+        {op.data.title ?? 'Select an Option'}
+      </Text>
+      <List>
+        {options.map((option, index) => (
+          <List.Item key={index}>
+            <Anchor
+              onClick={() => {
+                openDrawer({
+                  type: instanceOfOperationSelectOptionCustom(option)
+                    ? 'generic'
+                    : option._content_type === 'ability-block'
+                      ? option.type
+                      : option._content_type,
+                  data: instanceOfOperationSelectOptionCustom(option)
+                    ? {
+                        title: option.title,
+                        description: option.description,
+                        operations: option.operations,
+                      }
+                    : { id: option?.id, action: option },
+                  extra: { addToHistory: true },
+                });
+              }}
+            >
+              {instanceOfOperationSelectOptionCustom(option) ? option.title : option.name}
+            </Anchor>
+            {instanceOfOperationSelectOptionCustom(option)
+              ? selectedId === option.id
+                ? ' (Selected)'
+                : ''
+              : selectedId === option._select_uuid
+                ? ' (Selected)'
+                : ''}
+          </List.Item>
         ))}
-      </Stack>
+      </List>
     </Box>
   );
 }

--- a/frontend/src/process/operations/operation-utils.ts
+++ b/frontend/src/process/operations/operation-utils.ts
@@ -250,7 +250,10 @@ export const hasOperationSelection = (result: OperationResult) => {
   return false;
 };
 
-export function getSelectedOption(entity: LivingEntity | null, op: Operation): OperationSelectOptionCustom | null {
+export function getSelectedCustomOption(
+  entity: LivingEntity | null,
+  op: Operation
+): OperationSelectOptionCustom | null {
   if (!entity) return null;
   if (op.type === 'select' && op.data.modeType === 'PREDEFINED' && op.data.optionType === 'CUSTOM') {
     // Custom select option
@@ -263,6 +266,35 @@ export function getSelectedOption(entity: LivingEntity | null, op: Operation): O
     ? op.data.optionsPredefined?.find((option) => option.id === entity!.operation_data!.selections![selectionKey])
     : null;
   return (selectedOption as OperationSelectOptionCustom) ?? null;
+}
+
+export async function getSelectedOption(
+  entity: LivingEntity | null,
+  op: OperationSelect
+): Promise<OperationSelectOptionCustom | ObjectWithUUID | null> {
+  if (!entity) return null;
+  if (op.type === 'select' && op.data.modeType === 'PREDEFINED' && op.data.optionType === 'CUSTOM') {
+    // Custom select option
+    const selectionKey = Object.keys(entity?.operation_data?.selections ?? {}).find((key) => key.endsWith(op.id));
+    const selectedOption = selectionKey
+      ? op.data.optionsPredefined?.find((option) => option.id === entity!.operation_data!.selections![selectionKey])
+      : null;
+    return (selectedOption as OperationSelectOptionCustom) ?? null;
+  } else {
+    const selectionKey = Object.keys(entity?.operation_data?.selections ?? {}).find((key) => key.endsWith(op.id));
+    if (!selectionKey) {
+      return null;
+    }
+    const options = await determineFilteredSelectionList(
+      op.data.optionType,
+      op.id,
+      (op.data.optionsFilters ?? []) as OperationSelectFilters
+    );
+    const selectedOption = options.find(
+      (option) => option._select_uuid === entity!.operation_data!.selections![selectionKey]
+    );
+    return (selectedOption as ObjectWithUUID) ?? null;
+  }
 }
 
 export function convertKeyToBasePrefix(key: string, id?: number): string {

--- a/frontend/src/typing/operations.d.ts
+++ b/frontend/src/typing/operations.d.ts
@@ -285,7 +285,7 @@ interface OperationSelectOptionBase {
   readonly type: OperationSelectOptionType;
 }
 
-interface OperationSelectOptionCustom extends OperationSelectOptionBase {
+export interface OperationSelectOptionCustom extends OperationSelectOptionBase {
   readonly type: 'CUSTOM';
   title: string;
   description: string;

--- a/frontend/src/utils/type-fixing.ts
+++ b/frontend/src/utils/type-fixing.ts
@@ -22,5 +22,6 @@ export function convertToSetEntity(setValue: SetterOrUpdater<Character | null> |
 }
 
 export function instanceOfOperationSelectOptionCustom(object: any): object is OperationSelectOptionCustom {
+  if (!object) return false;
   return 'type' in object && 'title' in object && 'description' in object && 'operations' in object;
 }

--- a/frontend/src/utils/type-fixing.ts
+++ b/frontend/src/utils/type-fixing.ts
@@ -1,4 +1,5 @@
 import { Character, Creature, LivingEntity } from '@typing/content';
+import { OperationSelectOptionCustom } from '@typing/operations';
 import { DefaultValue, SetterOrUpdater } from 'recoil';
 
 // Recoil's DefaultValues are annoying to work with, so we just ignore them.
@@ -18,4 +19,8 @@ export function isCreature(entity?: LivingEntity | null): entity is Creature {
 
 export function convertToSetEntity(setValue: SetterOrUpdater<Character | null> | SetterOrUpdater<Creature | null>) {
   return setValue as SetterOrUpdater<LivingEntity | null>;
+}
+
+export function instanceOfOperationSelectOptionCustom(object: any): object is OperationSelectOptionCustom {
+  return 'type' in object && 'title' in object && 'description' in object && 'operations' in object;
 }


### PR DESCRIPTION
## Proposed changes

Add a view of the selection options to ability blocks with feat selections as part of them

## Types of changes

What types of changes does your code introduce to Wanderer's Guide?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Screenshots

![image](https://github.com/user-attachments/assets/00894b10-aa3c-452c-8364-fa94c1f06b20)

## Further comments

Added features to display the selection as well as updates that allow display of the currently selected feat.