### PR TITLE
feat: default spells filters

### DIFF
--- a/frontend/src/common/select/SelectContent.tsx
+++ b/frontend/src/common/select/SelectContent.tsx
@@ -60,6 +60,7 @@ import {
 } from '@tabler/icons-react';
 import { useQuery } from '@tanstack/react-query';
 import { DrawerType } from '@typing/index';
+import { OperationSelectOptionCustom } from '@typing/operations';
 import { ExtendedProficiencyType, ProficiencyType, VariableListStr, VariableProf } from '@typing/variables';
 import { phoneQuery } from '@utils/mobile-responsive';
 import { pluralize, toLabel } from '@utils/strings';
@@ -101,8 +102,6 @@ import {
   VersatileHeritage,
 } from '../../typing/content';
 import { FilterOptions, SelectedFilter } from './filters';
-import { isAbilityBlockVisible } from '@content/content-hidden';
-import { OperationSelectOptionCustom } from '@typing/operations';
 
 export function SelectContentButton<T extends Record<string, any> = Record<string, any>>(props: {
   type: ContentType;
@@ -315,7 +314,24 @@ export default function SelectContentModal({
   const [searchQuery, setSearchQuery] = useDebouncedState('', 200);
   const [selectedSource, setSelectedSource] = useState<number | 'all'>('all');
 
-  const [filterSelections, setFilterSelections] = useState<Record<string, SelectedFilter>>({});
+  let initialFilters = {};
+
+  if (innerProps.options?.filterOptions) {
+    initialFilters = innerProps.options.filterOptions.options.reduce(
+      (acc, option) => {
+        if (option.default) {
+          acc[option.key] = {
+            filter: option,
+            value: option.default,
+          };
+        }
+        return acc;
+      },
+      {} as Record<string, SelectedFilter>,
+    );
+  }
+
+  const [filterSelections, setFilterSelections] = useState<Record<string, SelectedFilter>>(initialFilters);
   const [openedFilters, setOpenedFilters] = useState(false);
 
   const updateFilterSelection = (key: string, selectedFilter: SelectedFilter) => {
@@ -396,7 +412,7 @@ export default function SelectContentModal({
     queryFn: async ({ queryKey }) => {
       // @ts-ignore
       // eslint-disable-next-line
-      const [_key, {}] = queryKey;
+      const [_key, { }] = queryKey;
       return await fetchContentSources();
     },
     enabled: !!innerProps.options?.groupBySource && !innerProps.options?.overrideOptions,
@@ -754,9 +770,9 @@ export default function SelectContentModal({
                   onClick={
                     innerProps.onClick
                       ? (option) => {
-                          innerProps.onClick!(option);
-                          context.closeModal(id);
-                        }
+                        innerProps.onClick!(option);
+                        context.closeModal(id);
+                      }
                       : undefined
                   }
                   filterFn={getMergedFilterFn()}
@@ -780,15 +796,15 @@ export default function SelectContentModal({
                   onClick={
                     innerProps.onClick
                       ? (option) => {
-                          innerProps.onClick!({
-                            ...option,
-                            // Need this for selection ops to work correctly
-                            // since we're not using the override options
-                            _select_uuid: `${option.id}`,
-                            _content_type: 'ability-block',
-                          } satisfies ObjectWithUUID);
-                          context.closeModal(id);
-                        }
+                        innerProps.onClick!({
+                          ...option,
+                          // Need this for selection ops to work correctly
+                          // since we're not using the override options
+                          _select_uuid: `${option.id}`,
+                          _content_type: 'ability-block',
+                        } satisfies ObjectWithUUID);
+                        context.closeModal(id);
+                      }
                       : undefined
                   }
                   filterFn={(option) =>
@@ -817,15 +833,15 @@ export default function SelectContentModal({
                   onClick={
                     innerProps.onClick
                       ? (option) => {
-                          innerProps.onClick!({
-                            ...option,
-                            // Need this for selection ops to work correctly
-                            // since we're not using the override options
-                            _select_uuid: `${option.id}`,
-                            _content_type: 'ability-block',
-                          } satisfies ObjectWithUUID);
-                          context.closeModal(id);
-                        }
+                        innerProps.onClick!({
+                          ...option,
+                          // Need this for selection ops to work correctly
+                          // since we're not using the override options
+                          _select_uuid: `${option.id}`,
+                          _content_type: 'ability-block',
+                        } satisfies ObjectWithUUID);
+                        context.closeModal(id);
+                      }
                       : undefined
                   }
                   filterFn={(option) =>
@@ -862,9 +878,9 @@ export default function SelectContentModal({
                   onClick={
                     innerProps.onClick
                       ? (option) => {
-                          innerProps.onClick!(option);
-                          context.closeModal(id);
-                        }
+                        innerProps.onClick!(option);
+                        context.closeModal(id);
+                      }
                       : undefined
                   }
                   filterFn={(option) =>
@@ -890,15 +906,15 @@ export default function SelectContentModal({
                   onClick={
                     innerProps.onClick
                       ? (option) => {
-                          innerProps.onClick!({
-                            ...option,
-                            // Need this for selection ops to work correctly
-                            // since we're not using the override options
-                            _select_uuid: `${option.id}`,
-                            _content_type: 'ability-block',
-                          } satisfies ObjectWithUUID);
-                          context.closeModal(id);
-                        }
+                        innerProps.onClick!({
+                          ...option,
+                          // Need this for selection ops to work correctly
+                          // since we're not using the override options
+                          _select_uuid: `${option.id}`,
+                          _content_type: 'ability-block',
+                        } satisfies ObjectWithUUID);
+                        context.closeModal(id);
+                      }
                       : undefined
                   }
                   filterFn={(option) => !!versHeritageData?.versHeritages.find((v) => v.heritage_id === option.id)}
@@ -926,9 +942,9 @@ export default function SelectContentModal({
               onClick={
                 innerProps.onClick
                   ? (option) => {
-                      innerProps.onClick!(option);
-                      context.closeModal(id);
-                    }
+                    innerProps.onClick!(option);
+                    context.closeModal(id);
+                  }
                   : undefined
               }
               filterFn={getMergedFilterFn()}
@@ -1148,7 +1164,7 @@ export function SelectionOptionsInner(props: {
             type={props.type}
             skillAdjustment={props.skillAdjustment}
             abilityBlockType={props.abilityBlockType}
-            onClick={props.onClick ? props.onClick : () => {}}
+            onClick={props.onClick ? props.onClick : () => { }}
             selectedId={props.selectedId}
             showButton={props.showButton}
             includeOptions={props.includeOptions}
@@ -2412,9 +2428,9 @@ export function ClassSelectionOption(props: {
     attributes.length > 0
       ? attributes[0]
       : {
-          ui: null,
-          operation: null,
-        };
+        ui: null,
+        operation: null,
+      };
 
   const openConfirmModal = () =>
     modals.openConfirmModal({
@@ -2424,7 +2440,7 @@ export function ClassSelectionOption(props: {
         <Text size='sm'>Are you sure you want to change your class? Any previous class selections will be erased.</Text>
       ),
       labels: { confirm: 'Confirm', cancel: 'Cancel' },
-      onCancel: () => {},
+      onCancel: () => { },
       onConfirm: () => props.onClick(props.class_),
     });
 
@@ -2556,7 +2572,7 @@ export function AncestrySelectionOption(props: {
         </Text>
       ),
       labels: { confirm: 'Confirm', cancel: 'Cancel' },
-      onCancel: () => {},
+      onCancel: () => { },
       onConfirm: () => props.onClick(props.ancestry),
     });
 
@@ -2687,7 +2703,7 @@ export function BackgroundSelectionOption(props: {
         </Text>
       ),
       labels: { confirm: 'Confirm', cancel: 'Cancel' },
-      onCancel: () => {},
+      onCancel: () => { },
       onConfirm: () => props.onClick(props.background),
     });
 
@@ -2926,16 +2942,16 @@ export function ItemSelectionOption(props: {
       onClick={
         props.onClick
           ? () =>
-              openDrawer({
-                type: 'item',
-                data: {
-                  id: props.item.id,
-                  onSelect:
-                    props.showButton || props.showButton === undefined ? () => props.onClick?.(props.item) : undefined,
-                },
-                extra: { addToHistory: true },
-              })
-          : () => {}
+            openDrawer({
+              type: 'item',
+              data: {
+                id: props.item.id,
+                onSelect:
+                  props.showButton || props.showButton === undefined ? () => props.onClick?.(props.item) : undefined,
+              },
+              extra: { addToHistory: true },
+            })
+          : () => { }
       }
       level={props.item.level}
       buttonOverride={
@@ -3022,16 +3038,16 @@ export function SpellSelectionOption(props: {
       onClick={
         props.onClick
           ? () =>
-              openDrawer({
-                type: 'spell',
-                data: {
-                  id: props.spell.id,
-                  onSelect:
-                    props.showButton || props.showButton === undefined ? () => props.onClick?.(props.spell) : undefined,
-                },
-                extra: { addToHistory: true },
-              })
-          : () => {}
+            openDrawer({
+              type: 'spell',
+              data: {
+                id: props.spell.id,
+                onSelect:
+                  props.showButton || props.showButton === undefined ? () => props.onClick?.(props.spell) : undefined,
+              },
+              extra: { addToHistory: true },
+            })
+          : () => { }
       }
       buttonTitle='Select'
       disableButton={props.selected}

--- a/frontend/src/common/select/filters.ts
+++ b/frontend/src/common/select/filters.ts
@@ -6,6 +6,7 @@ export interface FilterOption {
   type: 'MULTI-SELECT' | 'SELECT' | 'TRAITS-SELECT' | 'TEXT-INPUT' | 'NUMBER-INPUT' | 'CHECKBOX';
   key: string;
   options?: string[] | { label: string; value: string }[];
+  default?: string[];
   isActionOption?: boolean
   filterFn?: (option: Record<string, any>) => boolean;
 }

--- a/frontend/src/modals/ManageSpellsModal.tsx
+++ b/frontend/src/modals/ManageSpellsModal.tsx
@@ -316,7 +316,7 @@ const SlotsSection = (props: {
                             {
                               title: 'Rank',
                               type: 'MULTI-SELECT',
-                              default: props.filter?.ranks,
+                              default: Array.from({ length: parseInt(rank) + 1 }, (_, i) => i.toString()),
                               options: [
                                 { label: 'Cantrip', value: '0' },
                                 { label: '1st', value: '1' },

--- a/frontend/src/modals/ManageSpellsModal.tsx
+++ b/frontend/src/modals/ManageSpellsModal.tsx
@@ -37,6 +37,10 @@ export default function ManageSpellsModal(props: {
   onClose: () => void;
   source: string;
   type: 'SLOTS-ONLY' | 'SLOTS-AND-LIST' | 'LIST-ONLY';
+  filter?: {
+    traditions?: string[];
+    ranks?: string[];
+  };
 }) {
   const isRituals = props.source === 'RITUALS';
 
@@ -130,6 +134,7 @@ export default function ManageSpellsModal(props: {
             spells={spells ?? []}
             source={props.source}
             searchQuery={searchQuery}
+            filter={props.filter}
             setSearchQuery={(val) => {
               setSearchQuery(val);
             }}
@@ -141,6 +146,7 @@ export default function ManageSpellsModal(props: {
                 spells={spells ?? []}
                 source={props.source}
                 searchQuery={searchQuery}
+                filter={props.filter}
                 setSearchQuery={(val) => {
                   setSearchQuery(val);
                 }}
@@ -148,13 +154,22 @@ export default function ManageSpellsModal(props: {
             </Grid.Col>
             <Grid.Col span={6}>
               <LoadingOverlay visible={isFetching} />
-              <SlotsSection slots={slots} spells={spells ?? []} source={props.source} />
+              <SlotsSection
+                filter={props.filter}
+                slots={slots}
+                spells={spells ?? []}
+                source={props.source}
+              />
             </Grid.Col>
           </Grid>
         ) : (
           <>
             <LoadingOverlay visible={isFetching} />
-            <SlotsSection slots={slots} source={props.source} />
+            <SlotsSection
+              filter={props.filter}
+              slots={slots}
+              source={props.source}
+            />
           </>
         )}
       </Stack>
@@ -162,7 +177,15 @@ export default function ManageSpellsModal(props: {
   );
 }
 
-const SlotsSection = (props: { slots: Record<string, SpellSlot[]>; spells?: Spell[]; source: string }) => {
+const SlotsSection = (props: {
+  slots: Record<string, SpellSlot[]>;
+  spells?: Spell[];
+  source: string;
+  filter?: {
+    traditions?: string[];
+    ranks?: string[];
+  };
+}) => {
   const theme = useMantineTheme();
   const [_drawer, openDrawer] = useRecoilState(drawerState);
   const [character, setCharacter] = useRecoilState(characterState);
@@ -269,7 +292,7 @@ const SlotsSection = (props: { slots: Record<string, SpellSlot[]>; spells?: Spel
                           //     ? props.spells.find((s) => s.id === spell.id)
                           //     : undefined;
                           // if (props.spells !== undefined && !foundSpell) return false;
-                          
+
                           if (rank === '0') {
                             return isNormalSpell(spell) && isCantrip(spell);
                           } else {
@@ -288,10 +311,12 @@ const SlotsSection = (props: { slots: Record<string, SpellSlot[]>; spells?: Spel
                                 { label: 'Primal', value: 'primal' },
                               ],
                               key: 'traditions',
+                              default: props.filter?.traditions,
                             },
                             {
                               title: 'Rank',
                               type: 'MULTI-SELECT',
+                              default: props.filter?.ranks,
                               options: [
                                 { label: 'Cantrip', value: '0' },
                                 { label: '1st', value: '1' },
@@ -328,6 +353,10 @@ const ListSection = (props: {
   source: string;
   searchQuery: string;
   setSearchQuery: (val: string) => void;
+  filter?: {
+    traditions?: string[];
+    ranks?: string[];
+  };
 }) => {
   const isRituals = props.source === 'RITUALS';
 
@@ -429,6 +458,7 @@ const ListSection = (props: {
                     {
                       title: 'Tradition',
                       type: 'MULTI-SELECT',
+                      default: props.filter?.traditions,
                       options: [
                         { label: 'Arcane', value: 'arcane' },
                         { label: 'Divine', value: 'divine' },
@@ -440,6 +470,7 @@ const ListSection = (props: {
                     {
                       title: 'Rank',
                       type: 'MULTI-SELECT',
+                      default: props.filter?.ranks,
                       options: [
                         { label: 'Cantrip', value: '0' },
                         { label: '1st', value: '1' },

--- a/frontend/src/pages/character_sheet/panels/SpellsPanel.tsx
+++ b/frontend/src/pages/character_sheet/panels/SpellsPanel.tsx
@@ -45,6 +45,10 @@ export default function SpellsPanel(props: { panelHeight: number; panelWidth: nu
     | {
       source: string;
       type: 'SLOTS-ONLY' | 'SLOTS-AND-LIST' | 'LIST-ONLY';
+      filter?: {
+        traditions?: string[];
+        ranks?: string[];
+      };
     }
     | undefined
   >();
@@ -176,7 +180,7 @@ export default function SpellsPanel(props: { panelHeight: number; panelWidth: nu
                           allSpells={allSpells}
                           type='SPONTANEOUS'
                           extra={{ slots: charData.slots.filter((s) => s.source === source.name), charData: charData }}
-                          openManageSpells={(source, type) => setManageSpells({ source, type })}
+                          openManageSpells={(source, type, filter) => setManageSpells({ source, type, filter })}
                           hasFilters={hasFilters}
                         />
                       }
@@ -191,7 +195,7 @@ export default function SpellsPanel(props: { panelHeight: number; panelWidth: nu
                           allSpells={allSpells}
                           type='PREPARED'
                           extra={{ slots: charData.slots.filter((s) => s.source === source.name), charData: charData }}
-                          openManageSpells={(source, type) => setManageSpells({ source, type })}
+                          openManageSpells={(source, type, filter) => setManageSpells({ source, type, filter })}
                           hasFilters={hasFilters}
                         />
                       }
@@ -243,6 +247,7 @@ export default function SpellsPanel(props: { panelHeight: number; panelWidth: nu
           onClose={() => setManageSpells(undefined)}
           source={manageSpells.source}
           type={manageSpells.type}
+          filter={manageSpells.filter}
         />
       )}
     </Box>
@@ -378,7 +383,14 @@ function SpellList(props: {
     innates?: SpellInnateEntry[];
   };
   hasFilters: boolean;
-  openManageSpells?: (source: string, type: 'SLOTS-ONLY' | 'SLOTS-AND-LIST' | 'LIST-ONLY') => void;
+  openManageSpells?: (
+    source: string, 
+    type: 'SLOTS-ONLY' | 'SLOTS-AND-LIST' | 'LIST-ONLY',
+    filter?: {
+      traditions?: string[];
+      ranks?: string[];
+    },
+  ) => void;
 }) {
   const [character, setCharacter] = useRecoilState(characterState);
 

--- a/frontend/src/pages/character_sheet/panels/spells_list/PreparedSpellsList.tsx
+++ b/frontend/src/pages/character_sheet/panels/spells_list/PreparedSpellsList.tsx
@@ -180,6 +180,7 @@ export default function PreparedSpellsList(props: {
                               props.source!.type === 'PREPARED-LIST' ? 'SLOTS-AND-LIST' : 'SLOTS-ONLY',
                               {
                                 traditions: [props.source!.tradition.toLowerCase()],
+                                ranks: Array.from({ length: parseInt(rank) + 1 }, (_, i) => i.toString()),
                               },
                             );
                           }}

--- a/frontend/src/pages/character_sheet/panels/spells_list/PreparedSpellsList.tsx
+++ b/frontend/src/pages/character_sheet/panels/spells_list/PreparedSpellsList.tsx
@@ -28,7 +28,14 @@ export default function PreparedSpellsList(props: {
     innates?: SpellInnateEntry[];
   };
   hasFilters: boolean;
-  openManageSpells?: (source: string, type: 'SLOTS-ONLY' | 'SLOTS-AND-LIST' | 'LIST-ONLY') => void;
+  openManageSpells?: (
+    source: string,
+    type: 'SLOTS-ONLY' | 'SLOTS-AND-LIST' | 'LIST-ONLY',
+    filter?: {
+      traditions?: string[];
+      ranks?: string[];
+    },
+  ) => void;
   slots: Dictionary<{
     spell: Spell | undefined;
     rank: number;
@@ -68,7 +75,10 @@ export default function PreparedSpellsList(props: {
                 e.preventDefault();
                 props.openManageSpells?.(
                   props.source!.name,
-                  props.source!.type === 'PREPARED-LIST' ? 'SLOTS-AND-LIST' : 'SLOTS-ONLY'
+                  props.source!.type === 'PREPARED-LIST' ? 'SLOTS-AND-LIST' : 'SLOTS-ONLY',
+                  {
+                    traditions: [props.source!.tradition.toLowerCase()],
+                  },
                 );
               }}
             >
@@ -162,7 +172,10 @@ export default function PreparedSpellsList(props: {
                           onOpenManageSpells={() => {
                             props.openManageSpells?.(
                               props.source!.name,
-                              props.source!.type === 'PREPARED-LIST' ? 'SLOTS-AND-LIST' : 'SLOTS-ONLY'
+                              props.source!.type === 'PREPARED-LIST' ? 'SLOTS-AND-LIST' : 'SLOTS-ONLY',
+                              {
+                                traditions: [props.source!.tradition.toLowerCase()],
+                              },
                             );
                           }}
                           hasFilters={props.hasFilters}

--- a/frontend/src/pages/character_sheet/panels/spells_list/PreparedSpellsList.tsx
+++ b/frontend/src/pages/character_sheet/panels/spells_list/PreparedSpellsList.tsx
@@ -47,6 +47,10 @@ export default function PreparedSpellsList(props: {
   castSpell: (cast: boolean, spell: Spell) => void;
 }) {
   const { slots, castSpell } = props;
+  const highestRank = Object.keys(slots || {}).reduce(
+    (acc, rank) => (parseInt(rank) > acc ? parseInt(rank) : acc),
+    0,
+  );
   // If there are no spells to display, and there are filters, return null
   if (
     props.hasFilters &&
@@ -78,6 +82,7 @@ export default function PreparedSpellsList(props: {
                   props.source!.type === 'PREPARED-LIST' ? 'SLOTS-AND-LIST' : 'SLOTS-ONLY',
                   {
                     traditions: [props.source!.tradition.toLowerCase()],
+                    ranks: Array.from({ length: highestRank + 1 }, (_, i) => i.toString()),
                   },
                 );
               }}

--- a/frontend/src/pages/character_sheet/panels/spells_list/SpontaneousSpellsList.tsx
+++ b/frontend/src/pages/character_sheet/panels/spells_list/SpontaneousSpellsList.tsx
@@ -53,6 +53,10 @@ export default function SpontaneousSpellsList(props: {
   setCharacter: SetterOrUpdater<Character | null>;
 }) {
   const { slots, castSpell, spells, setCharacter, } = props;
+  const highestRank = Object.keys(slots || {}).reduce(
+    (acc, rank) => (parseInt(rank) > acc ? parseInt(rank) : acc),
+    0,
+  );
   // If there are no spells to display, and there are filters, return null
   if (
     props.hasFilters &&
@@ -84,6 +88,7 @@ export default function SpontaneousSpellsList(props: {
                   'LIST-ONLY',
                   {
                     traditions: [props.source!.tradition.toLowerCase()],
+                    ranks: Array.from({ length: highestRank + 1 }, (_, i) => i.toString()),
                   },
                 );
               }}

--- a/frontend/src/pages/character_sheet/panels/spells_list/SpontaneousSpellsList.tsx
+++ b/frontend/src/pages/character_sheet/panels/spells_list/SpontaneousSpellsList.tsx
@@ -32,7 +32,14 @@ export default function SpontaneousSpellsList(props: {
     innates?: SpellInnateEntry[];
   };
   hasFilters: boolean;
-  openManageSpells?: (source: string, type: 'SLOTS-ONLY' | 'SLOTS-AND-LIST' | 'LIST-ONLY') => void;
+  openManageSpells?: (
+    source: string,
+    type: 'SLOTS-ONLY' | 'SLOTS-AND-LIST' | 'LIST-ONLY',
+    filter?: {
+      traditions?: string[];
+      ranks?: string[];
+    },
+  ) => void;
   slots: Dictionary<{
     spell: Spell | undefined;
     rank: number;
@@ -72,7 +79,13 @@ export default function SpontaneousSpellsList(props: {
               onClick={(e) => {
                 e.stopPropagation();
                 e.preventDefault();
-                props.openManageSpells?.(props.source!.name, 'LIST-ONLY');
+                props.openManageSpells?.(
+                  props.source!.name,
+                  'LIST-ONLY',
+                  {
+                    traditions: [props.source!.tradition.toLowerCase()],
+                  },
+                );
               }}
             >
               Manage
@@ -200,7 +213,10 @@ export default function SpontaneousSpellsList(props: {
                           onOpenManageSpells={() => {
                             props.openManageSpells?.(
                               props.source!.name,
-                              props.source!.type === 'PREPARED-LIST' ? 'SLOTS-AND-LIST' : 'SLOTS-ONLY'
+                              props.source!.type === 'PREPARED-LIST' ? 'SLOTS-AND-LIST' : 'SLOTS-ONLY',
+                              {
+                                traditions: [props.source!.tradition.toLowerCase()],
+                              },
                             );
                           }}
                           hasFilters={props.hasFilters}


### PR DESCRIPTION
## Proposed changes

Adds the tradition and rank as default options for the spell filters.

Closes #132 
Closes #61 

## Types of changes

What types of changes does your code introduce to Wanderer's Guide?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Screenshots

[spells-filters.webm](https://github.com/user-attachments/assets/5986d69a-76a1-4447-b0cd-253384b2e343)