### PR TITLE
added DESTINY trait for Mythic Archetypes

### DIFF
--- a/frontend/src/modals/CreateArchetypeModal.tsx
+++ b/frontend/src/modals/CreateArchetypeModal.tsx
@@ -179,7 +179,7 @@ export function CreateArchetypeModal(props: {
                 showButton: false,
                 overrideLabel: 'Select a Dedication',
                 abilityBlockType: 'feat',
-                filterFn: (feat) => hasTraitType('DEDICATION', feat.traits),
+                filterFn: (feat) => hasTraitType('DEDICATION', feat.traits) || hasTraitType('DESTINY', feat.traits),
               }}
               selectedId={form.values.dedication_feat_id}
             />

--- a/frontend/src/utils/traits.ts
+++ b/frontend/src/utils/traits.ts
@@ -77,7 +77,7 @@ const traitMap: Record<number, TraitType> = {
   1580: 'FLEXIBLE',
   1446: 'MULTICLASS',
   1445: 'DEDICATION',
-  1444: 'DESTINY',
+  4074: 'DESTINY',
   1504: 'MAGICAL',
   1546: 'STAFF',
   1665: 'WAND',

--- a/frontend/src/utils/traits.ts
+++ b/frontend/src/utils/traits.ts
@@ -26,6 +26,7 @@ export type TraitType =
   | 'FLEXIBLE'
   | 'MULTICLASS'
   | 'DEDICATION'
+  | 'DESTINY'
   | 'ARCHAIC'
   | 'MAGICAL'
   | 'STAFF'
@@ -76,6 +77,7 @@ const traitMap: Record<number, TraitType> = {
   1580: 'FLEXIBLE',
   1446: 'MULTICLASS',
   1445: 'DEDICATION',
+  1444: 'DESTINY',
   1504: 'MAGICAL',
   1546: 'STAFF',
   1665: 'WAND',


### PR DESCRIPTION
## Proposed changes

Added the DESTINY trait and allow for feats with the DESTINY trait to be selected when creating an Archetype for the purpose of Mythic Destiny Archetypes.

## Types of changes

What types of changes does your code introduce to Wanderer's Guide?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Further comments

This is my first contribution. It seemed like a simple fix but I likely missed something. Also, I was unsure how to link it, but this is for Issue #168.