### PR TITLE
fix(save): stop infinite "Merged a remote update" loop for read-only viewers

### DIFF
--- a/docs/api-reference/openapi.json
+++ b/docs/api-reference/openapi.json
@@ -1921,7 +1921,7 @@
       "post": {
         "tags": ["Characters"],
         "summary": "Update an existing character",
-        "description": "Same body shape as `create-character` but `id` is required. Forbidden keys (`id`, `created_at`, `content_source_id`, `user_id`) are stripped server-side.",
+        "description": "Same body shape as `create-character` but `id` is required. Forbidden keys (`id`, `created_at`, `content_source_id`, `user_id`) are stripped server-side.\n\n**Optimistic concurrency:** pass `expected_updated_at` (the `updated_at` value from your last read of the character) to make the write conditional. If the row changed since, the write is NOT applied and the response data is `{ \"__conflict\": true, \"character\": <current row> }` so you can merge and retry with the fresh `updated_at`. If your session can read but not write the character (e.g. viewing someone else's public character), the response data is `{ \"__forbidden\": true, \"reason\": \"WRITE_DENIED\" | \"NOT_VISIBLE\" }` — stop retrying; the write will never be accepted. Omitting `expected_updated_at` keeps the legacy unconditional write behavior.",
         "operationId": "updateCharacter",
         "requestBody": {
           "required": true,
@@ -1930,7 +1930,17 @@
               "schema": {
                 "allOf": [
                   { "$ref": "#/components/schemas/Character" },
-                  { "type": "object", "required": ["id"] }
+                  {
+                    "type": "object",
+                    "required": ["id"],
+                    "properties": {
+                      "expected_updated_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Optimistic-concurrency token: the character's `updated_at` from your last read. When provided, the update only applies if the row is unchanged."
+                      }
+                    }
+                  }
                 ]
               }
             }
