### PR TITLE
Limit displayed selections

### DIFF
--- a/frontend/src/drawers/types/ActionDrawer.tsx
+++ b/frontend/src/drawers/types/ActionDrawer.tsx
@@ -24,6 +24,8 @@ import { instanceOfOperationSelectOptionCustom } from '@utils/type-fixing';
 import { useEffect, useState } from 'react';
 import { useRecoilState, useRecoilValue } from 'recoil';
 
+const SELECTION_DISPLAY_LIMIT = 25;
+
 export function ActionDrawerTitle(props: { data: { id?: number; action?: AbilityBlock; onSelect?: () => void } }) {
   const id = props.data.id;
 
@@ -235,6 +237,9 @@ export function DisplayOperationSelection(op: OperationSelect, index: number) {
           (op.data.optionsFilters ?? []) as OperationSelectFilters
         );
         ops.sort(sortObjectByName);
+        if (ops.length > SELECTION_DISPLAY_LIMIT) {
+          ops.length = SELECTION_DISPLAY_LIMIT;
+        }
         setOptions(ops);
       }
     }

--- a/frontend/src/drawers/types/ActionDrawer.tsx
+++ b/frontend/src/drawers/types/ActionDrawer.tsx
@@ -225,6 +225,7 @@ export function DisplayOperationSelection(op: OperationSelect, index: number) {
   const character = useRecoilValue(characterState);
 
   const [options, setOptions] = useState([] as OperationSelectOptionCustom[] | ObjectWithUUID[]);
+  const [more, setMore] = useState(null as string | null);
   useEffect(() => {
     // React advises to declare the async function directly inside useEffect
     async function getOptions() {
@@ -238,6 +239,7 @@ export function DisplayOperationSelection(op: OperationSelect, index: number) {
         );
         ops.sort(sortObjectByName);
         if (ops.length > SELECTION_DISPLAY_LIMIT) {
+          setMore(`and ${ops.length - SELECTION_DISPLAY_LIMIT} more...`);
           ops.length = SELECTION_DISPLAY_LIMIT;
         }
         setOptions(ops);
@@ -296,6 +298,7 @@ export function DisplayOperationSelection(op: OperationSelect, index: number) {
                 : ''}
           </List.Item>
         ))}
+        {more === null ? null : <List.Item key={options.length}>{more}</List.Item>}
       </List>
     </Box>
   );


### PR DESCRIPTION
## Proposed changes

Limits the number of non-custom selections displayed to 25.

## Types of changes

What types of changes does your code introduce to Wanderer's Guide?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Further comments

This prevents a massive list of feats from being displayed in cases of expansive selections such as "all skill feats" or mistakes in content submissions. On low memory devices this also prevents crashes when displaying such long lists.
Does not affect the length of custom lists.