### PR TITLE
feat: show rune damage

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,4 +40,3 @@ id,created_at,user_id,display_name,image_url,background_image_url,site_theme,is_
 1,2024-04-03 21:30:01.720023+00,UUID HERE,User Name,,,,false,false,false,,,,,true,
 ```
 4. Login with the email and password
-

--- a/README.md
+++ b/README.md
@@ -40,3 +40,4 @@ id,created_at,user_id,display_name,image_url,background_image_url,site_theme,is_
 1,2024-04-03 21:30:01.720023+00,UUID HERE,User Name,,,,false,false,false,,,,,true,
 ```
 4. Login with the email and password
+

--- a/frontend/src/common/ItemIcon.tsx
+++ b/frontend/src/common/ItemIcon.tsx
@@ -29,7 +29,7 @@ type ItemIconType =
   | 'CONTAINER'
   | 'HIGH_TECH_GUN';
 
-const getIconMap = (size: string, color: string): Record<ItemIconType, JSX.Element> => ({
+export const getIconMap = (size: string, color: string): Record<ItemIconType, JSX.Element> => ({
   GENERAL: <GiSwapBag color={color} size={size} />,
   ARMOR: <GiChestArmor color={color} size={size} />,
   WEAPON: <GiBroadsword color={color} size={size} />,

--- a/frontend/src/common/ItemRunesDescription.tsx
+++ b/frontend/src/common/ItemRunesDescription.tsx
@@ -1,0 +1,35 @@
+import { isItemWithPropertyRunes } from "@items/inv-utils";
+import { Divider, Group, Text, useMantineTheme } from "@mantine/core";
+import { Item } from "@typing/content";
+import { GiRuneStone } from "react-icons/gi";
+import RichText from "./RichText";
+import { getIconMap } from "./ItemIcon";
+
+export function ItemRunesDescription(
+  props: {
+    item: Item;
+  }
+) {
+  const theme = useMantineTheme();
+  const { item } = props;
+
+  if (!isItemWithPropertyRunes(item)) {
+    return <></>;
+  }
+
+  const runes = item.meta_data?.runes?.property || [];
+  runes.sort((a, b) => a.name.localeCompare(b.name));
+
+  return <>
+    {runes.map(
+      (rune, _) => <>
+        <Divider />
+        <Group>
+          {getIconMap('1.0rem', theme.colors.gray[6])['RUNE']}
+          <Text fw={600} c='gray.5' span>{rune.name}</Text>
+        </Group>
+        <RichText>{rune.rune?.description}</RichText>
+      </>
+    )}
+  </>;
+}

--- a/frontend/src/drawers/types/InvItemDrawer.tsx
+++ b/frontend/src/drawers/types/InvItemDrawer.tsx
@@ -60,6 +60,7 @@ import { getArmorSpecialization } from '@specializations/armor-specializations';
 import { getWeaponSpecialization } from '@specializations/weapon-specializations';
 import { drawerState } from '@atoms/navAtoms';
 import TokenSelect from '@common/TokenSelect';
+import { ItemRunesDescription } from '@common/ItemRunesDescription';
 
 export function InvItemDrawerTitle(props: { data: { invItem: InventoryItem } }) {
   let type = `Item ${props.data.invItem.item.level}`;
@@ -201,6 +202,8 @@ export function InvItemDrawerContent(props: {
         <RichText ta='justify' store='CHARACTER' py={5}>
           {invItem.item.description}
         </RichText>
+
+        <ItemRunesDescription item={invItem.item} />
 
         {craftReq && (
           <>

--- a/frontend/src/drawers/types/InvItemDrawer.tsx
+++ b/frontend/src/drawers/types/InvItemDrawer.tsx
@@ -18,7 +18,7 @@ import {
   isItemWithRunes,
   labelizeBulk,
 } from '@items/inv-utils';
-import { getWeaponStats } from '@items/weapon-handler';
+import { getWeaponStats, parseOtherDamage } from '@items/weapon-handler';
 import {
   ActionIcon,
   Badge,
@@ -596,8 +596,9 @@ function InvItemSections(props: {
             <Text c='gray.5' span>
               {weaponStats.damage.dice}
               {weaponStats.damage.die}
-              {damageBonus} {weaponStats.damage.damageType}{' '}
-              {/* {weaponStats.damage.extra ? `+ ${weaponStats.damage.extra}` : ''} */}
+              {damageBonus} {weaponStats.damage.damageType}
+              {parseOtherDamage(weaponStats.damage.other)}
+              {weaponStats.damage.extra ? `+ ${weaponStats.damage.extra}` : ''}
             </Text>
           </Group>
         </Group>

--- a/frontend/src/drawers/types/ItemDrawer.tsx
+++ b/frontend/src/drawers/types/ItemDrawer.tsx
@@ -50,6 +50,7 @@ import { getWeaponSpecialization } from '@specializations/weapon-specializations
 import { SetterOrUpdater, useRecoilState } from 'recoil';
 import { drawerState } from '@atoms/navAtoms';
 import ShowInjectedText from '@drawers/ShowInjectedText';
+import { ItemRunesDescription } from '@common/ItemRunesDescription';
 
 export function ItemDrawerTitle(props: { data: { id?: number; item?: Item } }) {
   const id = props.data.id;
@@ -226,6 +227,8 @@ export function ItemDrawerContent(props: {
         <RichText ta='justify' py={5}>
           {item.description}
         </RichText>
+
+        <ItemRunesDescription item={item} />
 
         {craftReq && (
           <>

--- a/frontend/src/drawers/types/ItemDrawer.tsx
+++ b/frontend/src/drawers/types/ItemDrawer.tsx
@@ -19,7 +19,7 @@ import {
   isItemWithRunes,
   labelizeBulk,
 } from '@items/inv-utils';
-import { getWeaponStats } from '@items/weapon-handler';
+import { getWeaponStats, parseOtherDamage } from '@items/weapon-handler';
 import {
   Title,
   Text,
@@ -362,8 +362,9 @@ function MiscItemSections(props: { item: Item; store: StoreID; openDrawer: Sette
             <Text c='gray.5' span>
               {weaponStats.damage.dice}
               {weaponStats.damage.die}
-              {damageBonus} {weaponStats.damage.damageType}{' '}
-              {/* {weaponStats.damage.extra ? `+ ${weaponStats.damage.extra}` : ''} */}
+              {damageBonus} {weaponStats.damage.damageType}
+              {parseOtherDamage(weaponStats.damage.other)}
+              {weaponStats.damage.extra ? `+ ${weaponStats.damage.extra}` : ''}
             </Text>
           </Group>
         </Group>

--- a/frontend/src/drawers/types/StatWeaponDrawer.tsx
+++ b/frontend/src/drawers/types/StatWeaponDrawer.tsx
@@ -1,9 +1,8 @@
-import { getWeaponStats } from '@items/weapon-handler';
-import { Title, Text, Group, Box, Accordion, Kbd, HoverCard } from '@mantine/core';
+import { getWeaponStats, parseOtherDamage } from '@items/weapon-handler';
+import { Accordion, Box, Group, HoverCard, Kbd, Text, Title } from '@mantine/core';
 import { IconMathSymbols } from '@tabler/icons-react';
 import { Item } from '@typing/content';
 import { sign } from '@utils/numbers';
-import * as _ from 'lodash-es';
 
 export function StatWeaponDrawerTitle(props: { data: { item: Item } }) {
   return (
@@ -59,7 +58,8 @@ export function StatWeaponDrawerContent(props: { data: { item: Item } }) {
               <Text c='gray.5' span>
                 {stats.damage.dice}
                 {stats.damage.die} + {stats.damage.bonus.total} {stats.damage.damageType}
-                {/* {stats.damage.extra ? `+ ${stats.damage.extra}` : ''} */}
+                {parseOtherDamage(stats.damage.other)}
+                {stats.damage.extra ? `+ ${stats.damage.extra}` : ''}
               </Text>
               =
               <Text c='gray.5' span>

--- a/frontend/src/modals/CreateItemModal.tsx
+++ b/frontend/src/modals/CreateItemModal.tsx
@@ -1,4 +1,3 @@
-import { drawerState } from '@atoms/navAtoms';
 import { ItemMultiSelect, ItemSelect } from '@common/ItemSelect';
 import TraitsInput from '@common/TraitsInput';
 import { OperationSection } from '@common/operations/Operations';
@@ -7,7 +6,6 @@ import { selectContent } from '@common/select/SelectContent';
 import { DISCORD_URL, EDIT_MODAL_HEIGHT } from '@constants/data';
 import { fetchContentById, fetchTraits } from '@content/content-store';
 import { toHTML } from '@content/content-utils';
-import { convertToGp } from '@items/currency-handler';
 import {
   Accordion,
   ActionIcon,
@@ -15,7 +13,6 @@ import {
   Badge,
   Box,
   Button,
-  Checkbox,
   Collapse,
   Divider,
   Group,
@@ -31,7 +28,7 @@ import {
   Text,
   TextInput,
   Title,
-  useMantineTheme,
+  useMantineTheme
 } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { useDisclosure } from '@mantine/hooks';
@@ -44,7 +41,6 @@ import { toLabel } from '@utils/strings';
 import useRefresh from '@utils/use-refresh';
 import _ from 'lodash-es';
 import { useState } from 'react';
-import { useRecoilState } from 'recoil';
 
 /**
  * Modal for creating or editing an item
@@ -136,7 +132,7 @@ export function CreateItemModal(props: {
   const [strikingRune, setStrikingRune] = useState<number | undefined>(0);
   const [resilientRune, setResilientRune] = useState<number | undefined>(0);
   const [potencyRune, setPotencyRune] = useState<number | undefined>(0);
-  const [propertyRunes, setPropertyRunes] = useState<{ name: string; id: number }[] | undefined>([]);
+  const [propertyRunes, setPropertyRunes] = useState<{ name: string; id: number, rune?: Item }[] | undefined>([]);
 
   const [baseItem, setBaseItem] = useState<string | undefined>();
   const [baseItemContent, setBaseItemContent] = useState<Item | undefined>();
@@ -747,7 +743,7 @@ export function CreateItemModal(props: {
                               if ((items ?? []).length > (potencyRune ?? 0)) {
                                 return;
                               }
-                              setPropertyRunes(items?.map((item) => ({ name: item.name, id: item.id })) ?? []);
+                              setPropertyRunes(items?.map((item) => ({ name: item.name, id: item.id, rune: item, })) ?? []);
                             }}
                           />
                         </Stack>

--- a/frontend/src/pages/campaign/panels/InspirationPanel.tsx
+++ b/frontend/src/pages/campaign/panels/InspirationPanel.tsx
@@ -10,7 +10,6 @@ import { collectCharacterAbilityBlocks } from '@content/collect-content';
 import { isAbilityBlockVisible } from '@content/content-hidden';
 import { importFromFTC } from '@import/ftc/import-from-ftc';
 import { isItemWeapon, handleUpdateItem, handleDeleteItem, handleMoveItem } from '@items/inv-utils';
-import { getWeaponStats } from '@items/weapon-handler';
 import {
   useMantineTheme,
   Group,

--- a/frontend/src/pages/character_sheet/panels/InventoryPanel.tsx
+++ b/frontend/src/pages/character_sheet/panels/InventoryPanel.tsx
@@ -26,7 +26,7 @@ import {
   labelizeBulk,
   reachedInvestedLimit,
 } from '@items/inv-utils';
-import { getWeaponStats } from '@items/weapon-handler';
+import { getWeaponStats, parseOtherDamage } from '@items/weapon-handler';
 import {
   Accordion,
   ActionIcon,
@@ -551,7 +551,8 @@ function InvItemOption(props: {
                 {weaponStats.damage.die}
                 {weaponStats.damage.bonus.total > 0 ? ` + ${weaponStats.damage.bonus.total}` : ``}{' '}
                 {weaponStats.damage.damageType}
-                {/* {weaponStats.damage.extra ? `+ ${weaponStats.damage.extra}` : ''} */}
+                {parseOtherDamage(weaponStats.damage.other)}
+                {weaponStats.damage.extra ? `+ ${weaponStats.damage.extra}` : ''}
               </Text>
             </Group>
           )}

--- a/frontend/src/pages/character_sheet/panels/SkillsActionsPanel.tsx
+++ b/frontend/src/pages/character_sheet/panels/SkillsActionsPanel.tsx
@@ -6,7 +6,7 @@ import { ICON_BG_COLOR_HOVER } from '@constants/data';
 import { collectCharacterAbilityBlocks } from '@content/collect-content';
 import { isAbilityBlockVisible } from '@content/content-hidden';
 import { isItemWeapon, handleUpdateItem, handleDeleteItem, handleMoveItem } from '@items/inv-utils';
-import { getWeaponStats } from '@items/weapon-handler';
+import { getWeaponStats, parseOtherDamage } from '@items/weapon-handler';
 import {
   useMantineTheme,
   Group,
@@ -85,20 +85,20 @@ export default function SkillsActionsPanel(props: {
     // Filter actions
     return searchQuery.trim() || actionTypeFilter !== 'ALL'
       ? allActions.filter((action) => {
-          // Custom search, alt could be to use JsSearch here
-          const query = searchQuery.trim().toLowerCase();
+        // Custom search, alt could be to use JsSearch here
+        const query = searchQuery.trim().toLowerCase();
 
-          const checkAction = (action: AbilityBlock) => {
-            if (actionTypeFilter !== 'ALL' && action.actions !== actionTypeFilter) return false;
+        const checkAction = (action: AbilityBlock) => {
+          if (actionTypeFilter !== 'ALL' && action.actions !== actionTypeFilter) return false;
 
-            if (action.name.toLowerCase().includes(query)) return true;
-            //if (action.description.toLowerCase().includes(query)) return true;
-            return false;
-          };
-
-          if (checkAction(action)) return true;
+          if (action.name.toLowerCase().includes(query)) return true;
+          //if (action.description.toLowerCase().includes(query)) return true;
           return false;
-        })
+        };
+
+        if (checkAction(action)) return true;
+        return false;
+      })
       : allActions;
   }, [props.content.abilityBlocks, actionTypeFilter, searchQuery]);
 
@@ -110,19 +110,19 @@ export default function SkillsActionsPanel(props: {
     // Filter weapons
     return searchQuery.trim() || actionTypeFilter !== 'ALL'
       ? weapons.filter((invItem) => {
-          // Custom search, alt could be to use JsSearch here
-          const query = searchQuery.trim().toLowerCase();
+        // Custom search, alt could be to use JsSearch here
+        const query = searchQuery.trim().toLowerCase();
 
-          const checkInvItem = (invItem: InventoryItem) => {
-            if (actionTypeFilter !== 'ALL') return false;
+        const checkInvItem = (invItem: InventoryItem) => {
+          if (actionTypeFilter !== 'ALL') return false;
 
-            if (invItem.item.name.toLowerCase().includes(query)) return true;
-            return false;
-          };
-
-          if (checkInvItem(invItem)) return true;
+          if (invItem.item.name.toLowerCase().includes(query)) return true;
           return false;
-        })
+        };
+
+        if (checkInvItem(invItem)) return true;
+        return false;
+      })
       : weapons;
   }, [props.inventory.items, actionTypeFilter, searchQuery]);
 
@@ -142,6 +142,7 @@ export default function SkillsActionsPanel(props: {
               {weaponStats.damage.die}
               {weaponStats.damage.bonus.total > 0 ? ` + ${weaponStats.damage.bonus.total}` : ``}{' '}
               {weaponStats.damage.damageType}
+              {parseOtherDamage(weaponStats.damage.other)}
               {/* {weaponStats.damage.extra ? `+ ${weaponStats.damage.extra}` : ''} */}
             </Text>
           </Group>
@@ -238,25 +239,25 @@ export default function SkillsActionsPanel(props: {
     // Filter items
     return searchQuery.trim() || actionTypeFilter !== 'ALL'
       ? actionItems.filter((invItem) => {
-          // Custom search, alt could be to use JsSearch here
-          const query = searchQuery.trim().toLowerCase();
+        // Custom search, alt could be to use JsSearch here
+        const query = searchQuery.trim().toLowerCase();
 
-          const checkInvItem = (invItem: InventoryItem) => {
-            if (actionTypeFilter !== 'ALL') {
-              const actions = findActions(invItem.item.description);
-              const hasAction = actions.find((action) => action === actionTypeFilter);
-              if (!hasAction) return false;
-            }
-            if (invItem.item.name.toLowerCase().includes(query)) return true;
-            if (invItem.item.description.toLowerCase().includes(query)) return true;
-            if (invItem.item.group.toLowerCase().includes(query)) return true;
-            return false;
-          };
-
-          if (checkInvItem(invItem)) return true;
-          if (invItem.container_contents.some((containedItem) => checkInvItem(containedItem))) return true;
+        const checkInvItem = (invItem: InventoryItem) => {
+          if (actionTypeFilter !== 'ALL') {
+            const actions = findActions(invItem.item.description);
+            const hasAction = actions.find((action) => action === actionTypeFilter);
+            if (!hasAction) return false;
+          }
+          if (invItem.item.name.toLowerCase().includes(query)) return true;
+          if (invItem.item.description.toLowerCase().includes(query)) return true;
+          if (invItem.item.group.toLowerCase().includes(query)) return true;
           return false;
-        })
+        };
+
+        if (checkInvItem(invItem)) return true;
+        if (invItem.container_contents.some((containedItem) => checkInvItem(containedItem))) return true;
+        return false;
+      })
       : actionItems;
   }, [props.inventory.items, actionTypeFilter, searchQuery]);
 
@@ -268,19 +269,19 @@ export default function SkillsActionsPanel(props: {
     // Filter feats
     return searchQuery.trim() || actionTypeFilter !== 'ALL'
       ? feats.filter((feat) => {
-          // Custom search, alt could be to use JsSearch here
-          const query = searchQuery.trim().toLowerCase();
+        // Custom search, alt could be to use JsSearch here
+        const query = searchQuery.trim().toLowerCase();
 
-          const checkFeat = (feat: AbilityBlock) => {
-            if (actionTypeFilter !== 'ALL' && feat.actions !== actionTypeFilter) return false;
+        const checkFeat = (feat: AbilityBlock) => {
+          if (actionTypeFilter !== 'ALL' && feat.actions !== actionTypeFilter) return false;
 
-            if (feat.name.toLowerCase().includes(query)) return true;
-            return false;
-          };
-
-          if (checkFeat(feat)) return true;
+          if (feat.name.toLowerCase().includes(query)) return true;
           return false;
-        })
+        };
+
+        if (checkFeat(feat)) return true;
+        return false;
+      })
       : feats;
   }, [character, props.content.abilityBlocks, actionTypeFilter, searchQuery]);
 
@@ -737,7 +738,7 @@ function ActionAccordionItem(props: {
       <Accordion.Panel>
         <Stack gap={5}>
           {props.actions.map((action, index) => (
-            <ActionSelectionOption key={index} action={action} onClick={() => {}} isPhone={props.isPhone} />
+            <ActionSelectionOption key={index} action={action} onClick={() => { }} isPhone={props.isPhone} />
           ))}
         </Stack>
       </Accordion.Panel>

--- a/frontend/src/process/items/inv-utils.tsx
+++ b/frontend/src/process/items/inv-utils.tsx
@@ -536,7 +536,7 @@ export function isItemWithQuantity(item: Item) {
  * @returns - Whether the item is a weapon
  */
 export function isItemWeapon(item: Item) {
-  return !!item.meta_data?.damage?.damageType;
+  return !!item.meta_data?.damage?.damageType && item.group === 'WEAPON';
 }
 
 /**

--- a/frontend/src/typing/content.d.ts
+++ b/frontend/src/typing/content.d.ts
@@ -175,7 +175,7 @@ interface Item {
       striking?: number;
       resilient?: number;
       potency?: number;
-      property?: { name: string; id: number }[];
+      property?: { name: string; id: number, rune?: Item }[];
     };
     starfinder?: {
       capacity?: string;


### PR DESCRIPTION
## Proposed changes

Displays the damage from runes and the `extra damage` field. The rune description shows up below the weapon description in the item drawer.

To implement the new feature, runes that modify a weapon's damage must have the damage listed in the `Weapon` section of the item. When a rune is added to a weapon, the `meta_data.runes.property` type of the weapon now has the `rune` entry which is a copy of the item.

The `extra damage` field was uncommented from the pages where the code was commented.

## Types of changes

What types of changes does your code introduce to Wanderer's Guide?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Screenshots
![Screenshot from 2024-09-12 16-35-21](https://github.com/user-attachments/assets/f5534abf-06cb-4fcb-9576-a3261798ed71)

![Screenshot from 2024-09-13 16-21-03](https://github.com/user-attachments/assets/99c576a2-fc37-42b6-b15e-4bf686f92611)

![Screenshot from 2024-09-13 16-21-13](https://github.com/user-attachments/assets/01c5f71d-f968-4078-9bd7-8749e679a939)


## Further comments
I've been unable to add the runes damage breakdown to the `parts` array since it expects only numbers.