### PR TITLE
Allow equipping all staves (codas)

### DIFF
--- a/frontend/src/process/items/inv-utils.tsx
+++ b/frontend/src/process/items/inv-utils.tsx
@@ -752,7 +752,7 @@ export function isItemImplantable(item: Item) {
  * @returns - Whether the item is equippable
  */
 export function isItemEquippable(item: Item) {
-  return isItemWeapon(item) || isItemArmor(item) || isItemShield(item);
+  return isItemWeapon(item) || isItemArmor(item) || isItemShield(item) || isItemStave(item);
 }
 
 /**
@@ -846,6 +846,15 @@ export function isItemArmor(item: Item) {
  */
 export function isItemShield(item: Item) {
   return item.meta_data?.ac_bonus !== undefined && !isItemArmor(item);
+}
+
+/**
+ * Utility function to determine if an item is a stave
+ * @param item - Item
+ * @returns - Whether the item is a stave
+ */
+export function isItemStave(item: Item) {
+  return hasTraitType('STAFF', item.traits);
 }
 
 /**


### PR DESCRIPTION
## Proposed changes

Allow all staves to be equipped

## Types of changes

What types of changes does your code introduce to Wanderer's Guide?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Further comments

The code that adds a stave's spell list to the spellcasting panel requires that the stave be equipped. In most cases this is not an issue since staves are weapons, which can be equipped. In the case of [codas](https://2e.aonprd.com/Rules.aspx?ID=1913) however, they are not weapons and need a small amount of extra code to allow equipping. This also future-proofs against any future staves that behave like codas.