### PR TITLE
fix(content): initialize idStore maps for all 13 content types

### DIFF
--- a/frontend/src/process/content/content-store.ts
+++ b/frontend/src/process/content/content-store.ts
@@ -71,6 +71,10 @@ function emptyIdStore() {
   newStore.set('language', new Map());
   newStore.set('spell', new Map());
   newStore.set('trait', new Map());
+  newStore.set('archetype', new Map());
+  newStore.set('versatile-heritage', new Map());
+  newStore.set('class-archetype', new Map());
+  newStore.set('creature', new Map());
   newStore.set('content-source', new Map());
   return newStore;
 }


### PR DESCRIPTION
## Summary
`emptyIdStore()` in `frontend/src/process/content/content-store.ts` only initialized by-id `idStore` Maps for **9 of the 13** `ContentType`s — omitting `archetype`, `versatile-heritage`, `class-archetype`, and `creature`.

Because every writer uses optional chaining (`idStore.get(type)?.set(...)` in `importFromContentPackage`, `setStoredIds`, etc.), stores for those 4 types **silently no-opped**. So `getStoredIds`, `getContentFast`, and `getCachedContent` never returned cached entries for them, and they were re-fetched from the network every time.

## Fix
Add the 4 missing types to `emptyIdStore()`. One-line-each, no behavior change beyond those types now actually caching by id.

## Notes
- **Pre-existing on `main`** — not introduced by (and independent of) the IndexedDB content-cache PR #251. Surfaced during that PR's review and split out to keep it focused.
- Verified nothing relied on those types being absent from the by-id store (`getCachedContent`/`getContentFast` have no call sites for them).
- `tsc --noEmit`: clean on `content-store.ts` (the 4 remaining errors are a pre-existing `prosemirror-model` dedup artifact in `ContentLinkExtension.ts`, unrelated). `eslint`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
