### PR TITLE
Manage Staves and Wands

### DIFF
--- a/frontend/cypress/e2e/characters/characterBuilder.cy.ts
+++ b/frontend/cypress/e2e/characters/characterBuilder.cy.ts
@@ -11,6 +11,7 @@ describe('Characters', () => {
   describe('Character builder', () => {
     beforeEach(() => {
       cy.get('.tabler-icon-user-plus').click();
+      cy.wait(500);
       cy.location('pathname').should('include', '/builder');
     });
 
@@ -91,6 +92,7 @@ describe('Characters', () => {
 
       // Finished!
       cy.get('button[aria-label="Next Page"]').click();
+      cy.wait(500);
       cy.location('pathname').should('include', '/sheet');
     });
   });

--- a/frontend/cypress/e2e/characters/characterBuilder.cy.ts
+++ b/frontend/cypress/e2e/characters/characterBuilder.cy.ts
@@ -11,7 +11,7 @@ describe('Characters', () => {
   describe('Character builder', () => {
     beforeEach(() => {
       cy.get('.tabler-icon-user-plus').click();
-      cy.wait(500);
+      cy.wait(2000);
       cy.location('pathname').should('include', '/builder');
     });
 

--- a/frontend/cypress/e2e/characters/preparedCaster.cy.ts
+++ b/frontend/cypress/e2e/characters/preparedCaster.cy.ts
@@ -14,6 +14,7 @@ describe('Character builder', () => {
 
     // Finished!
     cy.get('button[aria-label="Next Page"]').click();
+    cy.wait(500);
     cy.location('pathname').should('include', '/sheet');
   });
 

--- a/frontend/cypress/e2e/login/login.cy.ts
+++ b/frontend/cypress/e2e/login/login.cy.ts
@@ -1,24 +1,27 @@
 describe('Login', () => {
-  beforeEach( () => {
+  beforeEach(() => {
     cy.visit('/');
   });
 
   it('should login', () => {
     cy.get('button').contains('Sign in').click();
+    cy.wait(500);
     cy.location('pathname').should('eq', '/login');
 
     cy.get('input[name="email"]').type(Cypress.env('TEST_EMAIL'));
     cy.get('input[name="password"]').type(Cypress.env('TEST_PASSWORD'));
     cy.get('button[type="submit"]').contains('Sign in').click();
-    cy.location('pathname', {timeout: 1000}).should('eq', '/characters');
+    cy.wait(500);
+    cy.location('pathname', { timeout: 1000 }).should('eq', '/characters');
   });
 
   it('should show error message for invalid credentials', () => {
     cy.get('button').contains('Sign in').click();
+    cy.wait(500);
     cy.location('pathname').should('eq', '/login');
 
-    cy.get('input[name="email"]').type("foo@bar.com");
-    cy.get('input[name="password"]').type("wrongpassword");
+    cy.get('input[name="email"]').type('foo@bar.com');
+    cy.get('input[name="password"]').type('wrongpassword');
     cy.get('button[type="submit"]').contains('Sign in').click();
     cy.contains('Invalid login credentials').should('exist');
   });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -33,6 +33,7 @@ import UpdateCharacterPortraitModal from '@modals/UpdateCharacterPortraitModal';
 import UpdateNotePageModal from '@modals/UpdateNotePageModal';
 import AddItemsModal from '@modals/AddItemsModal';
 import _ from 'lodash-es';
+import SelectSpellSlotModal from '@modals/SelectSpellSlotModal';
 
 // TODO, it would be great to dynamically import these modals, but it with Mantine v7.6.2 it doesn't work
 // const SelectContentModal = lazy(() => import('@common/select/SelectContent'));
@@ -48,6 +49,7 @@ const modals = {
   selectContent: SelectContentModal,
   selectImage: SelectImageModal,
   selectIcon: SelectIconModal,
+  selectSpellSlot: SelectSpellSlotModal,
   updateCharacterPortrait: UpdateCharacterPortraitModal,
   addNewLore: AddNewLoreModal,
   updateNotePage: UpdateNotePageModal,
@@ -55,11 +57,11 @@ const modals = {
   createDicePreset: CreateDicePresetModal,
   addItems: AddItemsModal,
 };
-declare module '@mantine/modals' {
-  export interface MantineModalsOverride {
-    modals: typeof modals;
-  }
-}
+// declare module '@mantine/modals' {
+//   export interface MantineModalsOverride {
+//     modals: typeof modals;
+//   }
+// }
 
 function getShadesFromColor(color: string) {
   let lightShades = [];

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -34,6 +34,7 @@ import UpdateNotePageModal from '@modals/UpdateNotePageModal';
 import AddItemsModal from '@modals/AddItemsModal';
 import _ from 'lodash-es';
 import SelectSpellSlotModal from '@modals/SelectSpellSlotModal';
+import SelectStaffCastingModal from '@modals/SelectStaffCastingModal';
 
 // TODO, it would be great to dynamically import these modals, but it with Mantine v7.6.2 it doesn't work
 // const SelectContentModal = lazy(() => import('@common/select/SelectContent'));
@@ -50,6 +51,7 @@ const modals = {
   selectImage: SelectImageModal,
   selectIcon: SelectIconModal,
   selectSpellSlot: SelectSpellSlotModal,
+  selectStaffCasting: SelectStaffCastingModal,
   updateCharacterPortrait: UpdateCharacterPortraitModal,
   addNewLore: AddNewLoreModal,
   updateNotePage: UpdateNotePageModal,

--- a/frontend/src/common/ItemIcon.tsx
+++ b/frontend/src/common/ItemIcon.tsx
@@ -12,7 +12,8 @@ import {
   GiRollingBomb,
   GiRuneStone,
   GiShield,
-  GiShoulderArmor,
+  GiWizardStaff,
+  GiCrystalWand,
   GiSlashedShield,
   GiSwapBag,
 } from 'react-icons/gi';
@@ -27,6 +28,8 @@ type ItemIconType =
   | 'UNARMED'
   | 'BOMB'
   | 'CONTAINER'
+  | 'STAFF'
+  | 'WAND'
   | 'HIGH_TECH_GUN';
 
 export const getIconMap = (size: string, color: string): Record<ItemIconType, JSX.Element> => ({
@@ -39,6 +42,8 @@ export const getIconMap = (size: string, color: string): Record<ItemIconType, JS
   UNARMED: <GiFist color={color} size={size} />,
   BOMB: <GiRollingBomb color={color} size={size} />,
   CONTAINER: <GiLightBackpack color={color} size={size} />,
+  STAFF: <GiWizardStaff color={color} size={size} />,
+  WAND: <GiCrystalWand color={color} size={size} />,
   HIGH_TECH_GUN: <GiBolterGun color={color} size={size} />,
 });
 
@@ -50,6 +55,14 @@ export function ItemIcon(props: { item: Item; size: string; color: string; useDe
 
   if (hasTraitType('BOMB', props.item.traits)) {
     type = 'BOMB';
+  }
+
+  if (hasTraitType('STAFF', props.item.traits)) {
+    type = 'STAFF';
+  }
+
+  if (hasTraitType('WAND', props.item.traits)) {
+    type = 'WAND';
   }
 
   if (type === 'GENERAL' && props.item.meta_data?.bulk.capacity) {

--- a/frontend/src/common/select/SelectContent.tsx
+++ b/frontend/src/common/select/SelectContent.tsx
@@ -2996,6 +2996,7 @@ export function SpellSelectionOption(props: {
   hideRank?: boolean;
   exhausted?: boolean;
   px?: number;
+  prefix?: React.ReactNode;
 }) {
   const [_drawer, openDrawer] = useRecoilState(drawerState);
   const isPhone = useMediaQuery(phoneQuery());
@@ -3007,8 +3008,9 @@ export function SpellSelectionOption(props: {
     <BaseSelectionOption
       leftSection={
         <Group wrap='nowrap' gap={5}>
-          <Box pl={8}>
+          <Box>
             <Text fz='sm' td={props.exhausted ? 'line-through' : undefined}>
+              {props.prefix}
               {props.spell.name}
             </Text>
           </Box>
@@ -3051,6 +3053,7 @@ export function SpellSelectionOption(props: {
           : () => {}
       }
       buttonTitle='Select'
+      px={props.px}
       disableButton={props.selected}
       onButtonClick={props.onClick ? () => props.onClick?.(props.spell) : undefined}
       includeOptions={props.includeOptions}

--- a/frontend/src/css/ActionsGrid.module.css
+++ b/frontend/src/css/ActionsGrid.module.css
@@ -15,6 +15,10 @@
   text-align: center;
   border-radius: var(--mantine-radius-md);
   height: rem(90px);
+  border: 2px solid var(--mantine-color-dark-7);
+}
+
+.item:not([disabled]) {
   background-color: light-dark(var(--mantine-color-white), var(--mantine-color-dark-7));
   transition: box-shadow 150ms ease, transform 100ms ease;
 

--- a/frontend/src/modals/SelectIconModal.tsx
+++ b/frontend/src/modals/SelectIconModal.tsx
@@ -29,6 +29,7 @@ export function SelectIconModalContents(props: {
     .sort()
     .map((name, index) => (
       <UnstyledButton
+        key={index}
         className={classes.item}
         onClick={() => {
           props.onSelect(name);

--- a/frontend/src/modals/SelectSpellSlotModal.tsx
+++ b/frontend/src/modals/SelectSpellSlotModal.tsx
@@ -1,0 +1,93 @@
+import { characterState } from '@atoms/characterAtoms';
+import { Icon, iconComponents } from '@common/Icon';
+import { collectEntitySpellcasting } from '@content/collect-content';
+import classes from '@css/ActionsGrid.module.css';
+import { Text, Card, ScrollArea, SimpleGrid, Stack, UnstyledButton, Divider, Box } from '@mantine/core';
+import { ContextModalProps } from '@mantine/modals';
+import { Spell, SpellSlot, SpellSlotRecord } from '@typing/content';
+import { rankNumber } from '@utils/numbers';
+import { useRecoilState } from 'recoil';
+
+export default function SelectSpellSlotModal({
+  context,
+  id,
+  innerProps,
+}: ContextModalProps<{
+  allSpells: Spell[];
+  text?: string;
+  source?: string;
+  onSelect: (slot: SpellSlotRecord) => void;
+}>) {
+  return (
+    <SelectSpellSlotModalContents
+      allSpells={innerProps.allSpells}
+      text={innerProps.text}
+      source={innerProps.source}
+      onSelect={innerProps.onSelect}
+      onClose={() => context.closeModal(id)}
+    />
+  );
+}
+
+export function SelectSpellSlotModalContents(props: {
+  allSpells: Spell[];
+  text?: string;
+  source?: string;
+  onSelect: (slot: SpellSlotRecord) => void;
+  onClose: () => void;
+}) {
+  const [character, setCharacter] = useRecoilState(characterState);
+  const slots = (character && collectEntitySpellcasting('CHARACTER', character).slots) ?? [];
+
+  const items = slots
+    .sort((a, b) => a.rank - b.rank)
+    .filter((slot) => {
+      if (props.source) {
+        return slot.source === props.source;
+      } else {
+        return true;
+      }
+    })
+    .filter((slot) => slot.rank !== 0)
+    .map((slot, index) => (
+      <UnstyledButton
+        key={index}
+        className={classes.item}
+        onClick={() => {
+          props.onSelect(slot);
+          props.onClose();
+        }}
+        disabled={slot.exhausted}
+      >
+        <Stack align='center' justify='flex-start' gap={10} style={{ height: '100%' }}>
+          <Box>
+            <Text>{`${rankNumber(slot.rank)} Rank`}</Text>
+            <Divider c={'gray.0'} />
+          </Box>
+
+          <Text>
+            {slot.spell_id ? (
+              <Text fw={600}>{props.allSpells.find((s) => s.id === slot.spell_id)!.name}</Text>
+            ) : (
+              <Text c='gray.6' fs='italic' fz='sm'>
+                {'No Spell Prepared'}
+              </Text>
+            )}
+          </Text>
+        </Stack>
+      </UnstyledButton>
+    ));
+
+  return (
+    <Stack>
+      {props.text && <Text>{props.text}</Text>}
+      <Card withBorder radius='md' className={classes.card} pl={15} py={15} pr={5}>
+        <ScrollArea h={315} scrollbars='y'>
+          <SimpleGrid cols={3} pl={5} py={5} pr={15}>
+            {items}
+          </SimpleGrid>
+        </ScrollArea>
+      </Card>
+    </Stack>
+  );
+}

--- a/frontend/src/modals/SelectStaffCastingModal.tsx
+++ b/frontend/src/modals/SelectStaffCastingModal.tsx
@@ -1,0 +1,115 @@
+import { characterState } from '@atoms/characterAtoms';
+import { Icon, iconComponents } from '@common/Icon';
+import { collectEntitySpellcasting } from '@content/collect-content';
+import classes from '@css/ActionsGrid.module.css';
+import {
+  Text,
+  Card,
+  ScrollArea,
+  SimpleGrid,
+  Stack,
+  UnstyledButton,
+  Divider,
+  Box,
+  Menu,
+  Button,
+  Group,
+} from '@mantine/core';
+import { ContextModalProps } from '@mantine/modals';
+import { Spell, SpellSlot, SpellSlotRecord } from '@typing/content';
+import { rankNumber } from '@utils/numbers';
+import _ from 'lodash';
+import { useRecoilState } from 'recoil';
+
+/**
+ * This modal is used for selecting the casting option when casting a spell from a staff and you're a spontaneous caster.
+ */
+export default function SelectStaffCastingModal({
+  context,
+  id,
+  innerProps,
+}: ContextModalProps<{
+  spell: Spell;
+  canCastNormally: boolean;
+  onSelect: (option: 'NORMAL' | 'SLOT-CONSUME', slotRank?: number) => void;
+}>) {
+  return (
+    <SelectStaffCastingModalContents
+      spell={innerProps.spell}
+      canCastNormally={innerProps.canCastNormally}
+      onSelect={innerProps.onSelect}
+      onClose={() => context.closeModal(id)}
+    />
+  );
+}
+
+export function SelectStaffCastingModalContents(props: {
+  spell: Spell;
+  canCastNormally: boolean;
+  onSelect: (option: 'NORMAL' | 'SLOT-CONSUME', slotRank?: number) => void;
+  onClose: () => void;
+}) {
+  const [character, setCharacter] = useRecoilState(characterState);
+  const slots = (character && collectEntitySpellcasting('CHARACTER', character).slots) ?? [];
+  const groupedSlots = _.groupBy(slots, 'rank');
+
+  const rankLevels: number[] = [];
+  for (const rank of Object.keys(groupedSlots)) {
+    const nonExhaustedSlot = groupedSlots[rank].find((s) => s.exhausted !== true);
+    if (nonExhaustedSlot) {
+      const rankInt = parseInt(rank);
+      if (rankInt >= props.spell.rank) {
+        rankLevels.push(rankInt);
+      }
+    }
+  }
+
+  return (
+    <Stack>
+      <Text fz='sm'>
+        Since you're a spontaneous spellcaster, you can cast this spell either normally (by consuming charges equal to
+        the spell's rank) or by consuming 1 charge and a spell slot of the same rank or greater as the spell you're
+        casting.
+      </Text>
+      <Divider my={0} />
+      <Group align='center' justify='center'>
+        <Box>
+          <Button
+            variant='light'
+            size='sm'
+            radius='xl'
+            onClick={() => {
+              props.onSelect('NORMAL');
+              props.onClose();
+            }}
+            disabled={!props.canCastNormally}
+          >
+            Cast Normally
+          </Button>
+        </Box>
+        <Box>
+          <Menu withinPortal>
+            <Menu.Target>
+              <Button variant='light' size='sm' radius='xl' disabled={rankLevels.length === 0}>
+                Cast with Slot
+              </Button>
+            </Menu.Target>
+            <Menu.Dropdown>
+              {rankLevels.map((rank, index) => (
+                <Menu.Item
+                  key={index}
+                  onClick={() => {
+                    props.onSelect('SLOT-CONSUME', rank);
+                    props.onClose();
+                  }}
+                >
+                  {rankNumber(rank)} Rank Slot
+                </Menu.Item>
+              ))}
+            </Menu.Dropdown>
+          </Menu>
+        </Box>
+      </Group>
+    </Stack>
+  );
+}

--- a/frontend/src/pages/character_builder/CharBuilderHome.tsx
+++ b/frontend/src/pages/character_builder/CharBuilderHome.tsx
@@ -80,6 +80,7 @@ import { userState } from '@atoms/userAtoms';
 import { makeRequest } from '@requests/request-manager';
 import { set } from 'node_modules/cypress/types/lodash';
 import { updateSubscriptions } from '@content/homebrew';
+import { ImageOption } from '@typing/index';
 
 export default function CharBuilderHome(props: { pageHeight: number }) {
   const theme = useMantineTheme();
@@ -924,7 +925,7 @@ export default function CharBuilderHome(props: { pageHeight: number }) {
                   title: <Title order={3}>Select Background</Title>,
                   innerProps: {
                     options: getAllBackgroundImages(),
-                    onSelect: (option) => {
+                    onSelect: (option: ImageOption) => {
                       if (!hasPatreonAccess(getCachedPublicUser(), 2)) {
                         displayPatronOnly();
                         return;
@@ -1178,7 +1179,7 @@ export default function CharBuilderHome(props: { pageHeight: number }) {
                     title: <Title order={3}>Select Portrait</Title>,
                     innerProps: {
                       options: getAllPortraitImages(),
-                      onSelect: (option) => {
+                      onSelect: (option: ImageOption) => {
                         setCharacter((prev) => {
                           if (!prev) return prev;
                           return {

--- a/frontend/src/pages/character_sheet/panels/SpellsPanel.tsx
+++ b/frontend/src/pages/character_sheet/panels/SpellsPanel.tsx
@@ -625,14 +625,19 @@ function SpellList(props: {
 
   if (props.type === 'STAFF' && character) {
     return (
-      <StaffSpellsList
-        {...props}
-        castSpell={castSpell}
-        // Get first equipped staff, we know there's one already
-        staff={filterByTraitType(character?.inventory?.items ?? [], 'STAFF').find((invItem) => invItem.is_equipped)!}
-        character={character}
-        setCharacter={setCharacter}
-      />
+      <>
+        {filterByTraitType(character?.inventory?.items ?? [], 'STAFF')
+          .filter((invItem) => invItem.is_equipped)
+          .map((invItem) => (
+            <StaffSpellsList
+              {...props}
+              castSpell={castSpell}
+              staff={invItem}
+              character={character}
+              setCharacter={setCharacter}
+            />
+          ))}
+      </>
     );
   }
 

--- a/frontend/src/pages/character_sheet/panels/SpellsPanel.tsx
+++ b/frontend/src/pages/character_sheet/panels/SpellsPanel.tsx
@@ -623,13 +623,14 @@ function SpellList(props: {
     );
   }
 
-  if (props.type === 'STAFF') {
+  if (props.type === 'STAFF' && character) {
     return (
       <StaffSpellsList
         {...props}
         castSpell={castSpell}
         // Get first equipped staff, we know there's one already
         staff={filterByTraitType(character?.inventory?.items ?? [], 'STAFF').find((invItem) => invItem.is_equipped)!}
+        character={character}
         setCharacter={setCharacter}
       />
     );

--- a/frontend/src/pages/character_sheet/panels/SpellsPanel.tsx
+++ b/frontend/src/pages/character_sheet/panels/SpellsPanel.tsx
@@ -32,6 +32,8 @@ import InnateSpellsList from './spells_list/InnateSpellsList';
 import PreparedSpellsList from './spells_list/PreparedSpellsList';
 import RitualSpellsList from './spells_list/RitualSpellsList';
 import SpontaneousSpellsList from './spells_list/SpontaneousSpellsList';
+import StaffSpellsList from './spells_list/StaffSpellsList';
+import { filterByTraitType } from '@items/inv-utils';
 
 export default function SpellsPanel(props: { panelHeight: number; panelWidth: number }) {
   const theme = useMantineTheme();
@@ -222,6 +224,16 @@ export default function SpellsPanel(props: { panelHeight: number; panelWidth: nu
                   hasFilters={hasFilters}
                 />
               )}
+              {filterByTraitType(character?.inventory?.items ?? [], 'STAFF').find((invItem) => invItem.is_equipped) && (
+                <SpellList
+                  index={'staff'}
+                  spellIds={[]}
+                  allSpells={allSpells}
+                  type='STAFF'
+                  hasFilters={hasFilters}
+                  extra={{ charData: charData }}
+                />
+              )}
               {/* Always display ritual section */}
               {true && (
                 <SpellList
@@ -365,7 +377,7 @@ function SpellList(props: {
   source?: CastingSource;
   spellIds: number[];
   allSpells: Spell[];
-  type: 'PREPARED' | 'SPONTANEOUS' | 'FOCUS' | 'INNATE' | 'RITUAL';
+  type: 'PREPARED' | 'SPONTANEOUS' | 'FOCUS' | 'INNATE' | 'RITUAL' | 'STAFF';
   extra: {
     charData: {
       slots: SpellSlot[];
@@ -608,6 +620,18 @@ function SpellList(props: {
   if (props.type === 'INNATE' && props.extra?.innates) {
     return (
       <InnateSpellsList {...props} castSpell={castSpell} innateSpells={innateSpells} setCharacter={setCharacter} />
+    );
+  }
+
+  if (props.type === 'STAFF') {
+    return (
+      <StaffSpellsList
+        {...props}
+        castSpell={castSpell}
+        // Get first equipped staff, we know there's one already
+        staff={filterByTraitType(character?.inventory?.items ?? [], 'STAFF').find((invItem) => invItem.is_equipped)!}
+        setCharacter={setCharacter}
+      />
     );
   }
 

--- a/frontend/src/pages/character_sheet/panels/SpellsPanel.tsx
+++ b/frontend/src/pages/character_sheet/panels/SpellsPanel.tsx
@@ -21,7 +21,15 @@ import ManageSpellsModal from '@modals/ManageSpellsModal';
 import { isCantrip } from '@spells/spell-utils';
 import { IconSearch, IconSquareRounded, IconSquareRoundedFilled } from '@tabler/icons-react';
 import { useQuery } from '@tanstack/react-query';
-import { ActionCost, CastingSource, Spell, SpellInnateEntry, SpellListEntry, SpellSlot } from '@typing/content';
+import {
+  ActionCost,
+  CastingSource,
+  Spell,
+  SpellInnateEntry,
+  SpellListEntry,
+  SpellSectionType,
+  SpellSlot,
+} from '@typing/content';
 import useRefresh from '@utils/use-refresh';
 import * as JsSearch from 'js-search';
 import _ from 'lodash-es';
@@ -34,6 +42,7 @@ import RitualSpellsList from './spells_list/RitualSpellsList';
 import SpontaneousSpellsList from './spells_list/SpontaneousSpellsList';
 import StaffSpellsList from './spells_list/StaffSpellsList';
 import { filterByTraitType, handleUpdateItemCharges } from '@items/inv-utils';
+import WandSpellsList from './spells_list/WandSpellsList';
 
 export default function SpellsPanel(props: { panelHeight: number; panelWidth: number }) {
   const theme = useMantineTheme();
@@ -234,6 +243,16 @@ export default function SpellsPanel(props: { panelHeight: number; panelWidth: nu
                   extra={{ charData: charData }}
                 />
               )}
+              {filterByTraitType(character?.inventory?.items ?? [], 'WAND').length > 0 && (
+                <SpellList
+                  index={'wand'}
+                  spellIds={[]}
+                  allSpells={allSpells}
+                  type='WAND'
+                  hasFilters={hasFilters}
+                  extra={{ charData: charData }}
+                />
+              )}
               {/* Always display ritual section */}
               {true && (
                 <SpellList
@@ -377,7 +396,7 @@ function SpellList(props: {
   source?: CastingSource;
   spellIds: number[];
   allSpells: Spell[];
-  type: 'PREPARED' | 'SPONTANEOUS' | 'FOCUS' | 'INNATE' | 'RITUAL' | 'STAFF';
+  type: SpellSectionType;
   extra: {
     charData: {
       slots: SpellSlot[];
@@ -632,6 +651,17 @@ function SpellList(props: {
             <StaffSpellsList {...props} staff={invItem} character={character} setCharacter={setCharacter} />
           ))}
       </>
+    );
+  }
+
+  if (props.type === 'WAND' && character) {
+    return (
+      <WandSpellsList
+        {...props}
+        wands={filterByTraitType(character?.inventory?.items ?? [], 'WAND')}
+        character={character}
+        setCharacter={setCharacter}
+      />
     );
   }
 

--- a/frontend/src/pages/character_sheet/panels/SpellsPanel.tsx
+++ b/frontend/src/pages/character_sheet/panels/SpellsPanel.tsx
@@ -33,7 +33,7 @@ import PreparedSpellsList from './spells_list/PreparedSpellsList';
 import RitualSpellsList from './spells_list/RitualSpellsList';
 import SpontaneousSpellsList from './spells_list/SpontaneousSpellsList';
 import StaffSpellsList from './spells_list/StaffSpellsList';
-import { filterByTraitType } from '@items/inv-utils';
+import { filterByTraitType, handleUpdateItemCharges } from '@items/inv-utils';
 
 export default function SpellsPanel(props: { panelHeight: number; panelWidth: number }) {
   const theme = useMantineTheme();
@@ -629,13 +629,7 @@ function SpellList(props: {
         {filterByTraitType(character?.inventory?.items ?? [], 'STAFF')
           .filter((invItem) => invItem.is_equipped)
           .map((invItem) => (
-            <StaffSpellsList
-              {...props}
-              castSpell={castSpell}
-              staff={invItem}
-              character={character}
-              setCharacter={setCharacter}
-            />
+            <StaffSpellsList {...props} staff={invItem} character={character} setCharacter={setCharacter} />
           ))}
       </>
     );

--- a/frontend/src/pages/character_sheet/panels/SpellsPanel.tsx
+++ b/frontend/src/pages/character_sheet/panels/SpellsPanel.tsx
@@ -648,7 +648,13 @@ function SpellList(props: {
         {filterByTraitType(character?.inventory?.items ?? [], 'STAFF')
           .filter((invItem) => invItem.is_equipped)
           .map((invItem) => (
-            <StaffSpellsList {...props} staff={invItem} character={character} setCharacter={setCharacter} />
+            <StaffSpellsList
+              {...props}
+              index={`${props.index}-${invItem.id}`}
+              staff={invItem}
+              character={character}
+              setCharacter={setCharacter}
+            />
           ))}
       </>
     );

--- a/frontend/src/pages/character_sheet/panels/spells_list/FocusSpellsList.tsx
+++ b/frontend/src/pages/character_sheet/panels/spells_list/FocusSpellsList.tsx
@@ -18,7 +18,7 @@ export default function FocusSpellsList(props: {
   source?: CastingSource;
   spellIds: number[];
   allSpells: Spell[];
-  type: 'PREPARED' | 'SPONTANEOUS' | 'FOCUS' | 'INNATE' | 'RITUAL';
+  type: 'PREPARED' | 'SPONTANEOUS' | 'FOCUS' | 'INNATE' | 'RITUAL' | 'STAFF';
   extra: {
     charData: {
       slots: SpellSlot[];
@@ -169,7 +169,7 @@ export default function FocusSpellsList(props: {
                         </Text>
                       </Badge>
                     </Group>
-                    <Divider my='md' />
+                    <Divider my={5} />
                     <Stack gap={5} mb='md'>
                       {spells[rank].map((spell, index) => (
                         <SpellListEntrySection

--- a/frontend/src/pages/character_sheet/panels/spells_list/FocusSpellsList.tsx
+++ b/frontend/src/pages/character_sheet/panels/spells_list/FocusSpellsList.tsx
@@ -1,7 +1,15 @@
 import { getFocusPoints } from '@content/collect-content';
 import { Accordion, Badge, Box, Divider, Group, Paper, Stack, Text } from '@mantine/core';
 import { getSpellStats } from '@spells/spell-handler';
-import { CastingSource, Character, Spell, SpellInnateEntry, SpellListEntry, SpellSlot } from '@typing/content';
+import {
+  CastingSource,
+  Character,
+  Spell,
+  SpellInnateEntry,
+  SpellListEntry,
+  SpellSectionType,
+  SpellSlot,
+} from '@typing/content';
 import { rankNumber, sign } from '@utils/numbers';
 import { toLabel } from '@utils/strings';
 import { getTraitIdByType } from '@utils/traits';
@@ -18,7 +26,7 @@ export default function FocusSpellsList(props: {
   source?: CastingSource;
   spellIds: number[];
   allSpells: Spell[];
-  type: 'PREPARED' | 'SPONTANEOUS' | 'FOCUS' | 'INNATE' | 'RITUAL' | 'STAFF';
+  type: SpellSectionType;
   extra: {
     charData: {
       slots: SpellSlot[];

--- a/frontend/src/pages/character_sheet/panels/spells_list/InnateSpellsList.tsx
+++ b/frontend/src/pages/character_sheet/panels/spells_list/InnateSpellsList.tsx
@@ -1,18 +1,18 @@
-import { Accordion, Badge, Divider, Group, Paper, Stack, Text } from "@mantine/core";
-import { getSpellStats } from "@spells/spell-handler";
-import { CastingSource, Character, Spell, SpellInnateEntry, SpellListEntry, SpellSlot } from "@typing/content";
-import { rankNumber, sign } from "@utils/numbers";
-import { Dictionary } from "node_modules/cypress/types/lodash";
-import { SetterOrUpdater } from "recoil";
-import { SpellSlotSelect } from "../SpellsPanel";
-import SpellListEntrySection from "./SpellListEntrySection";
+import { Accordion, Badge, Divider, Group, Paper, Stack, Text } from '@mantine/core';
+import { getSpellStats } from '@spells/spell-handler';
+import { CastingSource, Character, Spell, SpellInnateEntry, SpellListEntry, SpellSlot } from '@typing/content';
+import { rankNumber, sign } from '@utils/numbers';
+import { Dictionary } from 'node_modules/cypress/types/lodash';
+import { SetterOrUpdater } from 'recoil';
+import { SpellSlotSelect } from '../SpellsPanel';
+import SpellListEntrySection from './SpellListEntrySection';
 
 export default function InnateSpellsList(props: {
   index: string;
   source?: CastingSource;
   spellIds: number[];
   allSpells: Spell[];
-  type: 'PREPARED' | 'SPONTANEOUS' | 'FOCUS' | 'INNATE' | 'RITUAL';
+  type: 'PREPARED' | 'SPONTANEOUS' | 'FOCUS' | 'INNATE' | 'RITUAL' | 'STAFF';
   extra: {
     charData: {
       slots: SpellSlot[];
@@ -32,14 +32,16 @@ export default function InnateSpellsList(props: {
   openManageSpells?: (source: string, type: 'SLOTS-ONLY' | 'SLOTS-AND-LIST' | 'LIST-ONLY') => void;
   castSpell: (cast: boolean, spell: Spell) => void;
   setCharacter: SetterOrUpdater<Character | null>;
-  innateSpells: Dictionary<{
-    spell: Spell | undefined;
-    spell_id: number;
-    rank: number;
-    tradition: string;
-    casts_max: number;
-    casts_current: number;
-  }[]> | null;
+  innateSpells: Dictionary<
+    {
+      spell: Spell | undefined;
+      spell_id: number;
+      rank: number;
+      tradition: string;
+      casts_max: number;
+      casts_current: number;
+    }[]
+  > | null;
 }) {
   const { castSpell, setCharacter, innateSpells } = props;
 
@@ -51,7 +53,6 @@ export default function InnateSpellsList(props: {
   ) {
     return null;
   }
-
 
   return (
     <Accordion.Item value={props.index}>
@@ -111,8 +112,8 @@ export default function InnateSpellsList(props: {
                         </Text>
                       </Badge>
                     </Group>
-                    <Divider my="md" />
-                    <Stack gap={5} mb="md">
+                    <Divider my={5} />
+                    <Stack gap={5} mb='md'>
                       {innateSpells[rank].map((innate, index) => (
                         <SpellListEntrySection
                           key={index}

--- a/frontend/src/pages/character_sheet/panels/spells_list/InnateSpellsList.tsx
+++ b/frontend/src/pages/character_sheet/panels/spells_list/InnateSpellsList.tsx
@@ -1,6 +1,14 @@
 import { Accordion, Badge, Divider, Group, Paper, Stack, Text } from '@mantine/core';
 import { getSpellStats } from '@spells/spell-handler';
-import { CastingSource, Character, Spell, SpellInnateEntry, SpellListEntry, SpellSlot } from '@typing/content';
+import {
+  CastingSource,
+  Character,
+  Spell,
+  SpellInnateEntry,
+  SpellListEntry,
+  SpellSectionType,
+  SpellSlot,
+} from '@typing/content';
 import { rankNumber, sign } from '@utils/numbers';
 import { Dictionary } from 'node_modules/cypress/types/lodash';
 import { SetterOrUpdater } from 'recoil';
@@ -12,7 +20,7 @@ export default function InnateSpellsList(props: {
   source?: CastingSource;
   spellIds: number[];
   allSpells: Spell[];
-  type: 'PREPARED' | 'SPONTANEOUS' | 'FOCUS' | 'INNATE' | 'RITUAL' | 'STAFF';
+  type: SpellSectionType;
   extra: {
     charData: {
       slots: SpellSlot[];

--- a/frontend/src/pages/character_sheet/panels/spells_list/PreparedSpellsList.tsx
+++ b/frontend/src/pages/character_sheet/panels/spells_list/PreparedSpellsList.tsx
@@ -176,7 +176,7 @@ export default function PreparedSpellsList(props: {
                         </Text>
                       </Badge>
                     </Group>
-                    <Divider my='md' />
+                    <Divider my={5} />
                     <Stack gap={5} mb='md'>
                       {slots[rank].map((slot, index) => (
                         <SpellListEntrySection

--- a/frontend/src/pages/character_sheet/panels/spells_list/RitualSpellsList.tsx
+++ b/frontend/src/pages/character_sheet/panels/spells_list/RitualSpellsList.tsx
@@ -1,6 +1,14 @@
 import BlurButton from '@common/BlurButton';
 import { Accordion, Badge, Box, Group, Stack, Text } from '@mantine/core';
-import { CastingSource, Character, Spell, SpellInnateEntry, SpellListEntry, SpellSlot } from '@typing/content';
+import {
+  CastingSource,
+  Character,
+  Spell,
+  SpellInnateEntry,
+  SpellListEntry,
+  SpellSectionType,
+  SpellSlot,
+} from '@typing/content';
 import { Dictionary } from 'node_modules/cypress/types/lodash';
 import SpellListEntrySection from './SpellListEntrySection';
 
@@ -9,7 +17,7 @@ export default function RitualSpellsList(props: {
   source?: CastingSource;
   spellIds: number[];
   allSpells: Spell[];
-  type: 'PREPARED' | 'SPONTANEOUS' | 'FOCUS' | 'INNATE' | 'RITUAL' | 'STAFF';
+  type: SpellSectionType;
   extra: {
     charData: {
       slots: SpellSlot[];

--- a/frontend/src/pages/character_sheet/panels/spells_list/RitualSpellsList.tsx
+++ b/frontend/src/pages/character_sheet/panels/spells_list/RitualSpellsList.tsx
@@ -9,7 +9,7 @@ export default function RitualSpellsList(props: {
   source?: CastingSource;
   spellIds: number[];
   allSpells: Spell[];
-  type: 'PREPARED' | 'SPONTANEOUS' | 'FOCUS' | 'INNATE' | 'RITUAL';
+  type: 'PREPARED' | 'SPONTANEOUS' | 'FOCUS' | 'INNATE' | 'RITUAL' | 'STAFF';
   extra: {
     charData: {
       slots: SpellSlot[];

--- a/frontend/src/pages/character_sheet/panels/spells_list/SpellListEntrySection.tsx
+++ b/frontend/src/pages/character_sheet/panels/spells_list/SpellListEntrySection.tsx
@@ -1,10 +1,10 @@
-import { drawerState } from "@atoms/navAtoms";
-import { SpellSelectionOption } from "@common/select/SelectContent";
-import { Text } from "@mantine/core";
-import { StatButton } from "@pages/character_builder/CharBuilderCreation";
-import { isCantrip, isRitual } from "@spells/spell-utils";
-import { Spell } from "@typing/content";
-import { useRecoilState } from "recoil";
+import { drawerState } from '@atoms/navAtoms';
+import { SpellSelectionOption } from '@common/select/SelectContent';
+import { Text } from '@mantine/core';
+import { StatButton } from '@pages/character_builder/CharBuilderCreation';
+import { isCantrip, isRitual } from '@spells/spell-utils';
+import { Spell } from '@typing/content';
+import { useRecoilState } from 'recoil';
 
 export default function SpellListEntrySection(props: {
   spell?: Spell;
@@ -15,6 +15,7 @@ export default function SpellListEntrySection(props: {
   onOpenManageSpells?: () => void;
   hasFilters: boolean;
   leftSection?: React.ReactNode;
+  prefix?: React.ReactNode;
 }) {
   const [_drawer, openDrawer] = useRecoilState(drawerState);
   const exhausted = props.spell && isCantrip(props.spell) ? false : props.exhausted;
@@ -61,6 +62,7 @@ export default function SpellListEntrySection(props: {
           spell={props.spell}
           leftSection={props.leftSection}
           px={0}
+          prefix={props.prefix}
         />
       </StatButton>
     );
@@ -76,7 +78,7 @@ export default function SpellListEntrySection(props: {
         props.onOpenManageSpells?.();
       }}
     >
-      <Text fz='xs' fs='italic' c='dimmed' fw={500} pl={7}>
+      <Text fz='xs' fs='italic' c='dimmed' fw={500}>
         No Spell Prepared
       </Text>
     </StatButton>

--- a/frontend/src/pages/character_sheet/panels/spells_list/SpontaneousSpellsList.tsx
+++ b/frontend/src/pages/character_sheet/panels/spells_list/SpontaneousSpellsList.tsx
@@ -17,7 +17,7 @@ export default function SpontaneousSpellsList(props: {
   source?: CastingSource;
   spellIds: number[];
   allSpells: Spell[];
-  type: 'PREPARED' | 'SPONTANEOUS' | 'FOCUS' | 'INNATE' | 'RITUAL';
+  type: 'PREPARED' | 'SPONTANEOUS' | 'FOCUS' | 'INNATE' | 'RITUAL' | 'STAFF';
   extra: {
     charData: {
       slots: SpellSlot[];
@@ -211,9 +211,8 @@ export default function SpontaneousSpellsList(props: {
                         </Text>
                       </Badge>
                     </Group>
-                    <Divider my='md' />
+                    <Divider my={5} />
                     <Stack gap={5} mb='md'>
-                      <Divider color='dark.6' />
                       {spells[rank]?.map((spell, index) => (
                         <SpellListEntrySection
                           key={index}

--- a/frontend/src/pages/character_sheet/panels/spells_list/SpontaneousSpellsList.tsx
+++ b/frontend/src/pages/character_sheet/panels/spells_list/SpontaneousSpellsList.tsx
@@ -2,7 +2,15 @@ import BlurButton from '@common/BlurButton';
 import { collectEntitySpellcasting } from '@content/collect-content';
 import { Accordion, Badge, Box, Divider, Group, Paper, Stack, Text } from '@mantine/core';
 import { getSpellStats } from '@spells/spell-handler';
-import { CastingSource, Character, Spell, SpellInnateEntry, SpellListEntry, SpellSlot } from '@typing/content';
+import {
+  CastingSource,
+  Character,
+  Spell,
+  SpellInnateEntry,
+  SpellListEntry,
+  SpellSectionType,
+  SpellSlot,
+} from '@typing/content';
 import { rankNumber, sign } from '@utils/numbers';
 import { toLabel } from '@utils/strings';
 import { Dictionary } from 'node_modules/cypress/types/lodash';
@@ -17,7 +25,7 @@ export default function SpontaneousSpellsList(props: {
   source?: CastingSource;
   spellIds: number[];
   allSpells: Spell[];
-  type: 'PREPARED' | 'SPONTANEOUS' | 'FOCUS' | 'INNATE' | 'RITUAL' | 'STAFF';
+  type: SpellSectionType;
   extra: {
     charData: {
       slots: SpellSlot[];

--- a/frontend/src/pages/character_sheet/panels/spells_list/StaffSpellsList.tsx
+++ b/frontend/src/pages/character_sheet/panels/spells_list/StaffSpellsList.tsx
@@ -1,0 +1,204 @@
+import { Accordion, Badge, Box, Button, Divider, Group, Paper, Stack, Text } from '@mantine/core';
+import { getSpellStats } from '@spells/spell-handler';
+import {
+  CastingSource,
+  Character,
+  InventoryItem,
+  Item,
+  Spell,
+  SpellInnateEntry,
+  SpellListEntry,
+  SpellSlot,
+} from '@typing/content';
+import { rankNumber, sign } from '@utils/numbers';
+import { Dictionary } from 'node_modules/cypress/types/lodash';
+import { SetterOrUpdater } from 'recoil';
+import { SpellSlotSelect } from '../SpellsPanel';
+import SpellListEntrySection from './SpellListEntrySection';
+import { detectSpells } from '@spells/spell-utils';
+import _ from 'lodash-es';
+import { use } from 'chai';
+import { useEffect } from 'react';
+import BlurButton from '@common/BlurButton';
+
+export default function StaffSpellsList(props: {
+  index: string;
+  staff: InventoryItem;
+  allSpells: Spell[];
+  extra: {
+    charData: {
+      slots: SpellSlot[];
+      list: SpellListEntry[];
+      focus: {
+        spell_id: number;
+        source: string;
+        rank: number | undefined;
+      }[];
+      innate: SpellInnateEntry[];
+      sources: CastingSource[];
+    };
+  };
+  hasFilters: boolean;
+  castSpell: (cast: boolean, spell: Spell) => void;
+  setCharacter: SetterOrUpdater<Character | null>;
+}) {
+  const { castSpell, setCharacter } = props;
+
+  const detectedSpells = _.groupBy(detectSpells(props.staff.item.description, props.allSpells), 'rank');
+
+  useEffect(() => {
+    const maxCharges = props.staff.item.meta_data?.charges?.max ?? 0;
+    //const currentCharges = props.staff.item.meta_data?.charges?.current ?? 0;
+    let greatestSlotRank = 0;
+    for (const slot of props.extra.charData.slots) {
+      if (slot.rank > greatestSlotRank) {
+        greatestSlotRank = slot.rank;
+      }
+    }
+
+    if (greatestSlotRank > maxCharges) {
+      // Update item to have max charges equal to greatest slot rank
+      setCharacter((char) => {
+        if (!char || !char.inventory) return null;
+
+        return {
+          ...char,
+          inventory: {
+            ...char.inventory,
+            items: char.inventory.items.map((i) => {
+              if (i.id !== props.staff.id) return i;
+
+              // If it's the staff item, update the charges
+              return {
+                ...i,
+                item: {
+                  ...i.item,
+                  meta_data: {
+                    ...i.item.meta_data!,
+                    charges: {
+                      ...i.item.meta_data?.charges,
+                      max: greatestSlotRank,
+                    },
+                  },
+                },
+              };
+            }),
+          },
+        };
+      });
+    }
+  }, []);
+
+  // If there are no spells to display, and there are filters, return null
+  if (
+    props.hasFilters &&
+    detectedSpells &&
+    Object.keys(detectedSpells).filter((rank) => detectedSpells[rank].find((s) => s.spell)).length === 0
+  ) {
+    return null;
+  }
+
+  return (
+    <Accordion.Item value={props.index}>
+      <Accordion.Control>
+        <Group wrap='nowrap' justify='space-between' gap={0}>
+          <Text c='gray.5' fw={700} fz='sm'>
+            {props.staff.item.name}
+          </Text>
+
+          <Box mr={10}>
+            <Group wrap='nowrap' gap={10}>
+              <BlurButton
+                size='compact-xs'
+                fw={500}
+                fz={10}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  e.preventDefault();
+                }}
+              >
+                Add Charges
+              </BlurButton>
+              <SpellSlotSelect
+                text='Staff Charges'
+                current={props.staff.item.meta_data?.charges?.current ?? 0}
+                max={props.staff.item.meta_data?.charges?.max ?? 0}
+                onChange={(v) => {}}
+              />
+            </Group>
+          </Box>
+        </Group>
+      </Accordion.Control>
+      <Accordion.Panel
+        styles={{
+          content: {
+            padding: 0,
+          },
+        }}
+      >
+        <Stack gap={0}>
+          {/* <Divider color='dark.6' /> */}
+          <Accordion
+            px={10}
+            pb={5}
+            variant='separated'
+            multiple
+            defaultValue={[]}
+            styles={{
+              label: {
+                paddingTop: 5,
+                paddingBottom: 5,
+              },
+              control: {
+                paddingLeft: 13,
+                paddingRight: 13,
+              },
+              item: {
+                marginTop: 0,
+                marginBottom: 5,
+              },
+            }}
+          >
+            {detectedSpells &&
+              Object.keys(detectedSpells)
+                .filter((rank) =>
+                  detectedSpells[rank].length > 0 && props.hasFilters ? detectedSpells[rank].find((s) => s.spell) : true
+                )
+                .map((rank, index) => (
+                  <div key={index} data-wg-name={`rank-group-${index}`}>
+                    <Group wrap='nowrap' justify='space-between' gap={0}>
+                      <Text c='gray.5' fw={700} fz='sm'>
+                        {rank === '0' ? 'Cantrips' : `${rankNumber(parseInt(rank))}`}
+                      </Text>
+                      <Badge mr='sm' variant='outline' color='gray.5' size='xs'>
+                        <Text fz='sm' c='gray.5' span>
+                          {props.hasFilters
+                            ? detectedSpells[rank].filter((s) => s.spell).length
+                            : detectedSpells[rank].length}
+                        </Text>
+                      </Badge>
+                    </Group>
+                    <Divider my={5} />
+                    <Stack gap={5} mb='md'>
+                      {detectedSpells[rank].map((record, index) => (
+                        <SpellListEntrySection
+                          key={index}
+                          spell={record.spell}
+                          exhausted={false}
+                          tradition={'NONE'}
+                          attribute={'ATTRIBUTE_CHA'}
+                          onCastSpell={(cast: boolean) => {
+                            if (record.spell) castSpell(cast, record.spell);
+                          }}
+                          hasFilters={props.hasFilters}
+                        />
+                      ))}
+                    </Stack>
+                  </div>
+                ))}
+          </Accordion>
+        </Stack>
+      </Accordion.Panel>
+    </Accordion.Item>
+  );
+}

--- a/frontend/src/pages/character_sheet/panels/spells_list/WandSpellsList.tsx
+++ b/frontend/src/pages/character_sheet/panels/spells_list/WandSpellsList.tsx
@@ -1,0 +1,252 @@
+import { Accordion, Badge, Divider, Group, Paper, Stack, Text, Title } from '@mantine/core';
+import { getSpellStats } from '@spells/spell-handler';
+import {
+  CastingSource,
+  Character,
+  InventoryItem,
+  Spell,
+  SpellInnateEntry,
+  SpellListEntry,
+  SpellSlot,
+} from '@typing/content';
+import { rankNumber, sign } from '@utils/numbers';
+import { Dictionary } from 'node_modules/cypress/types/lodash';
+import { SetterOrUpdater } from 'recoil';
+import { SpellSlotSelect } from '../SpellsPanel';
+import SpellListEntrySection from './SpellListEntrySection';
+import { useEffect, useMemo } from 'react';
+import { detectSpells } from '@spells/spell-utils';
+import { handleUpdateItemCharges, isItemBroken } from '@items/inv-utils';
+import { modals } from '@mantine/modals';
+import { convertToHardcodedLink } from '@content/hardcoded-links';
+import RichText from '@common/RichText';
+
+const DEFAULT_WAND_HP = 2;
+
+export default function WandSpellsList(props: {
+  index: string;
+  wands: InventoryItem[];
+  allSpells: Spell[];
+  extra: {
+    charData: {
+      slots: SpellSlot[];
+      list: SpellListEntry[];
+      focus: {
+        spell_id: number;
+        source: string;
+        rank: number | undefined;
+      }[];
+      innate: SpellInnateEntry[];
+      sources: CastingSource[];
+    };
+  };
+  hasFilters: boolean;
+  character: Character;
+  setCharacter: SetterOrUpdater<Character | null>;
+}) {
+  const { setCharacter } = props;
+
+  const processedWands = useMemo(() => {
+    const processed = [];
+    for (const wand of props.wands) {
+      const detectedSpells = detectSpells(wand.item.description, props.allSpells, true);
+      if (detectedSpells.length === 0) {
+        continue;
+      }
+
+      const maxCharges = wand.item.meta_data?.charges?.max ?? 0;
+      const currentCharges = wand.item.meta_data?.charges?.current ?? 0;
+
+      processed.push({
+        item: wand,
+        spell: detectedSpells[0],
+        detectedSpells: detectedSpells,
+        charges: { current: currentCharges, max: maxCharges },
+      });
+    }
+
+    return processed;
+  }, [props.wands, props.allSpells]);
+
+  // On init, set max charges to 1 if wand has no max
+  useEffect(() => {
+    for (const wand of processedWands) {
+      if (wand.charges.max === 0) {
+        handleUpdateItemCharges(setCharacter, wand.item, { max: 1 });
+      }
+    }
+  }, [processedWands, setCharacter]);
+
+  // If there are no wands to display, and there are filters, return null
+  if (props.hasFilters && props.wands.length === 0) {
+    return null;
+  }
+
+  return (
+    <Accordion.Item value={props.index}>
+      <Accordion.Control>
+        <Group wrap='nowrap' justify='space-between' gap={0}>
+          <Group gap={10}>
+            <Text c='gray.5' fw={700} fz='sm'>
+              Wands
+            </Text>
+            <Badge variant='outline' color='gray.5' size='xs'>
+              <Text fz='sm' c='gray.5' span>
+                {props.wands.length}
+              </Text>
+            </Badge>
+          </Group>
+        </Group>
+      </Accordion.Control>
+      <Accordion.Panel
+        styles={{
+          content: {
+            padding: 0,
+          },
+        }}
+        px={0}
+        pb={5}
+      >
+        <Stack gap={0}>
+          {/* <Divider color='dark.6' /> */}
+          <Accordion
+            px={10}
+            pb={5}
+            variant='separated'
+            multiple
+            defaultValue={[]}
+            styles={{
+              label: {
+                paddingTop: 5,
+                paddingBottom: 5,
+              },
+              control: {
+                paddingLeft: 13,
+                paddingRight: 13,
+              },
+              item: {
+                marginTop: 0,
+                marginBottom: 5,
+              },
+            }}
+          >
+            {processedWands.map((wand, index) => (
+              <SpellListEntrySection
+                key={index}
+                spell={wand.spell.spell}
+                exhausted={isItemBroken(wand.item.item)}
+                tradition={'NONE'}
+                attribute={'ATTRIBUTE_CHA'}
+                onCastSpell={(cast: boolean) => {
+                  if (cast) {
+                    if (wand.charges.current >= wand.charges.max) {
+                      modals.openConfirmModal({
+                        id: 'overload-wand',
+                        title: <Title order={4}>{`Overcharge Wand`}</Title>,
+                        children: (
+                          <RichText size='sm'>
+                            You've already {convertToHardcodedLink('action', 'Cast a Spell')} on this wand today. You
+                            can cast it again by overcharging the wand at the risk of destroying it. You{' '}
+                            {convertToHardcodedLink('action', 'Cast a Spell', 'Cast the Spell')} again, then roll a DC
+                            10 flat check. On a success, the wand is broken. On a failure, the wand is destroyed.
+                          </RichText>
+                        ),
+                        labels: { confirm: 'Break Wand', cancel: 'Cancel' },
+                        onCancel: () => {},
+                        onConfirm: async () => {
+                          setCharacter((char) => {
+                            if (!char || !char.inventory) return null;
+
+                            return {
+                              ...char,
+                              inventory: {
+                                ...char.inventory,
+                                items: char.inventory.items.map((i) => {
+                                  if (i.id !== wand.item.id) return i;
+
+                                  // If it's the item, update the charges
+                                  return {
+                                    ...i,
+                                    item: {
+                                      ...i.item,
+                                      meta_data: {
+                                        ...i.item.meta_data!,
+                                        // Update charges
+                                        charges: {
+                                          ...i.item.meta_data?.charges,
+                                          current: wand.charges.max,
+                                          max: wand.charges.max,
+                                        },
+                                        // Make sure wand is broken
+                                        hp_max: i.item.meta_data?.hp_max || DEFAULT_WAND_HP,
+                                        hp: Math.floor((i.item.meta_data?.hp_max || DEFAULT_WAND_HP) / 2),
+                                        broken_threshold: Math.floor((i.item.meta_data?.hp_max || DEFAULT_WAND_HP) / 2),
+                                      },
+                                    },
+                                  };
+                                }),
+                              },
+                            };
+                          });
+                        },
+                      });
+                    } else {
+                      handleUpdateItemCharges(setCharacter, wand.item, { current: wand.charges.current + 1 });
+                    }
+                  } else {
+                    // Reset wand
+                    setCharacter((char) => {
+                      if (!char || !char.inventory) return null;
+
+                      return {
+                        ...char,
+                        inventory: {
+                          ...char.inventory,
+                          items: char.inventory.items.map((i) => {
+                            if (i.id !== wand.item.id) return i;
+
+                            // If it's the item, update the charges
+                            return {
+                              ...i,
+                              item: {
+                                ...i.item,
+                                meta_data: {
+                                  ...i.item.meta_data!,
+                                  // Update charges
+                                  charges: {
+                                    ...i.item.meta_data?.charges,
+                                    current: 0,
+                                    max: wand.charges.max,
+                                  },
+                                  // Make sure wand is broken
+                                  hp_max: i.item.meta_data?.hp_max || DEFAULT_WAND_HP,
+                                  hp: i.item.meta_data?.hp_max || DEFAULT_WAND_HP,
+                                  broken_threshold: Math.floor((i.item.meta_data?.hp_max || DEFAULT_WAND_HP) / 2),
+                                },
+                              },
+                            };
+                          }),
+                        },
+                      };
+                    });
+                  }
+                }}
+                hasFilters={props.hasFilters}
+                leftSection={
+                  <SpellSlotSelect
+                    text='Remaining Casts'
+                    current={wand.charges.current}
+                    max={wand.charges.max}
+                    onChange={(v) => {
+                      handleUpdateItemCharges(setCharacter, wand.item, { current: v });
+                    }}
+                  />
+                }
+              />
+            ))}
+          </Accordion>
+        </Stack>
+      </Accordion.Panel>
+    </Accordion.Item>
+  );
+}

--- a/frontend/src/pages/character_sheet/panels/spells_list/WandSpellsList.tsx
+++ b/frontend/src/pages/character_sheet/panels/spells_list/WandSpellsList.tsx
@@ -105,13 +105,13 @@ export default function WandSpellsList(props: {
           },
         }}
         px={0}
-        pb={5}
+        pb={10}
       >
         <Stack gap={0}>
           {/* <Divider color='dark.6' /> */}
           <Accordion
             px={10}
-            pb={5}
+            pb={0}
             variant='separated'
             multiple
             defaultValue={[]}
@@ -246,6 +246,12 @@ export default function WandSpellsList(props: {
             ))}
           </Accordion>
         </Stack>
+
+        {processedWands.length === 0 && (
+          <Text c='gray.6' fz='sm' fs='italic' ta='center' py={5}>
+            No spells detected in wands
+          </Text>
+        )}
       </Accordion.Panel>
     </Accordion.Item>
   );

--- a/frontend/src/pages/character_sheet/panels/spells_list/WandSpellsList.tsx
+++ b/frontend/src/pages/character_sheet/panels/spells_list/WandSpellsList.tsx
@@ -134,6 +134,7 @@ export default function WandSpellsList(props: {
               <SpellListEntrySection
                 key={index}
                 spell={wand.spell.spell}
+                prefix={`${wand.item.item.name} — `}
                 exhausted={isItemBroken(wand.item.item)}
                 tradition={'NONE'}
                 attribute={'ATTRIBUTE_CHA'}

--- a/frontend/src/pages/character_sheet/sections/ConditionSection.tsx
+++ b/frontend/src/pages/character_sheet/sections/ConditionSection.tsx
@@ -154,7 +154,7 @@ export function ConditionSection(props: {
                   ),
                   innerProps: {
                     condition: condition,
-                    onValueChange: (condition, value) => {
+                    onValueChange: (condition: Condition, value: number) => {
                       props.setEntity((c) => {
                         if (!c) return c;
                         return {

--- a/frontend/src/pages/character_sheet/sections/EntityInfoSection.tsx
+++ b/frontend/src/pages/character_sheet/sections/EntityInfoSection.tsx
@@ -20,6 +20,7 @@ import { isCharacter, isCreature } from '@utils/type-fixing';
 import { CreatureDetailedInfo } from '@common/CreatureInfo';
 import { ICON_BG_COLOR } from '@constants/data';
 import { modals } from '@mantine/modals';
+import { filterByTraitType, handleUpdateItemCharges } from '@items/inv-utils';
 
 export default function EntityInfoSection(props: {
   id: StoreID;
@@ -118,6 +119,50 @@ export default function EntityInfoSection(props: {
           };
         }) ?? [],
     };
+
+    // Reset Staff Charges
+    const staves = filterByTraitType(newEntity?.inventory?.items ?? [], 'STAFF').filter(
+      (invItem) => invItem.is_equipped
+    );
+    let greatestSlotRank = 0;
+    for (const slot of spellData.slots) {
+      if (slot.rank > greatestSlotRank) {
+        greatestSlotRank = slot.rank;
+      }
+    }
+    for (const staff of staves) {
+      newEntity.inventory = {
+        ...(newEntity.inventory ?? {
+          coins: {
+            cp: 0,
+            sp: 0,
+            gp: 0,
+            pp: 0,
+          },
+          items: [],
+        }),
+        items:
+          newEntity.inventory?.items.map((i) => {
+            if (i.id !== staff.id) return i;
+
+            // If it's the item, update the charges
+            return {
+              ...i,
+              item: {
+                ...i.item,
+                meta_data: {
+                  ...i.item.meta_data!,
+                  charges: {
+                    ...i.item.meta_data?.charges,
+                    current: 0,
+                    max: greatestSlotRank,
+                  },
+                },
+              },
+            };
+          }) ?? [],
+      };
+    }
 
     // Remove Fatigued Condition
     let newConditions = _.cloneDeep(props.entity?.details?.conditions ?? []).filter((c) => c.name !== 'Fatigued');

--- a/frontend/src/pages/character_sheet/sections/EntityInfoSection.tsx
+++ b/frontend/src/pages/character_sheet/sections/EntityInfoSection.tsx
@@ -164,6 +164,42 @@ export default function EntityInfoSection(props: {
       };
     }
 
+    // Reset Wands
+    const wands = filterByTraitType(newEntity?.inventory?.items ?? [], 'WAND');
+    for (const wand of wands) {
+      newEntity.inventory = {
+        ...(newEntity.inventory ?? {
+          coins: {
+            cp: 0,
+            sp: 0,
+            gp: 0,
+            pp: 0,
+          },
+          items: [],
+        }),
+        items:
+          newEntity.inventory?.items.map((i) => {
+            if (i.id !== wand.id) return i;
+
+            // If it's the item, update the charges
+            return {
+              ...i,
+              item: {
+                ...i.item,
+                meta_data: {
+                  ...i.item.meta_data!,
+                  charges: {
+                    ...i.item.meta_data?.charges,
+                    current: 0,
+                    max: 1,
+                  },
+                },
+              },
+            };
+          }) ?? [],
+      };
+    }
+
     // Remove Fatigued Condition
     let newConditions = _.cloneDeep(props.entity?.details?.conditions ?? []).filter((c) => c.name !== 'Fatigued');
 

--- a/frontend/src/process/conditions/condition-handler.ts
+++ b/frontend/src/process/conditions/condition-handler.ts
@@ -254,7 +254,7 @@ const CONDITIONS: Condition[] = [
   },
   {
     name: 'Stupefied',
-    description: `Your thoughts and instincts are clouded. Stupefied always includes a value. You take a status penalty equal to this value on Intelligence-, Wisdom-, and Charisma-based checks and DCs, including Will saving throws, spell attack modifiers, spell DCs, and skill checks that use these attribute modifiers. Any time you attempt to Cast a Spell while stupefied, the spell is disrupted unless you succeed at a flat check with a DC equal to 5 + your stupefied value.`,
+    description: `Your thoughts and instincts are clouded. Stupefied always includes a value. You take a status penalty equal to this value on Intelligence-, Wisdom-, and Charisma-based checks and DCs, including Will saving throws, spell attack modifiers, spell DCs, and skill checks that use these attribute modifiers. Any time you attempt to ${convertToHardcodedLink('action', 'Cast a Spell')} while stupefied, the spell is disrupted unless you succeed at a flat check with a DC equal to 5 + your stupefied value.`,
     value: 1,
     for_creature: true,
     for_object: false,

--- a/frontend/src/process/content/collect-content.ts
+++ b/frontend/src/process/content/collect-content.ts
@@ -8,6 +8,7 @@ import {
   CastingSource,
   SenseWithRange,
   LivingEntity,
+  SpellSlotRecord,
 } from '@typing/content';
 import { GiveSpellData, SpellMetadata } from '@typing/operations';
 import { StoreID, VariableListStr, VariableNum } from '@typing/variables';
@@ -148,18 +149,21 @@ export function collectEntitySpellcasting(id: StoreID, entity: LivingEntity) {
   const spellSlots = getVariable<VariableListStr>(id, 'SPELL_SLOTS')?.value ?? [];
 
   // Prefill slots from computed results
-  let slots: SpellSlot[] = [];
+  let slots: SpellSlotRecord[] = [];
+  let count = 0;
   for (const strS of spellSlots) {
     const slot = JSON.parse(strS) as { lvl: number; rank: number; amt: number; source: string };
     for (let i = 0; i < slot.amt; i++) {
       if (slot.lvl !== entity.level) continue;
       slots.push({
+        id: `${id}-spell-slot-${count}`,
         rank: slot.rank,
         source: slot.source,
         spell_id: undefined,
         exhausted: undefined,
         color: undefined,
       });
+      count++;
     }
   }
 
@@ -238,7 +242,7 @@ export function getFocusPoints(id: StoreID, entity: LivingEntity, focusSpells: R
   };
 }
 
-function mergeSpellSlots(emptySlots: SpellSlot[], characterSlots: SpellSlot[]): SpellSlot[] {
+function mergeSpellSlots(emptySlots: SpellSlotRecord[], characterSlots: SpellSlot[]) {
   // Preprocess character slots into a Map for quick lookup
   const slotMap = new Map();
   for (const slot of characterSlots) {

--- a/frontend/src/process/content/hardcoded-links.ts
+++ b/frontend/src/process/content/hardcoded-links.ts
@@ -16,6 +16,7 @@ const actionMap: Record<string, number> = {
   Hide: 19726,
   Craft: 19617,
   'Assisted Recovery': 21086,
+  'Cast a Spell': 19611,
 };
 
 export function convertToHardcodedLink(type: ContentType | AbilityBlockType, text: string, displayText?: string) {

--- a/frontend/src/process/items/inv-utils.tsx
+++ b/frontend/src/process/items/inv-utils.tsx
@@ -401,6 +401,48 @@ export const handleMoveItem = (
 };
 
 /**
+ * Utility function to update the charges for an item
+ * @param setInventory - Character state setter
+ * @param invItem - Inventory item to update
+ * @param charges - Charges to set
+ */
+export const handleUpdateItemCharges = (
+  setCharacter: React.Dispatch<React.SetStateAction<Character | null>>,
+  invItem: InventoryItem,
+  charges: { current?: number; max?: number }
+) => {
+  setCharacter((char) => {
+    if (!char || !char.inventory) return null;
+
+    return {
+      ...char,
+      inventory: {
+        ...char.inventory,
+        items: char.inventory.items.map((i) => {
+          if (i.id !== invItem.id) return i;
+
+          // If it's the item, update the charges
+          return {
+            ...i,
+            item: {
+              ...i.item,
+              meta_data: {
+                ...i.item.meta_data!,
+                charges: {
+                  ...i.item.meta_data?.charges,
+                  current: charges.current ?? i.item.meta_data?.charges?.current,
+                  max: charges.max ?? i.item.meta_data?.charges?.max,
+                },
+              },
+            },
+          };
+        }),
+      },
+    };
+  });
+};
+
+/**
  * Determines the "best" equipped armor in an inventory, based on total resulting AC
  * @param id - Variable Store ID
  * @param inv - Inventory

--- a/frontend/src/process/items/inv-utils.tsx
+++ b/frontend/src/process/items/inv-utils.tsx
@@ -5,7 +5,7 @@ import { isPlayingStarfinder } from '@content/system-handler';
 import { showNotification } from '@mantine/notifications';
 import { Character, ContentPackage, Inventory, InventoryItem, Item } from '@typing/content';
 import { StoreID, VariableListStr } from '@typing/variables';
-import { getTraitIdByType, hasTraitType } from '@utils/traits';
+import { getTraitIdByType, hasTraitType, TraitType } from '@utils/traits';
 import { getFinalAcValue, getFinalVariableValue } from '@variables/variable-display';
 import { addVariableBonus, getAllSkillVariables, getAllSpeedVariables, getVariable } from '@variables/variable-manager';
 import { labelToVariable } from '@variables/variable-utils';
@@ -726,4 +726,8 @@ export function reachedInvestedLimit(id: StoreID, inv?: Inventory) {
 
 export function getInvestedLimit(id: StoreID) {
   return 10 + getFinalVariableValue(id, 'INVEST_LIMIT_BONUS').total;
+}
+
+export function filterByTraitType(invItems: InventoryItem[], traitType: TraitType) {
+  return invItems.filter((invItem) => hasTraitType(traitType, compileTraits(invItem.item)));
 }

--- a/frontend/src/process/spells/spell-utils.ts
+++ b/frontend/src/process/spells/spell-utils.ts
@@ -47,6 +47,26 @@ export function isNormalSpell(spell: Spell) {
  */
 export function getSpellcastingType(id: StoreID, entity: LivingEntity): 'PREPARED' | 'SPONTANEOUS' | 'NONE' {
   const spellData = collectEntitySpellcasting(id, entity);
+
+  // If you have slots, get type with the greatest slot
+  let greatestSlot = { rank: 0, source: '' };
+  for (const slot of spellData.slots) {
+    if (slot.rank > greatestSlot.rank) {
+      greatestSlot = {
+        rank: slot.rank,
+        source: slot.source,
+      };
+    }
+  }
+  if (greatestSlot.source) {
+    if (greatestSlot.source.startsWith('PREPARED')) {
+      return 'PREPARED';
+    } else if (greatestSlot.source.startsWith('SPONTANEOUS')) {
+      return 'SPONTANEOUS';
+    }
+  }
+
+  // If no slots, just grab the first type
   for (const source of spellData.sources) {
     if (source.type.startsWith('PREPARED')) {
       return 'PREPARED';

--- a/frontend/src/typing/content.d.ts
+++ b/frontend/src/typing/content.d.ts
@@ -48,6 +48,10 @@ type ContentType =
   | 'language'
   | 'content-source';
 
+interface SpellSlotRecord extends SpellSlot {
+  id: string;
+}
+
 interface SpellSlot {
   rank: number;
   source: string;
@@ -175,7 +179,7 @@ interface Item {
       striking?: number;
       resilient?: number;
       potency?: number;
-      property?: { name: string; id: number, rune?: Item }[];
+      property?: { name: string; id: number; rune?: Item }[];
     };
     starfinder?: {
       capacity?: string;

--- a/frontend/src/typing/content.d.ts
+++ b/frontend/src/typing/content.d.ts
@@ -81,6 +81,8 @@ interface CastingSource {
   attribute: string;
 }
 
+type SpellSectionType = 'PREPARED' | 'SPONTANEOUS' | 'FOCUS' | 'INNATE' | 'RITUAL' | 'STAFF' | 'WAND';
+
 interface Trait {
   id: number;
   created_at: string;

--- a/frontend/src/utils/strings.tsx
+++ b/frontend/src/utils/strings.tsx
@@ -97,6 +97,9 @@ export function toLabel(text?: string | null) {
     label = label.slice(0, -2) + 'DC';
   }
 
+  // Format rankings
+  label = label.replaceAll(/(\W|^)\d(st|nd|rd|th)(\W|$)/gim, (m) => m.toLowerCase());
+
   return label.trim();
 }
 

--- a/frontend/src/utils/traits.ts
+++ b/frontend/src/utils/traits.ts
@@ -1,4 +1,4 @@
-type TraitType =
+export type TraitType =
   | 'GENERAL'
   | 'SKILL'
   | 'INVESTED'
@@ -19,6 +19,8 @@ type TraitType =
   | 'DEDICATION'
   | 'ARCHAIC'
   | 'MAGICAL'
+  | 'STAFF'
+  | 'WAND'
   | 'TECH'
   | 'TRACKING-1'
   | 'TRACKING-2';
@@ -43,6 +45,8 @@ const traitMap: Record<number, TraitType> = {
   1446: 'MULTICLASS',
   1445: 'DEDICATION',
   1504: 'MAGICAL',
+  1546: 'STAFF',
+  1506: 'WAND',
   2503: 'ARCHAIC',
   2508: 'TECH',
   2511: 'TRACKING-1',

--- a/frontend/src/utils/traits.ts
+++ b/frontend/src/utils/traits.ts
@@ -46,7 +46,7 @@ const traitMap: Record<number, TraitType> = {
   1445: 'DEDICATION',
   1504: 'MAGICAL',
   1546: 'STAFF',
-  1506: 'WAND',
+  1665: 'WAND',
   2503: 'ARCHAIC',
   2508: 'TECH',
   2511: 'TRACKING-1',


### PR DESCRIPTION
Closes #153

## Proposed changes

Staves and wands in the character's inventory will now have sections that are generated for them under the spells panel. It detects the spells from the item descriptions. For staves, we add support for prepared and spontaneous spellcasting. Prepared casters can click to add more charges by consuming a spell slot. Spontaneous casters will have a modal open up asking them to consume a spell slot or not when they cast a spell from the staff.

For wands, we allow them to overload the wand which will break the item.

## Types of changes

What types of changes does your code introduce to Wanderer's Guide?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Screenshots

![E3520C24-3C56-4484-A90C-2CFED4D717C1](https://github.com/user-attachments/assets/36da5f19-82b7-4096-b563-6a779450c55b)
![60A405DE-F53A-4ACD-8135-B7427D08DE09](https://github.com/user-attachments/assets/ebbab638-ae6f-4ba4-af30-114e373d9c07)

## Further comments

I decided the best solution to supporting staves and wands would be to keep all data storage on the item itself. Ultimately item charges will suffice as the only data needing to be saved. With this approach I also solved handling spell logic by just detecting the spell links in the item. For staves, it uses regex to detect the rank of the spell from the rank prefix on that line. This approach will allow any future staves and wands to automatically be supported, rather than needing use operations or the like to integrate spellcasting support.

Worth noting, if you overcharge a wand it will always just break it. The player is expected to handle the DC 10 flat check to determine whether it needs to be destroyed.