### PR TITLE
fix: Spells-tab crash, null-name crashes, and 3 save-loss paths (audit)

### DIFF
--- a/frontend/src/common/TokenSelect.tsx
+++ b/frontend/src/common/TokenSelect.tsx
@@ -14,7 +14,11 @@ export default function TokenSelect(props: {
   size?: MantineSize;
   invertedSelect?: boolean;
 }) {
-  const [value, setValue] = useState(props.value ?? props.count);
+  // Sanitize count: focus/slot math can yield a negative or NaN count (e.g. a reduced
+  // focus max), which makes Array.from({length}) and Mantine's <Rating count> throw a
+  // RangeError that blanks the whole Spells tab (#234). Clamp to a safe non-negative int.
+  const count = Number.isFinite(props.count) ? Math.max(0, Math.trunc(props.count)) : 0;
+  const [value, setValue] = useState(props.value ?? count);
   const isMobileTouch = useMediaQuery(tabletQuery()) && isTouchDevice();
 
   return (
@@ -24,12 +28,12 @@ export default function TokenSelect(props: {
           <NativeSelect
             size='xs'
             w={60}
-            data={Array.from({ length: props.count + 1 }, (_, i) => i).map((v) => `${v}`)}
-            value={`${props.invertedSelect ? props.count - value : value}`}
+            data={Array.from({ length: count + 1 }, (_, i) => i).map((v) => `${v}`)}
+            value={`${props.invertedSelect ? count - value : value}`}
             onChange={(e) => {
               let val = parseInt(e.target.value ?? '');
               // Invert the value if needed
-              val = props.invertedSelect ? props.count - val : val;
+              val = props.invertedSelect ? count - val : val;
 
               setValue(val);
               props.onChange?.(val);
@@ -45,7 +49,7 @@ export default function TokenSelect(props: {
         </>
       ) : (
         <Rating
-          count={props.count}
+          count={count}
           size={props.size}
           emptySymbol={props.emptySymbol}
           fullSymbol={props.fullSymbol}

--- a/frontend/src/pages/character_sheet/panels/DetailsPanel.tsx
+++ b/frontend/src/pages/character_sheet/panels/DetailsPanel.tsx
@@ -45,7 +45,7 @@ import { useDebouncedState, useDebouncedValue, useDidUpdate } from '@mantine/hoo
 import { makeRequest } from '@requests/request-manager';
 import { useMutation } from '@tanstack/react-query';
 import { JSendResponse } from '@schemas/requests';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { getCachedPublicUser, getPublicUser } from '@auth/user-manager';
 import { CreateSocietyAdventureEntryModal } from '@modals/CreateSocietyAdventureEntryModal';
 import { Money, getGpGained } from '@utils/money';
@@ -88,7 +88,25 @@ export default function DetailsPanel(props: { content: ContentPackage; panelHeig
   const armorProfs = getAllArmorVariables('CHARACTER').filter((prof) => compileProficiencyType(prof.value) !== 'U');
 
   const characterInfo = character?.details?.info;
-  const [debouncedInfo, setDebouncedInfo] = useDebouncedState<typeof characterInfo | null>(null, 200);
+  const [debouncedInfo, setDebouncedInfoRaw] = useDebouncedState<typeof characterInfo | null>(null, 200);
+  // Accumulate field edits so rapid edits across different fields don't clobber each other.
+  // Each onChange passes {...character.details?.info, field: value} — a snapshot that is stale
+  // during the debounce window, so a single shared debounced slot dropped the earlier field
+  // (#10). Diff each call against the committed info to extract only the changed field(s) and
+  // merge them into a live accumulator, then debounce that.
+  const infoAccumRef = useRef<Record<string, any>>((characterInfo ?? {}) as Record<string, any>);
+  useDidUpdate(() => {
+    infoAccumRef.current = (characterInfo ?? {}) as Record<string, any>;
+  }, [characterInfo]);
+  const setDebouncedInfo = (next: NonNullable<typeof characterInfo>) => {
+    const base = (characterInfo ?? {}) as Record<string, any>;
+    const merged: Record<string, any> = { ...infoAccumRef.current };
+    for (const k in next as Record<string, any>) {
+      if ((next as Record<string, any>)[k] !== base[k]) merged[k] = (next as Record<string, any>)[k];
+    }
+    infoAccumRef.current = merged;
+    setDebouncedInfoRaw(merged as typeof characterInfo);
+  };
   useDidUpdate(() => {
     // Saving details
     if (!character || !debouncedInfo) return;

--- a/frontend/src/pages/character_sheet/panels/NotesPanel.tsx
+++ b/frontend/src/pages/character_sheet/panels/NotesPanel.tsx
@@ -13,7 +13,7 @@ import { isPhoneSized } from '@utils/mobile-responsive';
 import { isCharacter } from '@utils/type-fixing';
 import useRefresh from '@utils/use-refresh';
 import { cloneDeep, truncate } from 'lodash-es';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { SetterOrUpdater } from '@utils/type-fixing';
 
 export default function NotesPanel(props: {
@@ -28,16 +28,20 @@ export default function NotesPanel(props: {
   const isInCampaign = isCharacter(props.entity) && !!props.entity?.campaign_id;
   const [displayNotes, refreshNotes] = useRefresh();
 
-  const [debouncedJson, setDebouncedJson] = useDebouncedState<{
-    index: number;
-    json: JSONContent;
-  } | null>(null, 500);
+  // Accumulate pending edits per page index and flush them together. A single debounced
+  // {index, json} slot lost the previous page's pending edit when you switched pages within
+  // the debounce window (#9) — the new page's write overwrote the pending one.
+  const pendingPagesRef = useRef<Map<number, JSONContent>>(new Map());
+  const [flushSignal, setFlushSignal] = useDebouncedState(0, 500);
 
   useDidUpdate(() => {
-    // Saving notes
-    if (!props.entity || !debouncedJson) return;
+    // Saving notes — flush every page with a pending edit, not just the most recent.
+    if (!props.entity || pendingPagesRef.current.size === 0) return;
     const newPages = cloneDeep(pages);
-    newPages[debouncedJson.index].contents = debouncedJson.json;
+    for (const [index, json] of pendingPagesRef.current) {
+      if (newPages[index]) newPages[index].contents = json;
+    }
+    pendingPagesRef.current.clear();
     props.setEntity({
       ...props.entity,
       notes: {
@@ -45,7 +49,7 @@ export default function NotesPanel(props: {
         pages: newPages,
       },
     });
-  }, [debouncedJson]);
+  }, [flushSignal]);
 
   useEffect(() => {
     refreshNotes();
@@ -84,7 +88,8 @@ export default function NotesPanel(props: {
           placeholder='Your notes...'
           value={page.contents}
           onChange={(text, json) => {
-            setDebouncedJson({ index: index, json: json });
+            pendingPagesRef.current.set(index, json);
+            setFlushSignal(Date.now());
           }}
           height={props.panelHeight}
           hasColorOptions={true}

--- a/frontend/src/pages/character_sheet/panels/spells_list/FocusSpellsList.tsx
+++ b/frontend/src/pages/character_sheet/panels/spells_list/FocusSpellsList.tsx
@@ -23,7 +23,6 @@ import { StatButton } from '@pages/character_builder/CharBuilderCreation';
 import { drawerState } from '@atoms/navAtoms';
 import { useMemo } from 'react';
 import { StoreID } from '@schemas/variables';
-import { isTruthy } from '@utils/type-fixing';
 import { uniq } from 'lodash-es';
 import { useMediaQuery } from '@mantine/hooks';
 import { phoneQuery } from '@utils/mobile-responsive';
@@ -64,12 +63,15 @@ export default function FocusSpellsList(props: {
   const [_drawer, openDrawer] = useAtom(drawerState);
 
   // Finds all the character's focus spells, regardless of source
+  // Count focus points from the character's ACTUAL focus spells (source-filtered), NOT
+  // resolved through props.allSpells — that array is search/action-filtered, so searching
+  // would shrink the focus-point max (#30). getFocusPoints only reads `rank`, which the
+  // focus entries already carry.
   const allFocusSpells = useMemo(() => {
-    return props.extra.charData.focus
-      .filter((f) => props.extra.charData.sources.map((s) => s.name).includes(f.source))
-      .map((f) => props.allSpells.find((s) => s.id === f.spell_id))
-      .filter(isTruthy);
-  }, [props.extra.charData, props.allSpells]);
+    return props.extra.charData.focus.filter((f) =>
+      props.extra.charData.sources.map((s) => s.name).includes(f.source)
+    );
+  }, [props.extra.charData]);
 
   // If there are no spells to display, and there are filters, return null
   if (props.hasFilters && spells && !Object.keys(spells).find((rank) => spells[rank].length > 0)) {

--- a/frontend/src/process/content/collect-content.ts
+++ b/frontend/src/process/content/collect-content.ts
@@ -244,9 +244,13 @@ export function getFocusPoints(id: StoreID, entity: LivingEntity, focusSpells: R
   const fromSpells = focusSpells.filter((f) => f?.rank !== 0).length ?? 0;
   const extra = getVariable<VariableNum>(id, 'FOCUS_POINT_BONUS')?.value ?? 0;
 
-  const maxFocusPoints = Math.min(fromSpells + extra, 3);
+  // Clamp: FOCUS_POINT_BONUS can be negative, and a retrain can leave a stored current
+  // above a reduced max — both would push a negative/NaN into the focus-point token
+  // control (RangeError, #234) or render a negative "expended" count (#31).
+  const maxFocusPoints = Math.max(0, Math.min(fromSpells + extra, 3));
+  const storedCurrent = entity.spells?.focus_point_current ?? maxFocusPoints;
   return {
-    current: entity.spells?.focus_point_current ?? maxFocusPoints,
+    current: Math.min(Math.max(storedCurrent, 0), maxFocusPoints),
     max: maxFocusPoints,
   };
 }

--- a/frontend/src/process/content/content-store.ts
+++ b/frontend/src/process/content/content-store.ts
@@ -754,5 +754,9 @@ function validateAndWarn<T>(type: ContentType, schema: z.ZodTypeAny, record: unk
       `[CONTENT-SCHEMA] ${type} id=${(record as any)?.id ?? '?'} "${(record as any)?.name ?? ''}" — ${summary}`
     );
   }
-  return parsed.success ? (parsed.data as T) : (record as T);
+  // On schema failure we keep the record (so we never silently hide content), but we
+  // guarantee a string `name` so downstream sorts and content-link resolution can never
+  // deref null — this retires the whole class of null-name .localeCompare / .toLowerCase
+  // crashes at the cache boundary instead of guarding each render site.
+  return parsed.success ? (parsed.data as T) : ({ ...(record as any), name: (record as any)?.name ?? '' } as T);
 }

--- a/frontend/src/utils/use-character.tsx
+++ b/frontend/src/utils/use-character.tsx
@@ -171,12 +171,17 @@ export default function useCharacter(
       const pending = localStorage.getItem(key);
       if (pending) {
         const { token, body } = JSON.parse(pending);
-        await fetch(`${import.meta.env.VITE_SUPABASE_URL}/functions/v1/update-character`, {
+        const replayRes = await fetch(`${import.meta.env.VITE_SUPABASE_URL}/functions/v1/update-character`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
           body: JSON.stringify(body),
         });
-        localStorage.removeItem(key);
+        // Only drop the buffered edit once the server has actually accepted it. If the
+        // replay fails (expired token -> 401, offline, 5xx) keep it so it retries on the
+        // next mount instead of silently discarding the user's only unsynced copy.
+        if (replayRes.ok) {
+          localStorage.removeItem(key);
+        }
       }
 
       // Now fetch the character from the database to ensure we have the latest version


### PR DESCRIPTION
Frontend fixes from the deep audit. Independent of #253 (touches different regions of the shared files — no conflict when both merge). Three focused commits.

## 1. Spells-tab `RangeError` (#234) — `8674773d`
A negative/non-integer focus-point count reached the token control (`Array.from({length})` / Mantine `<Rating count>`) → "RangeError: Invalid array length", blanking the whole Spells tab.
- `TokenSelect`: clamp count to a non-negative integer.
- `getFocusPoints`: clamp max ≥ 0 and stored current into `[0, max]` (#31).
- `FocusSpellsList`: count focus points from the character's actual focus spells, not the search/action-filtered `allSpells` — searching had shrunk the focus-point max (#30).

Resolves #234.

## 2. Null-name crashes, fixed at the source — `4a5ad2fd`
`validateAndWarn` returned schema-fail records unchanged, so a null-`name` record entered the content store and later crashed any `.name` deref (content-link `.toLowerCase`, sort `.localeCompare`), hard-crashing descriptions that reference it. Now coerces a string `name` at the cache boundary — retiring the whole crash class instead of guarding each render site.

## 3. Three silent save-loss paths — `0048eea9`
- **Offline replay**: only drop the buffered edit on a 2xx response. It was removed unconditionally, so a failed replay (expired token → 401, offline) silently discarded the user's only unsynced copy.
- **Notes**: accumulate edits per page and flush together — switching pages within the debounce window no longer drops the previous page's edit.
- **Details**: diff each field edit and merge into a live accumulator — rapid cross-field edits no longer clobber each other via the shared stale snapshot.

## Verification
`tsc --noEmit` + `eslint` clean on all 7 files (0 errors; the 4 pre-existing tsc errors are an unrelated prosemirror dep-dup in a file this PR doesn't touch).

## Follow-up (not in this PR)
The **cross-device** offline-replay clobber needs the buffered edit to carry a base `updated_at` so replay can go through the optimistic-concurrency merge — a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