@@ -1938,7 +1948,7 @@
         },
         "responses": {
           "200": {
-            "description": "JSend success.",
+            "description": "JSend success. With `expected_updated_at`, `data` may instead be a conflict object (`__conflict` + current `character`) or a forbidden object (`__forbidden` + `reason`).",
             "content": {
               "application/json": { "schema": { "$ref": "#/components/schemas/JSendBoolean" } }
             }

--- a/frontend/src/utils/use-character.tsx
+++ b/frontend/src/utils/use-character.tsx
@@ -124,6 +124,20 @@ export default function useCharacter(
   }, [character]);
   const lastSyncedRef = useRef<Character | null>(null);
 
+  // Latched when the server reports this session can read but not write the
+  // character (RLS: e.g. anyone viewing a public sheet, incl. logged-out users).
+  // Disables the auto-save pipeline — such a viewer's "saves" were previously
+  // misreported as concurrency conflicts, and the conflict handler's own state
+  // update re-triggered the save, producing an infinite merge-notification loop.
+  const readOnlyRef = useRef(false);
+  // Consecutive conflicts with no successful save in between. A genuine
+  // concurrent-edit conflict resolves in one round (merge → save with the fresh
+  // token → success), so a streak means the server keeps rejecting us — e.g. an
+  // older deployment that can't distinguish an RLS-denied write from a real
+  // conflict. Stop the merge-and-retry cycle instead of looping forever.
+  const conflictStreakRef = useRef(0);
+  const MAX_CONFLICT_STREAK = 3;
+
   const handleFetchedCharacter = (resultCharacter: Character | null | undefined) => {
     if (resultCharacter) {
       // This is authoritative server state — record it as the concurrency base even
@@ -341,6 +355,8 @@ export default function useCharacter(
   // Update character in db when state changed
   useDidUpdate(() => {
     if (!debouncedCharacter) return;
+    // View-only session — the server told us our writes are RLS-denied.
+    if (readOnlyRef.current) return;
     // Defense-in-depth against the empty-corpus wipe (#235): if content failed to load,
     // operations ran against nothing (HP/boosts/choices degrade to empty) — never persist
     // that. The page-level guard should prevent mounting here at all, but the save site is
@@ -381,22 +397,57 @@ export default function useCharacter(
         ...data,
         ...(expected_updated_at ? { expected_updated_at } : {}),
       });
+      // Forbidden: RLS lets this session read the character but not write it.
+      if (resData && !isArray(resData) && (resData as any).__forbidden) {
+        return { forbidden: true, conflict: false, server: null as Character | null };
+      }
       // Conflict: the server returned the current row instead of overwriting.
       if (resData && !isArray(resData) && (resData as any).__conflict) {
-        return { conflict: true, server: ((resData as any).character ?? null) as Character | null };
+        return {
+          forbidden: false,
+          conflict: true,
+          server: ((resData as any).character ?? null) as Character | null,
+        };
       }
       const row = isArray(resData) && resData.length > 0 ? (resData[0] as Character) : null;
-      return { conflict: false, server: row };
+      return { forbidden: false, conflict: false, server: row };
     },
     onSuccess: (result) => {
       if (!result) return;
+      if (result.forbidden) {
+        // View-only session (e.g. a public sheet). Stop auto-saving entirely —
+        // nothing we send will ever be accepted, and retrying just spams the API.
+        readOnlyRef.current = true;
+        pendingSaveRef.current = null;
+        console.warn('Character is view-only for this session; auto-save disabled.');
+        return;
+      }
       if (result.conflict) {
         const remote = result.server;
         if (!remote) return;
         // Drop any stale queued snapshot — the merge produces the correct next save.
         pendingSaveRef.current = null;
-        const merged = mergeCharacterOnConflict(lastSyncedRef.current, characterRef.current, remote);
+        // The three-way merge needs the PREVIOUS synced state as its base; adopt the
+        // fresh concurrency token only after capturing it (and even when we skip
+        // merging below, so the next save uses the current token).
+        const base = lastSyncedRef.current;
         lastSyncedRef.current = remote;
+        conflictStreakRef.current += 1;
+        if (conflictStreakRef.current >= MAX_CONFLICT_STREAK) {
+          // Merging again would only re-trigger another save → conflict round.
+          console.warn('Repeated save conflicts; pausing merge-and-retry until a save succeeds.');
+          return;
+        }
+        const merged = mergeCharacterOnConflict(base, characterRef.current, remote);
+        // Only apply + notify when the merge actually changes local data. Equal on
+        // every saved field means the server row already matches what we have
+        // (pure token skew) — updating state anyway would fire a pointless save.
+        const changed =
+          !characterRef.current ||
+          SAVED_CHARACTER_FIELDS.some(
+            (field) => !isEqual((merged as any)[field], (characterRef.current as any)[field])
+          );
+        if (!changed) return;
         setCharacter(merged);
         showNotification({
           icon: <IconRefresh />,
@@ -406,6 +457,7 @@ export default function useCharacter(
         });
       } else if (result.server) {
         // Record the authoritative post-write state (incl. the new updated_at token).
+        conflictStreakRef.current = 0;
         lastSyncedRef.current = result.server;
         console.log('> Fetched updated character: #', getUpdateHash(character), 'vs.', getUpdateHash(result.server));
       }
@@ -432,6 +484,7 @@ export default function useCharacter(
   });
 
   const mutateCharacter = (data: Record<string, any>) => {
+    if (readOnlyRef.current) return;
     if (savingRef.current) {
       // A save is already in flight — keep only the newest snapshot to send next.
       pendingSaveRef.current = data;

--- a/supabase/functions/_shared/helpers.ts
+++ b/supabase/functions/_shared/helpers.ts
@@ -852,8 +852,11 @@ export async function updateData(
     }
   }
 
-  // Guarded update that matched no rows = the row changed since the caller's snapshot.
-  // (Distinguishing this from a non-existent / RLS-hidden row is left to the caller.)
+  // Guarded update that matched no rows. CALLERS MUST DISAMBIGUATE: this is either a
+  // real concurrency conflict (the guard column changed) OR a row the caller cannot
+  // UPDATE under RLS / cannot see at all. Re-read the row with the same client and
+  // compare the guard column — see update-character for the reference implementation.
+  // Treating an RLS-denied write as a conflict makes read-only clients retry forever.
   if (options?.guard && Array.isArray(dataResult) && dataResult.length === 0) {
     return { status: 'CONFLICT', data: null };
   }

--- a/supabase/functions/_tests/seed.ts
+++ b/supabase/functions/_tests/seed.ts
@@ -17,7 +17,7 @@ const SUPABASE_URL =
 const SERVICE_ROLE_KEY =
   Deno.env.get('SERVICE_ROLE_KEY') ?? Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '';
 
-const ANON_KEY =
+export const ANON_KEY =
   Deno.env.get('PUBLIC_ANON_KEY') ??
   Deno.env.get('ANON_KEY') ??
   Deno.env.get('SUPABASE_ANON_KEY') ??

--- a/supabase/functions/_tests/update-character.test.ts
+++ b/supabase/functions/_tests/update-character.test.ts
@@ -1,9 +1,35 @@
-// Covers the update-* pattern, plus verifying that forbidden keys are stripped.
+// Covers the update-* pattern, plus verifying that forbidden keys are stripped,
+// plus the optimistic-concurrency guard (expected_updated_at): success, genuine
+// conflict, and the RLS-denied cases that must NOT be reported as conflicts
+// (a misreport makes read-only viewers merge-and-retry in an infinite loop).
 
 import { assertEquals, assert } from 'https://deno.land/std@0.203.0/assert/mod.ts';
-import { admin, callFunction, seed, stackUnavailable } from './seed.ts';
+import { ANON_KEY, admin, callFunction, seed, stackUnavailable } from './seed.ts';
 
 const skip = stackUnavailable();
+
+/** Create (or reuse) a second authenticated user — a NON-owner for RLS tests. */
+async function ensureSecondUser(): Promise<{ jwt: string }> {
+  const email = 'test-second@wanderersguide.app';
+  const password = 'test1234';
+  const { error: createError } = await admin.auth.admin.createUser({
+    email,
+    password,
+    email_confirm: true,
+  });
+  if (createError && !/already|exists|registered/i.test(createError.message)) {
+    throw createError;
+  }
+  const { createClient } = await import('https://esm.sh/@supabase/supabase-js@2.7.1');
+  const anon = createClient(
+    Deno.env.get('PUBLIC_SUPABASE_URL') ?? Deno.env.get('SUPABASE_URL') ?? 'http://127.0.0.1:54321',
+    ANON_KEY,
+    { auth: { persistSession: false, autoRefreshToken: false } }
+  );
+  const { data, error } = await anon.auth.signInWithPassword({ email, password });
+  if (error || !data?.session) throw error ?? new Error('second user sign-in failed');
+  return { jwt: data.session.access_token };
+}
 
 Deno.test({
   name: 'update-character: changes name and persists',
@@ -70,6 +96,166 @@ Deno.test({
       assertEquals(refreshed?.id, char.id);
       assertEquals(refreshed?.name, 'Updated');
       assertEquals(refreshed?.created_at, originalCreated);
+    } finally {
+      await admin.from('character').delete().eq('id', char.id);
+    }
+  },
+});
+
+Deno.test({
+  name: 'update-character: guarded write with a fresh token succeeds and bumps updated_at',
+  ignore: skip,
+  async fn() {
+    const { userId, jwt } = await seed();
+    const { data: char } = await admin
+      .from('character')
+      .insert({ name: 'Guarded', user_id: userId, level: 1, experience: 0 })
+      .select()
+      .single();
+    assert(char);
+    assert(char.updated_at, 'updated_at column must exist (migration applied)');
+
+    try {
+      const result = await callFunction(
+        'update-character',
+        { id: char.id, name: 'Guarded v2', expected_updated_at: char.updated_at },
+        { token: jwt }
+      );
+      assertEquals(result.status, 200);
+      assertEquals(result.body?.status, 'success');
+      const rows = result.body?.data;
+      assert(Array.isArray(rows) && rows.length === 1, 'guarded success returns the row');
+      assertEquals(rows[0].name, 'Guarded v2');
+      assert(rows[0].updated_at !== char.updated_at, 'trigger must bump updated_at');
+    } finally {
+      await admin.from('character').delete().eq('id', char.id);
+    }
+  },
+});
+
+Deno.test({
+  name: 'update-character: stale token returns __conflict with the current row (no overwrite)',
+  ignore: skip,
+  async fn() {
+    const { userId, jwt } = await seed();
+    const { data: char } = await admin
+      .from('character')
+      .insert({ name: 'Conflicted', user_id: userId, level: 1, experience: 0 })
+      .select()
+      .single();
+    assert(char);
+
+    try {
+      // A concurrent writer bumps the row after our snapshot.
+      const { data: bumped } = await admin
+        .from('character')
+        .update({ name: 'Concurrent Write' })
+        .eq('id', char.id)
+        .select()
+        .single();
+      assert(bumped && bumped.updated_at !== char.updated_at);
+
+      const result = await callFunction(
+        'update-character',
+        { id: char.id, name: 'Stale Write', expected_updated_at: char.updated_at },
+        { token: jwt }
+      );
+      assertEquals(result.status, 200);
+      assertEquals(result.body?.status, 'success');
+      assertEquals(result.body?.data?.__conflict, true);
+      assertEquals(result.body?.data?.character?.name, 'Concurrent Write');
+      assertEquals(result.body?.data?.character?.updated_at, bumped.updated_at);
+
+      // The stale write must NOT have been applied.
+      const { data: after } = await admin
+        .from('character')
+        .select('name')
+        .eq('id', char.id)
+        .single();
+      assertEquals(after?.name, 'Concurrent Write');
+    } finally {
+      await admin.from('character').delete().eq('id', char.id);
+    }
+  },
+});
+
+Deno.test({
+  name: 'update-character: read-only viewer of a public character gets __forbidden, not __conflict',
+  ignore: skip,
+  async fn() {
+    const { userId } = await seed();
+    const { data: char } = await admin
+      .from('character')
+      .insert({
+        name: 'Public Char',
+        user_id: userId,
+        level: 1,
+        experience: 0,
+        options: { is_public: true },
+      })
+      .select()
+      .single();
+    assert(char);
+
+    try {
+      // Anonymous viewer (browser sends the anon key as the bearer token).
+      const anonResult = await callFunction(
+        'update-character',
+        { id: char.id, name: 'Anon Write', expected_updated_at: char.updated_at },
+        { token: ANON_KEY }
+      );
+      assertEquals(anonResult.status, 200);
+      assertEquals(anonResult.body?.status, 'success');
+      assertEquals(anonResult.body?.data?.__forbidden, true, 'anon viewer must get __forbidden');
+      assertEquals(anonResult.body?.data?.__conflict, undefined);
+
+      // Authenticated NON-owner viewer.
+      const { jwt: otherJwt } = await ensureSecondUser();
+      const otherResult = await callFunction(
+        'update-character',
+        { id: char.id, name: 'Other Write', expected_updated_at: char.updated_at },
+        { token: otherJwt }
+      );
+      assertEquals(otherResult.status, 200);
+      assertEquals(otherResult.body?.data?.__forbidden, true, 'non-owner must get __forbidden');
+
+      // Neither write applied; token untouched (RLS denial must not bump the row).
+      const { data: after } = await admin
+        .from('character')
+        .select('name, updated_at')
+        .eq('id', char.id)
+        .single();
+      assertEquals(after?.name, 'Public Char');
+      assertEquals(after?.updated_at, char.updated_at);
+    } finally {
+      await admin.from('character').delete().eq('id', char.id);
+    }
+  },
+});
+
+Deno.test({
+  name: 'update-character: guarded write on an invisible character gets __forbidden (NOT_VISIBLE)',
+  ignore: skip,
+  async fn() {
+    const { userId } = await seed();
+    // Private character — a stranger can neither UPDATE nor SELECT it.
+    const { data: char } = await admin
+      .from('character')
+      .insert({ name: 'Private Char', user_id: userId, level: 1, experience: 0 })
+      .select()
+      .single();
+    assert(char);
+
+    try {
+      const { jwt: otherJwt } = await ensureSecondUser();
+      const result = await callFunction(
+        'update-character',
+        { id: char.id, name: 'Sneaky Write', expected_updated_at: char.updated_at },
+        { token: otherJwt }
+      );
+      assertEquals(result.status, 200);
+      assertEquals(result.body?.data?.__forbidden, true);
+      assertEquals(result.body?.data?.reason, 'NOT_VISIBLE');
     } finally {
       await admin.from('character').delete().eq('id', char.id);
     }

--- a/supabase/functions/update-character/index.ts
+++ b/supabase/functions/update-character/index.ts
@@ -73,12 +73,35 @@ serve(async (req: Request) => {
           data: data,
         };
       } else if (status === 'CONFLICT') {
-        // The character was updated elsewhere since the caller's snapshot. Don't
-        // overwrite — return the current server row so the client can merge and retry.
+        // The guarded UPDATE matched no row. Two very different causes look identical
+        // at that point: (a) the row changed since the caller's snapshot — a genuine
+        // conflict to merge; (b) RLS lets the caller SELECT the row but not UPDATE it
+        // (e.g. anyone viewing a public character). Re-read with the same RLS-scoped
+        // client to tell them apart — misreporting (b) as a conflict makes read-only
+        // clients merge-and-retry forever.
         const current = await fetchData<Character>(client, 'character', [{ column: 'id', value: id }]);
+        const row = current[0] ?? null;
+        if (!row) {
+          // The caller can't even see the row (deleted, or no read access) — there is
+          // nothing to merge and retrying will never succeed.
+          return {
+            status: 'success',
+            data: { __forbidden: true, reason: 'NOT_VISIBLE' },
+          };
+        }
+        if (row.updated_at === expected_updated_at) {
+          // The token still matches the row, so the UPDATE wasn't raced — it was
+          // filtered by RLS. The caller can read but not write this character.
+          return {
+            status: 'success',
+            data: { __forbidden: true, reason: 'WRITE_DENIED' },
+          };
+        }
+        // The row really did change since the caller's snapshot. Don't overwrite —
+        // return the current server row so the client can merge and retry.
         return {
           status: 'success',
-          data: { __conflict: true, character: current[0] ?? null },
+          data: { __conflict: true, character: row },
         };
       } else {
         return {


### PR DESCRIPTION
## Summary

Anyone viewing a character they can't write to — most commonly a **public character sheet while logged out** — got an infinite stream of "Merged a remote update" notifications (one every ~2s, forever). Reproduced on `/sheet/142809` in a fresh anonymous browser.

## Root cause

The character RLS policies allow public SELECT but deny UPDATE to non-owners. A read-only viewer's auto-save therefore matches **0 rows**, which the optimistic-concurrency guard added in #253 misreported as a **conflict**. The client then:

1. fetched the "current row" (SELECT is allowed!), merged, and toasted,
2. `setCharacter(merged)` re-triggered the debounced save 800ms later,
3. the save was RLS-denied again → "conflict" again → loop.

Before #253 the same denied write failed silently, which is why this is new.

## Fix

**Server** ([update-character](supabase/functions/update-character/index.ts)): on a guarded 0-row update, re-read the row with the same RLS-scoped client to disambiguate:
- row invisible → `__forbidden` (`NOT_VISIBLE`)
- row visible, token still matches → the write was RLS-filtered → `__forbidden` (`WRITE_DENIED`)
- token differs → genuine `__conflict` + current row (unchanged behavior)

**Client** ([use-character](frontend/src/utils/use-character.tsx)), defense in depth:
- `__forbidden` latches a read-only mode that disables the auto-save pipeline for the session
- conflict merges only apply + notify when the merge **actually changes a saved field**; identical merges silently adopt the fresh token instead of re-firing a save (removes the loop's fuel)
- circuit breaker: stop merge-and-retry after 3 consecutive conflicts — the loop cannot recur even against an older deployed server that still misreports

Owner/GM/admin saving and genuine concurrent-edit merging are unchanged.

## Verification

- **API tests** (new): guarded success bumps `updated_at`; stale token returns `__conflict` without overwriting; anon and authenticated non-owner viewers of a public character get `__forbidden` and the row is untouched. Full suite: **25 passed, 0 failed** against the local compose stack.
- **Browser, against the old prod API** (worst case — server still misreports): anonymous public sheet loads with zero toasts for 30+s; an XP edit as an anon viewer produces zero toasts, doesn't persist, and doesn't loop. Frontend typecheck clean.
- **Docs**: `expected_updated_at` / `__conflict` / `__forbidden` documented in the OpenAPI spec (missed in #253); `npm run docs:check` passes.

Note: the client changes alone already stop the loop everywhere; deploying the edge function completes the fix (zero noise, no wasted retry requests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)