### PR TITLE
fix: add weapon's extra damage to Weapon Attacks section

### DIFF
--- a/frontend/src/drawers/types/InvItemDrawer.tsx
+++ b/frontend/src/drawers/types/InvItemDrawer.tsx
@@ -600,7 +600,7 @@ function InvItemSections(props: {
               {weaponStats.damage.dice}
               {weaponStats.damage.die}
               {damageBonus} {weaponStats.damage.damageType}
-              {parseOtherDamage(weaponStats.damage.other)}
+              {parseOtherDamage(weaponStats.damage.other)}{' '}
               {weaponStats.damage.extra ? `+ ${weaponStats.damage.extra}` : ''}
             </Text>
           </Group>

--- a/frontend/src/drawers/types/ItemDrawer.tsx
+++ b/frontend/src/drawers/types/ItemDrawer.tsx
@@ -366,7 +366,7 @@ function MiscItemSections(props: { item: Item; store: StoreID; openDrawer: Sette
               {weaponStats.damage.dice}
               {weaponStats.damage.die}
               {damageBonus} {weaponStats.damage.damageType}
-              {parseOtherDamage(weaponStats.damage.other)}
+              {parseOtherDamage(weaponStats.damage.other)}{' '}
               {weaponStats.damage.extra ? `+ ${weaponStats.damage.extra}` : ''}
             </Text>
           </Group>

--- a/frontend/src/drawers/types/StatWeaponDrawer.tsx
+++ b/frontend/src/drawers/types/StatWeaponDrawer.tsx
@@ -58,7 +58,7 @@ export function StatWeaponDrawerContent(props: { data: { item: Item } }) {
               <Text c='gray.5' span>
                 {stats.damage.dice}
                 {stats.damage.die} + {stats.damage.bonus.total} {stats.damage.damageType}
-                {parseOtherDamage(stats.damage.other)}
+                {parseOtherDamage(stats.damage.other)}{' '}
                 {stats.damage.extra ? `+ ${stats.damage.extra}` : ''}
               </Text>
               =

--- a/frontend/src/pages/character_sheet/panels/InventoryPanel.tsx
+++ b/frontend/src/pages/character_sheet/panels/InventoryPanel.tsx
@@ -551,7 +551,7 @@ function InvItemOption(props: {
                 {weaponStats.damage.die}
                 {weaponStats.damage.bonus.total > 0 ? ` + ${weaponStats.damage.bonus.total}` : ``}{' '}
                 {weaponStats.damage.damageType}
-                {parseOtherDamage(weaponStats.damage.other)}
+                {parseOtherDamage(weaponStats.damage.other)}{' '}
                 {weaponStats.damage.extra ? `+ ${weaponStats.damage.extra}` : ''}
               </Text>
             </Group>

--- a/frontend/src/pages/character_sheet/panels/SkillsActionsPanel.tsx
+++ b/frontend/src/pages/character_sheet/panels/SkillsActionsPanel.tsx
@@ -142,8 +142,8 @@ export default function SkillsActionsPanel(props: {
               {weaponStats.damage.die}
               {weaponStats.damage.bonus.total > 0 ? ` + ${weaponStats.damage.bonus.total}` : ``}{' '}
               {weaponStats.damage.damageType}
-              {parseOtherDamage(weaponStats.damage.other)}
-              {/* {weaponStats.damage.extra ? `+ ${weaponStats.damage.extra}` : ''} */}
+              {parseOtherDamage(weaponStats.damage.other)}{' '}
+              {weaponStats.damage.extra ? `+ ${weaponStats.damage.extra}` : ''}
             </Text>
           </Group>
         ),


### PR DESCRIPTION
## Proposed changes

Display the extra damage in the Weapon Attacks section

## Types of changes

What types of changes does your code introduce to Wanderer's Guide?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Screenshots

![image](https://github.com/user-attachments/assets/7371e695-4ab5-41c2-b370-aaea5b1c9f8f)