### PR TITLE
fix(security): find-character campaign IDOR + content-update service-role writes (audit)

### DIFF
--- a/supabase/functions/find-character/index.ts
+++ b/supabase/functions/find-character/index.ts
@@ -2,7 +2,6 @@
 import { serve } from 'std/server';
 import type { Character } from '../_shared/content';
 import { connect, fetchData } from '../_shared/helpers.ts';
-import { createClient } from '@supabase/supabase-js';
 
 serve(async (req: Request) => {
   return await connect<{
@@ -14,26 +13,18 @@ serve(async (req: Request) => {
     async (client, body) => {
       let { id, user_id, campaign_id } = body;
 
-      let results = await fetchData<Character>(client, 'character', [
+      // Campaign visibility is enforced by RLS: the character SELECT policy already lets a
+      // campaign's GM (campaign.user_id = auth.uid()) see every character in it. We deliberately
+      // do NOT escalate to a service-role fetch of the whole campaign here. The previous
+      // `results.length > 0` gate was an IDOR — any authenticated user could set their own
+      // character's campaign_id to a victim campaign (self-update is allowed by the UPDATE
+      // policy) and then read every character in it. Letting non-GM players see each other
+      // needs a real membership model; until then we return only RLS-scoped results.
+      const results = await fetchData<Character>(client, 'character', [
         { column: 'id', value: id },
         { column: 'user_id', value: user_id },
         { column: 'campaign_id', value: campaign_id },
       ]);
-
-      // If we're using only campaign_id and we found at least one character, then return all campaign's characters
-      // This is so a member of the campaign can see all other player characters
-      if (!id && !user_id && campaign_id && results.length > 0) {
-        // Use unrestricted client access because we need to fetch all campaign characters
-        const unrestrictedClient = createClient(
-          // @ts-ignore
-          Deno.env.get('SUPABASE_URL') ?? '',
-          // @ts-ignore
-          Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
-        );
-        results = await fetchData<Character>(unrestrictedClient, 'character', [
-          { column: 'campaign_id', value: campaign_id },
-        ]);
-      }
 
       if (id && !Array.isArray(id)) {
         return {

--- a/supabase/functions/update-content-update/index.ts
+++ b/supabase/functions/update-content-update/index.ts
@@ -11,6 +11,7 @@ import {
 } from '../_shared/helpers.ts';
 import type { ContentUpdate, PublicUser } from '../_shared/content';
 import { populateCollection } from '../_shared/vector-db.ts';
+import { createClient } from '@supabase/supabase-js';
 
 const CONTENT_TIER_ACCESS_THRESHOLD = 100;
 
@@ -32,6 +33,16 @@ serve(async (req: Request) => {
           data: { message: 'Invalid auth token' },
         };
       }
+
+      // This is a validated service-to-service webhook (bypassAuth). Its writes are admin
+      // operations that must bypass RLS: content_update and the content tables have write
+      // policies scoped TO authenticated, but the connect() client here is anon — so
+      // RLS-scoped writes would match 0 rows and (because updateData treats a 0-row write as
+      // SUCCESS) silently no-op while reporting success. That is how "approved but didn't
+      // apply" could recur even after the apply-then-approve reorder. Use a service-role
+      // client for the actual reads/writes.
+      // @ts-ignore
+      client = createClient(Deno.env.get('SUPABASE_URL') ?? '', Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '');
 
       let results: ContentUpdate[] = await fetchData<ContentUpdate>(client, 'content_update', [
         { column: 'discord_msg_id', value: discord_msg_id },


### PR DESCRIPTION
Two backend security/correctness fixes from the deep audit. Independent of #253 (different files/regions — no conflict).

## 1. `find-character` campaign IDOR — `34ca18eb`  🔴
`find-character` escalated to a **SERVICE_ROLE** fetch of every character in a campaign, gated only by `results.length > 0` from the RLS-scoped query. Any authenticated user can satisfy that gate: the character UPDATE policy lets you edit your own character, so an attacker sets their own char's `campaign_id` to a victim campaign, then `find-character {campaign_id: V}` returns **every player's full character** (notes, inventory, spells, roll history).

**Fix:** remove the escalation and rely on RLS. The character SELECT policy already lets a campaign's **GM** (`campaign.user_id = auth.uid()`) see every character in it — so GM party views are unchanged. Non-GM "see other players' characters" was only possible via the insecure escalation; restoring it needs a real campaign-membership model.

## 2. `update-content-update` service-role writes — `51047ed9`
The webhook runs via `connect(bypassAuth)`, whose DB client is the **anon** role. `content_update` and the content tables have write policies `TO authenticated`, so those writes match **0 rows** — and since `updateData` reports a 0-row write as `SUCCESS`, a request could be marked `APPROVED` while the content write silently no-ops (the "approved but didn't apply" symptom, recurring even past #253). Now uses an explicit **service-role** client. Complementary to #253's apply-then-approve reorder (different region; they combine cleanly).

## Verification
- `deno check` clean on both — **0 new type errors** vs baseline (find-character 12=12, update-content-update 21=21; the rest are the repo's pre-existing edge-fn type-check noise).
- Behavioral: the content-update path was red-green tested against a local stack earlier; #2 makes the function self-provide the service-role context that test relied on. Happy to run the `_tests/` harness against the local stack on request.

## Deliberately NOT in this PR (flagged for follow-up)
- **`find-content-source` `keys.access_key` leak (audit #20):** lower-impact than it looks — the content tables are `SELECT USING (true)`, so homebrew content is *already world-readable* and the key only gates a **client-side** unlock modal. A real fix means server-side content protection + server-side unlock (a feature change), not a redaction (which would break unlocking).
- **The 0-row = SUCCESS behavior in `updateData`/`deleteData`** (audit #5, root): a broader latent issue across ~18 write functions. Making it return failure on 0 rows needs a per-function RLS review + tests (some functions can update-but-not-select under RLS), so it's a dedicated pass, not a drive-by.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
