### PR TITLE
Fixed links to campaign and characters inside campaigns

### DIFF
--- a/frontend/src/common/CharacterInfo.tsx
+++ b/frontend/src/common/CharacterInfo.tsx
@@ -1,5 +1,6 @@
 import classes from '@css/UserInfoIcons.module.css';
 import {
+  Anchor,
   Avatar,
   Badge,
   Box,
@@ -188,7 +189,6 @@ export const CharacterInfo = forwardRef(
 export function CharacterDetailedInfo(props: {
   character: Character | null;
   nameCutOff?: number;
-  onClick?: () => void;
 }) {
   const theme = useMantineTheme();
   const isPhone = useMediaQuery(phoneQuery());
@@ -202,145 +202,141 @@ export function CharacterDetailedInfo(props: {
 
   return (
     <div style={{ width: isPhone ? undefined : 240 }}>
-      <Group
-        wrap='nowrap'
-        align='flex-start'
-        gap={0}
-        style={{ cursor: props.onClick ? 'pointer' : 'auto' }}
-        onClick={(e) => {
-          if (props.onClick) {
-            e.stopPropagation();
-            props.onClick();
-          }
-        }}
-      >
-        <Box style={{ position: 'relative' }} mt={0} mr={10}>
-          {conditions.length > 0 && (
-            <HoverCard shadow='md' openDelay={250}>
-              <HoverCard.Target>
-                <Badge
-                  size='xs'
-                  color='red.6'
-                  style={{ position: 'absolute', bottom: 0, left: 0, zIndex: 100, cursor: 'pointer' }}
-                  circle
-                >
-                  {conditions.length}
-                </Badge>
-              </HoverCard.Target>
-              <HoverCard.Dropdown p={10}>
-                <Stack gap={10}>
-                  {conditions.map((condition) => (
-                    <Badge
-                      size='md'
-                      variant='light'
-                      color='gray'
-                      styles={{
-                        root: {
-                          textTransform: 'initial',
-                        },
-                      }}
-                    >
-                      {condition.name}
-                      {condition.value ? `, ${condition.value}` : ''}
-                    </Badge>
-                  ))}
-                </Stack>
-              </HoverCard.Dropdown>
-            </HoverCard>
-          )}
-          <Avatar
-            src={props.character?.details?.image_url}
-            alt='Character Portrait'
-            size={75}
-            radius={75}
-            variant='transparent'
-            color='dark.3'
-            bg={theme.colors.dark[6]}
-          />
-
-          <Box
-            style={{
-              position: 'absolute',
-              top: '50%',
-              left: '50%',
-              transform: 'translate(-50%, -50%)',
-            }}
+      <Anchor href={`/sheet/${props.character?.id}`} target={"_blank"} underline={"never"}>
+          <Group
+            wrap='nowrap'
+            align='flex-start'
+            gap={0}
+            style={{ cursor: 'pointer' }}
           >
-            <RingProgress
-              style={{
-                opacity: 0.5,
-              }}
-              size={90}
-              thickness={3}
-              sections={[
-                {
-                  value: currentHealth === 0 ? 100 : Math.ceil((currentHealth / maxHealth) * 100),
-                  color: interpolateHealth(currentHealth / maxHealth),
-                },
-              ]}
-            />
-          </Box>
-        </Box>
+            <Box style={{ position: 'relative' }} mt={0} mr={10}>
+              {conditions.length > 0 && (
+                <HoverCard shadow='md' openDelay={250}>
+                  <HoverCard.Target>
+                    <Badge
+                      size='xs'
+                      color='red.6'
+                      style={{ position: 'absolute', bottom: 0, left: 0, zIndex: 100, cursor: 'pointer' }}
+                      circle
+                    >
+                      {conditions.length}
+                    </Badge>
+                  </HoverCard.Target>
+                  <HoverCard.Dropdown p={10}>
+                    <Stack gap={10}>
+                      {conditions.map((condition) => (
+                        <Badge
+                          size='md'
+                          variant='light'
+                          color='gray'
+                          styles={{
+                            root: {
+                              textTransform: 'initial',
+                            },
+                          }}
+                        >
+                          {condition.name}
+                          {condition.value ? `, ${condition.value}` : ''}
+                        </Badge>
+                      ))}
+                    </Stack>
+                  </HoverCard.Dropdown>
+                </HoverCard>
+              )}
+              <Avatar
+                src={props.character?.details?.image_url}
+                alt='Character Portrait'
+                size={75}
+                radius={75}
+                variant='transparent'
+                color='dark.3'
+                bg={theme.colors.dark[6]}
+              />
 
-        <div style={{ flex: 1 }}>
-          <HoverCard shadow='md' openDelay={1000} position='top' withinPortal>
-            <HoverCard.Target>
-              <Text
-                c='gray.0'
-                fz={props.character && props.character.name.length >= 16 ? '0.9rem' : 'lg'}
-                fw={500}
-                className={classes.name}
+              <Box
+                style={{
+                  position: 'absolute',
+                  top: '50%',
+                  left: '50%',
+                  transform: 'translate(-50%, -50%)',
+                }}
               >
-                {truncate(props.character?.name, {
-                  length: props.nameCutOff ?? 18,
-                })}
-              </Text>
-            </HoverCard.Target>
-            <HoverCard.Dropdown py={5} px={10}>
-              <Text c='gray.0' size='sm'>
-                {props.character?.name}
-              </Text>
-            </HoverCard.Dropdown>
-          </HoverCard>
+                <RingProgress
+                  style={{
+                    opacity: 0.5,
+                  }}
+                  size={90}
+                  thickness={3}
+                  sections={[
+                    {
+                      value: currentHealth === 0 ? 100 : Math.ceil((currentHealth / maxHealth) * 100),
+                      color: interpolateHealth(currentHealth / maxHealth),
+                    },
+                  ]}
+                />
+              </Box>
+            </Box>
 
-          <Stack gap={3}>
-            <Box>
-              <Group wrap='nowrap' gap={10}>
-                <IconTree stroke={1.5} size='1rem' className={classes.icon} />
-                <Text fz='xs' c='gray.3'>
-                  {props.character?.details?.ancestry?.name ? (
-                    <>
-                      {/* {props.character?.details?.heritage?.name ?? ''}{' '} */}
-                      {props.character.details.ancestry.name}
-                    </>
-                  ) : (
-                    <>Missing Ancestry</>
-                  )}
-                </Text>
-              </Group>
-            </Box>
-            <Box>
-              <Group wrap='nowrap' gap={10}>
-                <IconWindow stroke={1.5} size='1rem' className={classes.icon} />
-                <Text fz='xs' c='gray.3'>
-                  {props.character?.details?.background?.name ?? 'Missing Background'}
-                </Text>
-              </Group>
-            </Box>
-            <Box>
-              <Group wrap='nowrap' gap={10}>
-                <IconVocabulary stroke={1.5} size='1rem' className={classes.icon} />
-                <Text fz='xs' c='gray.3'>
-                  {props.character?.details?.class?.name ?? 'Missing Class'}
-                  {props.character?.variants?.dual_class && (
-                    <> / {props.character?.details?.class_2?.name ?? 'Missing Class'}</>
-                  )}
-                </Text>
-              </Group>
-            </Box>
-          </Stack>
-        </div>
-      </Group>
+            <div style={{ flex: 1 }}>
+              <HoverCard shadow='md' openDelay={1000} position='top' withinPortal>
+                <HoverCard.Target>
+                  <Text
+                    c='gray.0'
+                    fz={props.character && props.character.name.length >= 16 ? '0.9rem' : 'lg'}
+                    fw={500}
+                    className={classes.name}
+                  >
+                    {truncate(props.character?.name, {
+                      length: props.nameCutOff ?? 18,
+                    })}
+                  </Text>
+                </HoverCard.Target>
+                <HoverCard.Dropdown py={5} px={10}>
+                  <Text c='gray.0' size='sm'>
+                    {props.character?.name}
+                  </Text>
+                </HoverCard.Dropdown>
+              </HoverCard>
+
+              <Stack gap={3}>
+                <Box>
+                  <Group wrap='nowrap' gap={10}>
+                    <IconTree stroke={1.5} size='1rem' className={classes.icon} />
+                    <Text fz='xs' c='gray.3'>
+                      {props.character?.details?.ancestry?.name ? (
+                        <>
+                          {/* {props.character?.details?.heritage?.name ?? ''}{' '} */}
+                          {props.character.details.ancestry.name}
+                        </>
+                      ) : (
+                        <>Missing Ancestry</>
+                      )}
+                    </Text>
+                  </Group>
+                </Box>
+                <Box>
+                  <Group wrap='nowrap' gap={10}>
+                    <IconWindow stroke={1.5} size='1rem' className={classes.icon} />
+                    <Text fz='xs' c='gray.3'>
+                      {props.character?.details?.background?.name ?? 'Missing Background'}
+                    </Text>
+                  </Group>
+                </Box>
+                <Box>
+                  <Group wrap='nowrap' gap={10}>
+                    <IconVocabulary stroke={1.5} size='1rem' className={classes.icon} />
+                    <Text fz='xs' c='gray.3'>
+                      {props.character?.details?.class?.name ?? 'Missing Class'}
+                      {props.character?.variants?.dual_class && (
+                        <> / {props.character?.details?.class_2?.name ?? 'Missing Class'}</>
+                      )}
+                    </Text>
+                  </Group>
+                </Box>
+              </Stack>
+            </div>
+          </Group>
+      </Anchor>
     </div>
   );
 }

--- a/frontend/src/pages/CampaignsPage.tsx
+++ b/frontend/src/pages/CampaignsPage.tsx
@@ -179,6 +179,7 @@ function CampaignCard(props: { campaign: Campaign }) {
           component='a'
           href={`/campaign/${props.campaign.id}`}
           style={{
+            zIndex: 1,
             position: 'absolute',
             top: 0,
             left: 0,

--- a/frontend/src/pages/campaign/CampaignOverviewPage.tsx
+++ b/frontend/src/pages/campaign/CampaignOverviewPage.tsx
@@ -284,9 +284,6 @@ export function CampaignInner(props: { campaignId: number; onFinishLoading: () =
                           <BlurBox blur={10} maw={280} py={5} px='sm'>
                             <CharacterDetailedInfo
                               character={character}
-                              onClick={() => {
-                                window.open(`/sheet/${character.id}`, '_blank');
-                              }}
                             />
                           </BlurBox>
                         ))}


### PR DESCRIPTION
## Proposed changes

On the Campaigns-List-Page the link behind the single campaign cards was not clickable. Clicking middle mouse button or rightclick->open link in new tab did not work. 
This is fixed with the zIndex.

Also on the campaign itself the character cards were clickable, but did not use a <a/>-Element in the background. So it did nothing when using the middle mouse button (although it did open in a new tab, when using left mouse button. But out of habit, I used middle mouse button). Using <a/>-Elements instead of onClick-listener should also be better for screen readers and accessibility. 
Please note, that the character cards of other characters of the same campaign in the campaign drawer of a character sheet are now also clickable (if they are displayed detailed and not status only). I can remove that, but I think it is a useful addition. 

## Types of changes

What types of changes does your code introduce to Wanderer's Guide?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Screenshots

(prefer animated gif)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...