### PR TITLE
fix: `getItemBulk` returns 0 if item has neglible bulk

### DIFF
--- a/frontend/src/process/items/inv-utils.tsx
+++ b/frontend/src/process/items/inv-utils.tsx
@@ -63,6 +63,8 @@ export function getInvBulk(inv: Inventory) {
 export function getItemBulk(invItem: InventoryItem) {
   if (isItemFormula(invItem)) return 0;
 
+  if (!invItem.item.bulk) return 0;
+
   let totalBulk = 0;
 
   if (invItem.item.bulk === 'L') {


### PR DESCRIPTION
## Proposed changes

Custom armor with 0 bulk would increase its value to 1 if not equipped. Since negligible bulk is GM dependent, this fix ignores the `armorWornModifier` for items with 0 bulk.

## Types of changes

What types of changes does your code introduce to Wanderer's Guide?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)