### PR TITLE
Feature/free lore

### DIFF
--- a/frontend/src/pages/character_builder/CharBuilderHome.tsx
+++ b/frontend/src/pages/character_builder/CharBuilderHome.tsx
@@ -499,6 +499,24 @@ export default function CharBuilderHome(props: { pageHeight: number }) {
                   }}
                 />
                 <LinkSwitch
+                  label='Free Lore'
+                  info={`Most characters have some elements that connect them to their ancestry but identify more strongly with their class or unique personality. Sometimes, though, a character is the embodiment of their ancestry to the point that it’s of equal importance to their class. For a game where an ancestral background is a major theme and such characters are the norm, your group might consider using the ancestry paragon variant.`}
+                  url='https://2e.aonprd.com/Rules.aspx?ID=1336'
+                  enabled={character?.variants?.free_lore}
+                  onLinkChange={(enabled) => {
+                    setCharacter((prev) => {
+                      if (!prev) return prev;
+                      return {
+                        ...prev,
+                        variants: {
+                          ...prev.variants,
+                          free_lore: enabled,
+                        },
+                      };
+                    });
+                  }}
+                />
+                <LinkSwitch
                   label='Dual Class'
                   info={`Sometimes, especially when you have a particularly small play group or want to play incredibly versatile characters, you might want to allow dual-class characters that have the full benefits of two different classes.`}
                   url='https://2e.aonprd.com/Rules.aspx?ID=1328'

--- a/frontend/src/pages/character_builder/CharBuilderHome.tsx
+++ b/frontend/src/pages/character_builder/CharBuilderHome.tsx
@@ -500,8 +500,7 @@ export default function CharBuilderHome(props: { pageHeight: number }) {
                 />
                 <LinkSwitch
                   label='Free Lore'
-                  info={`Most characters have some elements that connect them to their ancestry but identify more strongly with their class or unique personality. Sometimes, though, a character is the embodiment of their ancestry to the point that it’s of equal importance to their class. For a game where an ancestral background is a major theme and such characters are the norm, your group might consider using the ancestry paragon variant.`}
-                  url='https://2e.aonprd.com/Rules.aspx?ID=1336'
+                  info={`This variant is used to grant all characters a free lore skill. Use this for Pathfinder Society characters to allow all characters to be trained in Pathfinder Society Lore.`}
                   enabled={character?.variants?.free_lore}
                   onLinkChange={(enabled) => {
                     setCharacter((prev) => {

--- a/frontend/src/process/operations/operation-controller.ts
+++ b/frontend/src/process/operations/operation-controller.ts
@@ -226,6 +226,37 @@ export async function executeCharacterOperations(
     }
   }
 
+  // Add Free Lore
+  if (character.variants?.free_lore) {
+  }
+  classFeatures.push({
+    id: hashData({ name: 'free-lore', level: 1 }),
+    created_at: '',
+    operations: [
+      {id: `720d2fe6-f042-4353-8313-1293375b1301-223`,
+      type: 'select',
+      data: {
+        title: 'Select a Lore to be Trained',
+        modeType: 'FILTERED',
+        optionType: 'ADJ_VALUE',
+        optionsPredefined: [],
+        optionsFilters: {
+          id: `f8703468-ab35-4f84-8dc7-7c48556258e3-223`,
+          type: 'ADJ_VALUE',
+          group: 'ADD-LORE',
+          value: { value: 'T' },
+        },
+      },}
+    ],
+    name: 'Free Lore',
+    actions: null,
+    level: 1,
+    rarity: 'COMMON',
+    description: `You gain a class feat that you can only use for archetypes.`,
+    type: 'class-feature',
+    content_source_id: -1,
+  })
+
   // Gradual Attribute Boosts
   if (character.variants?.gradual_attribute_boosts) {
     const newClassFeatures: AbilityBlock[] = [];
@@ -267,7 +298,6 @@ export async function executeCharacterOperations(
       }
       newClassFeatures.push(...newBoostClassFeatures);
     }
-    classFeatures = newClassFeatures;
   }
 
   const operationsPassthrough = async (options?: OperationOptions) => {
@@ -750,6 +780,8 @@ export function addedClassSkillTrainings(varId: StoreID, baseTrainings: number):
         },
       },
     });
+
+
   }
 
   return operations;
@@ -865,6 +897,7 @@ export function addedAncestryLanguages(varId: StoreID, ancestry: Ancestry): Oper
     });
   }
 
+  
   return operations;
 }
 

--- a/frontend/src/process/operations/operation-controller.ts
+++ b/frontend/src/process/operations/operation-controller.ts
@@ -252,7 +252,7 @@ export async function executeCharacterOperations(
     actions: null,
     level: 1,
     rarity: 'COMMON',
-    description: `You gain a class feat that you can only use for archetypes.`,
+    description: `You are trained in a free Lore skill.`,
     type: 'class-feature',
     content_source_id: -1,
   })

--- a/frontend/src/process/operations/operation-controller.ts
+++ b/frontend/src/process/operations/operation-controller.ts
@@ -298,6 +298,7 @@ export async function executeCharacterOperations(
       }
       newClassFeatures.push(...newBoostClassFeatures);
     }
+    classFeatures = newClassFeatures;
   }
 
   const operationsPassthrough = async (options?: OperationOptions) => {

--- a/frontend/src/typing/content.d.ts
+++ b/frontend/src/typing/content.d.ts
@@ -481,6 +481,7 @@ interface Character extends LivingEntity {
     free_archetype?: boolean;
     dual_class?: boolean;
     gradual_attribute_boosts?: boolean;
+    free_lore?:boolean;
   };
   content_sources?: {
     enabled?: number[];


### PR DESCRIPTION
## Proposed changes

Adding a new Variant Rule - "Free Lore", which allows characters to be granted a free lore skill, the lore is up to the player but it is intended for things like PFS giving free Pathfinder Society Lore.

The IDs in operation-controller have been copied from other functions, so you may need to change the ids.

## Types of changes

What types of changes does your code introduce to Wanderer's Guide?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Screenshots

(prefer animated gif)
![image](https://github.com/user-attachments/assets/5900b222-2366-489d-b408-88257b36c784)
![image](https://github.com/user-attachments/assets/9a169803-69b6-4146-879e-93d6db5fb197)

## Further comments

I based it off how the free archtype variant is done, as an example of another variant rule, using the "Add a lore" operation instead. If there are major issues with how i've done it, please reach out to me on discord (rhaums).