### PR TITLE
fix: builder crashes, sheet data-loss, and content-update atomicity

### DIFF
--- a/frontend/src/common/select/SelectContent.tsx
+++ b/frontend/src/common/select/SelectContent.tsx
@@ -846,7 +846,7 @@ function SelectionOptions(props: {
       const diff = (prereqRank.get(a.id) ?? 2) - (prereqRank.get(b.id) ?? 2);
       if (diff !== 0) return diff;
     }
-    return a.name.localeCompare(b.name);
+    return (a.name ?? '').localeCompare(b.name ?? '');
   });
 
   return (

--- a/frontend/src/drawers/types/ClassArchetypeDrawer.tsx
+++ b/frontend/src/drawers/types/ClassArchetypeDrawer.tsx
@@ -148,7 +148,7 @@ export function ClassArchetypeDrawerContent(props: {
         <Stack gap={0}>
           <Divider color='dark.6' />
           {adjustments[level]
-            .sort((a, b) => a.type.localeCompare(b.type))
+            .sort((a, b) => (a.type ?? '').localeCompare(b.type ?? ''))
             .map((fa, index) => (
               <Box key={index}>
                 <Group justify='flex-start' wrap='nowrap' gap={5} p='sm'>

--- a/frontend/src/pages/character_builder/CharBuilderCreation.tsx
+++ b/frontend/src/pages/character_builder/CharBuilderCreation.tsx
@@ -6,7 +6,13 @@ import RichText from '@common/RichText';
 import ResultWrapper from '@common/operations/results/ResultWrapper';
 import { SelectContentButton, selectContent } from '@common/select/SelectContent';
 import { IMPRINT_BG_COLOR, IMPRINT_BG_COLOR_HOVER, IMPRINT_BORDER_COLOR } from '@constants/data';
-import { fetchContent, fetchContentPackage, fetchContentSources, getDefaultSources } from '@content/content-store';
+import {
+  fetchContent,
+  fetchContentPackage,
+  fetchContentSources,
+  getDefaultSources,
+  isContentPackageEmpty,
+} from '@content/content-store';
 import { getIconFromContentType } from '@content/content-utils';
 import classes from '@css/FaqSimple.module.css';
 import { AncestryInitialOverview, convertAncestryOperationsIntoUI } from '@drawers/types/AncestryDrawer';
@@ -68,7 +74,7 @@ export default function CharBuilderCreation(props: { characterId: number; pageHe
   const theme = useMantineTheme();
   const [doneLoading, setDoneLoading] = useState(false);
 
-  const { data: content, isFetching } = useQuery({
+  const { data: content, isFetching, refetch } = useQuery({
     queryKey: [`find-content-${props.characterId}-for-char-builder-creation`, { characterId: props.characterId }],
     queryFn: async () => {
       // Prefetch content sources (to avoid multiple requests)
@@ -105,8 +111,33 @@ export default function CharBuilderCreation(props: { characterId: number; pageHe
     </Box>
   );
 
+  const loadError = (
+    <Box
+      style={{
+        width: '100%',
+        height: '300px',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      <Stack align='center' gap='xs' maw={380} px='md'>
+        <Text fw={600}>Couldn't load game content</Text>
+        <Text size='sm' c='dimmed' ta='center'>
+          The content library didn't load, so the builder stayed closed to avoid saving your character against
+          missing data. Check your connection and try again.
+        </Text>
+        <Button onClick={() => refetch()}>Retry</Button>
+      </Stack>
+    </Box>
+  );
+
   if (isFetching || !content) {
     return loader;
+  } else if (isContentPackageEmpty(content)) {
+    // Resolved-but-empty corpus = failed fetch. Don't mount the builder against no
+    // content (it would degrade the character and the auto-save would persist it, #235).
+    return loadError;
   } else {
     return (
       <>

--- a/frontend/src/pages/character_sheet/CharacterSheetPage.tsx
+++ b/frontend/src/pages/character_sheet/CharacterSheetPage.tsx
@@ -1,7 +1,12 @@
 import D20Loader from '@assets/images/D20Loader';
 import { glassStyle } from '@utils/colors';
 import BlurBox from '@common/BlurBox';
-import { defineDefaultSources, fetchContentPackage, fetchContentSources } from '@content/content-store';
+import {
+  defineDefaultSources,
+  fetchContentPackage,
+  fetchContentSources,
+  isContentPackageEmpty,
+} from '@content/content-store';
 
 import {
   ActionIcon,
@@ -14,6 +19,7 @@ import {
   SimpleGrid,
   Stack,
   Tabs,
+  Text,
   rem,
   useMantineTheme,
 } from '@mantine/core';
@@ -90,7 +96,7 @@ export function Component(props: {}) {
   const theme = useMantineTheme();
   const [doneLoading, setDoneLoading] = useState(false);
 
-  const { data: content, isFetching } = useQuery({
+  const { data: content, isFetching, refetch } = useQuery({
     queryKey: [`find-content-${characterId}`],
     queryFn: async () => {
       // Set default sources
@@ -140,8 +146,34 @@ export function Component(props: {}) {
     </Box>
   );
 
+  const loadError = (
+    <Box
+      style={{
+        width: '100%',
+        height: '300px',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      <Stack align='center' gap='xs' maw={380} px='md'>
+        <Text fw={600}>Couldn't load game content</Text>
+        <Text size='sm' c='dimmed' ta='center'>
+          The content library didn't load, so the sheet stayed closed to avoid saving your character against
+          missing data. Check your connection and try again.
+        </Text>
+        <Button onClick={() => refetch()}>Retry</Button>
+      </Stack>
+    </Box>
+  );
+
   if (isFetching || !content) {
     return loader;
+  } else if (isContentPackageEmpty(content)) {
+    // A resolved-but-empty corpus means the fetch failed (see isContentPackageEmpty).
+    // Do NOT mount the sheet: EXECUTE_OPS against no content wipes HP/boosts/choices
+    // and the auto-save would then persist that loss (#235). Offer a retry instead.
+    return loadError;
   } else {
     // Render both elements simultaneously so CharacterSheetInner can run
     // EXECUTE_OPS in the background while the loader is still visible.

--- a/frontend/src/process/content/collect-content.ts
+++ b/frontend/src/process/content/collect-content.ts
@@ -35,7 +35,7 @@ export function collectEntityAbilityBlocks(
           return a.level - b.level;
         }
       }
-      return a.name.localeCompare(b.name);
+      return (a.name ?? '').localeCompare(b.name ?? '');
     });
 
   const generalAndSkillFeats = feats.filter((feat) => {
@@ -98,10 +98,10 @@ export function collectEntityAbilityBlocks(
           return a.level - b.level;
         }
       }
-      return a.name.localeCompare(b.name);
+      return (a.name ?? '').localeCompare(b.name ?? '');
     }),
-    physicalFeatures: physicalFeatures.sort((a, b) => a.name.localeCompare(b.name)),
-    heritages: heritages.sort((a, b) => a.name.localeCompare(b.name)),
+    physicalFeatures: physicalFeatures.sort((a, b) => (a.name ?? '').localeCompare(b.name ?? '')),
+    heritages: heritages.sort((a, b) => (a.name ?? '').localeCompare(b.name ?? '')),
     // For creature:
     baseAbilities: isCreature(entity) ? (entity.abilities_base ?? []) : [],
     addedAbilities: isCreature(entity)
@@ -233,9 +233,9 @@ export function collectEntitySpellcasting(id: StoreID, entity: LivingEntity) {
       })
       .sort((a, b) => {
         if (a.type !== b.type) {
-          return b.type.localeCompare(a.type);
+          return (b.type ?? '').localeCompare(a.type ?? '');
         }
-        return a.name.localeCompare(b.name);
+        return (a.name ?? '').localeCompare(b.name ?? '');
       }),
   };
 }

--- a/frontend/src/process/content/content-store.ts
+++ b/frontend/src/process/content/content-store.ts
@@ -576,7 +576,24 @@ export async function fetchContentSources(sources: SourceValue) {
     );
   }
 
-  return results.sort((a, b) => a.name.localeCompare(b.name));
+  return results.sort((a, b) => (a.name ?? '').localeCompare(b.name ?? ''));
+}
+
+/**
+ * True when a content package came back effectively empty — i.e. the core content
+ * tables (ancestries/classes/items/traits) all failed to load. The global content
+ * corpus is never legitimately empty for a real source set, so this reliably means
+ * the fetch failed (network/edge/DNS) rather than "the user genuinely has no content."
+ * Used to refuse mounting the sheet/builder — and to refuse auto-saving — against a
+ * corpus that isn't there, which would otherwise wipe the character (see issue #235).
+ */
+export function isContentPackageEmpty(content: ContentPackage): boolean {
+  return (
+    content.ancestries.length === 0 &&
+    content.classes.length === 0 &&
+    content.items.length === 0 &&
+    content.traits.length === 0
+  );
 }
 
 export async function fetchContentPackage(
@@ -603,18 +620,18 @@ export async function fetchContentPackage(
   ]);
 
   const p = {
-    ancestries: ((content[0] ?? []) as Ancestry[]).sort((a, b) => a.name.localeCompare(b.name)),
-    backgrounds: ((content[1] ?? []) as Background[]).sort((a, b) => a.name.localeCompare(b.name)),
-    classes: ((content[2] ?? []) as Class[]).sort((a, b) => a.name.localeCompare(b.name)),
-    abilityBlocks: ((content[3] ?? []) as AbilityBlock[]).sort((a, b) => a.name.localeCompare(b.name)),
-    items: ((content[4] ?? []) as Item[]).sort((a, b) => a.name.localeCompare(b.name)),
-    languages: ((content[5] ?? []) as Language[]).sort((a, b) => a.name.localeCompare(b.name)),
-    spells: ((content[6] ?? []) as Spell[]).sort((a, b) => a.name.localeCompare(b.name)),
-    traits: ((content[7] ?? []) as Trait[]).sort((a, b) => a.name.localeCompare(b.name)),
-    creatures: ((content[8] ?? []) as Creature[]).sort((a, b) => a.name.localeCompare(b.name)),
-    archetypes: ((content[9] ?? []) as Archetype[]).sort((a, b) => a.name.localeCompare(b.name)),
-    versatileHeritages: ((content[10] ?? []) as VersatileHeritage[]).sort((a, b) => a.name.localeCompare(b.name)),
-    classArchetypes: ((content[11] ?? []) as ClassArchetype[]).sort((a, b) => a.name.localeCompare(b.name)),
+    ancestries: ((content[0] ?? []) as Ancestry[]).sort((a, b) => (a.name ?? '').localeCompare(b.name ?? '')),
+    backgrounds: ((content[1] ?? []) as Background[]).sort((a, b) => (a.name ?? '').localeCompare(b.name ?? '')),
+    classes: ((content[2] ?? []) as Class[]).sort((a, b) => (a.name ?? '').localeCompare(b.name ?? '')),
+    abilityBlocks: ((content[3] ?? []) as AbilityBlock[]).sort((a, b) => (a.name ?? '').localeCompare(b.name ?? '')),
+    items: ((content[4] ?? []) as Item[]).sort((a, b) => (a.name ?? '').localeCompare(b.name ?? '')),
+    languages: ((content[5] ?? []) as Language[]).sort((a, b) => (a.name ?? '').localeCompare(b.name ?? '')),
+    spells: ((content[6] ?? []) as Spell[]).sort((a, b) => (a.name ?? '').localeCompare(b.name ?? '')),
+    traits: ((content[7] ?? []) as Trait[]).sort((a, b) => (a.name ?? '').localeCompare(b.name ?? '')),
+    creatures: ((content[8] ?? []) as Creature[]).sort((a, b) => (a.name ?? '').localeCompare(b.name ?? '')),
+    archetypes: ((content[9] ?? []) as Archetype[]).sort((a, b) => (a.name ?? '').localeCompare(b.name ?? '')),
+    versatileHeritages: ((content[10] ?? []) as VersatileHeritage[]).sort((a, b) => (a.name ?? '').localeCompare(b.name ?? '')),
+    classArchetypes: ((content[11] ?? []) as ClassArchetype[]).sort((a, b) => (a.name ?? '').localeCompare(b.name ?? '')),
     sources: content[12] as ContentSource[],
     defaultSources: {
       PAGE: getDefaultSources('PAGE'),

--- a/frontend/src/process/operations/operation-controller.ts
+++ b/frontend/src/process/operations/operation-controller.ts
@@ -178,7 +178,7 @@ export async function _executeCharacterOperations(data: {
         return a.level - b.level;
       }
     }
-    return a.name.localeCompare(b.name);
+    return (a.name ?? '').localeCompare(b.name ?? '');
   });
 
   const classFeatures_2 = getClassFeatures(content.abilityBlocks, class_2?.trait_id, '2').sort((a, b) => {
@@ -187,14 +187,14 @@ export async function _executeCharacterOperations(data: {
         return a.level - b.level;
       }
     }
-    return a.name.localeCompare(b.name);
+    return (a.name ?? '').localeCompare(b.name ?? '');
   });
 
   // Merge both but only keep one if they both have the same name and level
   let classFeatures = unionWith(
     classFeatures_1,
     classFeatures_2,
-    (a, b) => a.name.trim() === b.name.trim() && a.level === b.level
+    (a, b) => (a.name ?? '').trim() === (b.name ?? '').trim() && a.level === b.level
   );
 
   // Free Archetype feat at every even level
@@ -296,7 +296,7 @@ export async function _executeCharacterOperations(data: {
   if (character.variants?.gradual_attribute_boosts) {
     const newClassFeatures: AbilityBlock[] = [];
     for (const cf of classFeatures) {
-      if (!(cf.name.trim() === 'Attribute Boosts' && cf.operations?.length === 4) || cf.level === 1) {
+      if (!((cf.name ?? '').trim() === 'Attribute Boosts' && cf.operations?.length === 4) || cf.level === 1) {
         newClassFeatures.push(cf);
         continue;
       }

--- a/frontend/src/utils/use-character.tsx
+++ b/frontend/src/utils/use-character.tsx
@@ -1,7 +1,7 @@
 import { characterState } from '@atoms/characterAtoms';
 import { getCachedPublicUser } from '@auth/user-manager';
 import { applyConditions } from '@conditions/condition-handler';
-import { defineDefaultSources } from '@content/content-store';
+import { defineDefaultSources, isContentPackageEmpty } from '@content/content-store';
 import { saveCustomization } from '@content/customization-cache';
 import { applyEquipmentPenalties } from '@items/inv-utils';
 import { useDebouncedCallback, useDebouncedValue, useDidUpdate, usePrevious } from '@mantine/hooks';
@@ -336,6 +336,11 @@ export default function useCharacter(
   // Update character in db when state changed
   useDidUpdate(() => {
     if (!debouncedCharacter) return;
+    // Defense-in-depth against the empty-corpus wipe (#235): if content failed to load,
+    // operations ran against nothing (HP/boosts/choices degrade to empty) — never persist
+    // that. The page-level guard should prevent mounting here at all, but the save site is
+    // where the damage happens, so we refuse the write directly too.
+    if (options.type === 'EXECUTE_OPS' && isContentPackageEmpty(options.data.content)) return;
     mutateCharacter({
       name: debouncedCharacter.name,
       level: debouncedCharacter.level,

--- a/supabase/functions/_tests/update-content-update.test.ts
+++ b/supabase/functions/_tests/update-content-update.test.ts
@@ -1,0 +1,123 @@
+// Covers the content-update approve flow — specifically the apply-then-approve
+// ordering: a request is only marked APPROVED if the underlying content write
+// actually succeeds. This is the regression guard for the reported
+// "shows approved but didn't apply" bug (the status used to be flipped to
+// APPROVED up front, before the content write, with no rollback on failure).
+
+import { assertEquals, assert } from 'https://deno.land/std@0.203.0/assert/mod.ts';
+import { admin, callFunction, seed, stackUnavailable, testUuid, withContentSource } from './seed.ts';
+
+// The function authenticates a shared secret against Deno.env.get('CONTENT_UPDATE_KEY');
+// the SAME value must be present in the edge runtime. Skip (don't fail) when it —
+// or the local stack — isn't configured, matching helpers.test.ts.
+const CONTENT_UPDATE_KEY = Deno.env.get('CONTENT_UPDATE_KEY') ?? '';
+const skip = stackUnavailable() || !CONTENT_UPDATE_KEY;
+
+async function seedContentUpdate(fields: Record<string, unknown>) {
+  const { data, error } = await admin
+    .from('content_update')
+    .insert({ upvotes: [], downvotes: [], status: { state: 'PENDING' }, ...fields })
+    .select()
+    .single();
+  if (error || !data) throw error ?? new Error('failed to seed content_update');
+  return data;
+}
+
+Deno.test({
+  name: 'update-content-update: APPROVE applies the change AND marks it approved',
+  ignore: skip,
+  async fn() {
+    const { userId } = await seed();
+    await withContentSource(userId, async (sourceId) => {
+      const { data: trait } = await admin
+        .from('trait')
+        .insert({ name: 'Before', description: 'old desc', content_source_id: sourceId, uuid: testUuid() })
+        .select()
+        .single();
+      assert(trait, 'seed trait');
+
+      const msgId = `test-cu-${crypto.randomUUID()}`;
+      const cu = await seedContentUpdate({
+        user_id: userId,
+        type: 'trait',
+        ref_id: trait.id,
+        content_source_id: sourceId,
+        action: 'UPDATE',
+        data: { name: 'After', description: 'new desc' },
+        discord_msg_id: msgId,
+      });
+
+      try {
+        await callFunction(
+          'update-content-update',
+          { discord_msg_id: msgId, discord_user_id: 'mod-1', discord_user_name: 'Mod One', state: 'APPROVE' },
+          { token: CONTENT_UPDATE_KEY }
+        );
+
+        // Assert on DB state (not HTTP status): the embeddings step calls an external
+        // vector-db that isn't available locally, but it runs AFTER the writes commit
+        // and cannot roll them back.
+        const { data: after } = await admin.from('trait').select('name').eq('id', trait.id).single();
+        assertEquals(after?.name, 'After', 'trait content should be updated');
+
+        const { data: cuAfter } = await admin.from('content_update').select('status').eq('id', cu.id).single();
+        assertEquals(cuAfter?.status?.state, 'APPROVED', 'request should be marked approved');
+      } finally {
+        await admin.from('content_update').delete().eq('id', cu.id);
+        await admin.from('trait').delete().eq('id', trait.id);
+      }
+    });
+  },
+});
+
+Deno.test({
+  name: 'update-content-update: a failed apply is NOT marked approved (apply-then-approve regression)',
+  ignore: skip,
+  async fn() {
+    const { userId } = await seed();
+    await withContentSource(userId, async (sourceId) => {
+      const { data: trait } = await admin
+        .from('trait')
+        .insert({ name: 'Unchanged', description: 'keep', content_source_id: sourceId, uuid: testUuid() })
+        .select()
+        .single();
+      assert(trait, 'seed trait');
+
+      const msgId = `test-cu-${crypto.randomUUID()}`;
+      // data.name = null violates trait.name's NOT NULL constraint, so the content
+      // write fails. Under the OLD ordering the request would already have been
+      // flipped to APPROVED before this point — the exact "approved but not applied" bug.
+      const cu = await seedContentUpdate({
+        user_id: userId,
+        type: 'trait',
+        ref_id: trait.id,
+        content_source_id: sourceId,
+        action: 'UPDATE',
+        data: { name: null },
+        discord_msg_id: msgId,
+      });
+
+      try {
+        const res = await callFunction(
+          'update-content-update',
+          { discord_msg_id: msgId, discord_user_id: 'mod-1', discord_user_name: 'Mod One', state: 'APPROVE' },
+          { token: CONTENT_UPDATE_KEY }
+        );
+
+        // The function must not report success when the apply failed...
+        assert(res.body?.status !== 'success', `expected non-success, got ${JSON.stringify(res.body)}`);
+
+        // ...the request must NOT be left approved (the core regression assertion)...
+        const { data: cuAfter } = await admin.from('content_update').select('status').eq('id', cu.id).single();
+        assert(cuAfter?.status?.state !== 'APPROVED', 'must not be approved when the apply failed');
+
+        // ...and the content must be untouched.
+        const { data: after } = await admin.from('trait').select('name').eq('id', trait.id).single();
+        assertEquals(after?.name, 'Unchanged', 'content must be unchanged on a failed apply');
+      } finally {
+        await admin.from('content_update').delete().eq('id', cu.id);
+        await admin.from('trait').delete().eq('id', trait.id);
+      }
+    });
+  },
+});

--- a/supabase/functions/update-content-update/index.ts
+++ b/supabase/functions/update-content-update/index.ts
@@ -47,43 +47,18 @@ serve(async (req: Request) => {
 
       let result: 'SUCCESS' | 'ERROR_DUPLICATE' | 'ERROR_UNKNOWN' = 'ERROR_UNKNOWN';
       if (state === 'APPROVE') {
-        const updateRes = await updateData(client, 'content_update', update.id, {
-          status: {
-            state: 'APPROVED',
-            discord_user_id: discord_user_id,
-            discord_user_name: discord_user_name,
-          },
-        });
-        result = updateRes.status;
-
-        // If the update was approved, apply the changes
+        // Apply the content change FIRST, and only mark the request APPROVED if it
+        // actually succeeds. Previously the status was flipped to APPROVED up front and
+        // the content write ran afterward with no rollback — so any failure (or a missing
+        // ref_id) left the request permanently "approved" on the site while the content
+        // never changed, and the error was swallowed by the Discord bot (the reported
+        // "shows approved but didn't apply" bug).
         const tableName = convertContentTypeToTableName(update.type);
         if (!tableName)
           return {
             status: 'error',
             message: 'Invalid content type',
           };
-
-        // If they've reached the threshold, update their tier
-        const contentUpdates: ContentUpdate[] = await fetchData<ContentUpdate>(
-          client,
-          'content_update',
-          [{ column: 'user_id', value: update.user_id }]
-        );
-        const approvedContent = contentUpdates.filter(
-          (update) => update.status.state === 'APPROVED'
-        );
-        if (approvedContent.length >= CONTENT_TIER_ACCESS_THRESHOLD) {
-          // Update the user's tier
-          const results = await fetchData<PublicUser>(client, 'public_user', [
-            { column: 'user_id', value: update.user_id },
-          ]);
-          if (results && results.length > 0 && !results[0].is_community_paragon) {
-            await updateData(client, 'public_user', results[0].id, {
-              is_community_paragon: true,
-            });
-          }
-        }
 
         let content_id = update.ref_id;
         if (update.action === 'UPDATE' && update.ref_id) {
@@ -137,10 +112,46 @@ serve(async (req: Request) => {
           };
         }
 
-        // Generate embeddings for the updated content
         console.log('content_id', content_id, 'result', result);
-        if (result === 'SUCCESS' && content_id) {
-          await populateCollection(client, 'name', update.type, [content_id]);
+
+        // Only now that the content change has actually committed do we mark the request
+        // APPROVED, refresh the contributor's tier, and (re)generate embeddings. If the
+        // apply failed, the request is deliberately left un-approved (so it is not shown
+        // as applied and can be retried) and we fall through to the error response below.
+        if (result === 'SUCCESS') {
+          await updateData(client, 'content_update', update.id, {
+            status: {
+              state: 'APPROVED',
+              discord_user_id: discord_user_id,
+              discord_user_name: discord_user_name,
+            },
+          });
+
+          // If they've reached the threshold, update their tier
+          const contentUpdates: ContentUpdate[] = await fetchData<ContentUpdate>(
+            client,
+            'content_update',
+            [{ column: 'user_id', value: update.user_id }]
+          );
+          const approvedContent = contentUpdates.filter(
+            (update) => update.status.state === 'APPROVED'
+          );
+          if (approvedContent.length >= CONTENT_TIER_ACCESS_THRESHOLD) {
+            // Update the user's tier
+            const results = await fetchData<PublicUser>(client, 'public_user', [
+              { column: 'user_id', value: update.user_id },
+            ]);
+            if (results && results.length > 0 && !results[0].is_community_paragon) {
+              await updateData(client, 'public_user', results[0].id, {
+                is_community_paragon: true,
+              });
+            }
+          }
+
+          // Generate embeddings for the updated content
+          if (content_id) {
+            await populateCollection(client, 'name', update.type, [content_id]);
+          }
         }
       } else if (state === 'REJECT') {
         const updateRes = await updateData(client, 'content_update', update.id, {


### PR DESCRIPTION
Three reliability fixes surfaced by an audit of community bug reports + open issues. Each is an independent commit and can be reviewed on its own.

## 1. Builder Error-500 crashes on selection — `f4b4d75a`
Selecting certain class attributes / heritages / feats crashed the builder to the "Error 500" page — an uncaught `undefined.localeCompare(...)` in content sort comparators (the record's `name`/`type` was missing). Null-guarded every comparator on the selection / content-resolution paths with `(x ?? '')`, plus the `.name.trim()` derefs in the dual-class merge. Pure defensive fallbacks; ordering is unchanged when the field is present.

Addresses #246, #247, #248, #249, #237, #233.

## 2. Sheet/builder data-loss + infinite spinner on failed loads — `d22b307a`
A failed content load resolves to a truthy-but-**empty** package, so the sheet mounted on an empty corpus, operations degraded the character, and the auto-save persisted the wipe (#235). Now:
- `isContentPackageEmpty()` detects a failed load (core arrays all empty — the global corpus is never legitimately empty),
- the sheet/builder render a **retry screen** instead of mounting,
- the auto-save refuses to persist against an empty corpus (defense-in-depth),
- load-time sorts are guarded so a bad record can't reject the query into an infinite spinner.

Addresses #235. (The slow loads themselves are a serving-layer/edge concern, separate.)

## 3. Content-update "approved but didn't apply" — `770008b5`
`update-content-update` marked a request `APPROVED` **before** applying the content write, non-atomically — so a failed apply left it permanently "approved" with nothing changed (and the Discord bot swallowed the error). Reordered to **apply-then-approve**: only mark approved when the write succeeds; otherwise leave it un-approved + retryable and return an error. Adds `update-content-update.test.ts`.

## Verification
- **Frontend (1, 2):** `tsc --noEmit` + `eslint` clean on all changed files (0 errors; pre-existing warnings unrelated).
- **Edge function (3):** `deno lint` + `deno check` clean; the new integration test passes **and was confirmed to fail on the pre-fix ordering** (red-green, against a local Supabase stack).

## Not in this PR (follow-ups)
- The durable root cause behind (1): `validateAndWarn` accepting invalid content records (`content-store.ts`).
- `content-updates-bot` (separate repo/deploy): surface the edge function's error instead of swallowing the ✅, and add the `GuildMembers` intent so mod approvals aren't silently dropped.
- Frontend has no test runner; adding vitest would give (1)/(2) unit coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
