### PR TITLE
fix(content-update): accept the shared key from body again; unbreak bot approvals

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -30,3 +30,6 @@ EMAIL_AUTOCONFIRM=true
 STUDIO_PORT=54323
 DEFAULT_ORG_NAME=Default
 DEFAULT_PROJECT_NAME=Wanderer's Guide
+
+# Shared secret for the content-updates Discord bot webhook (update-content-update tests)
+CONTENT_UPDATE_KEY=pick-any-shared-secret

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -136,6 +136,9 @@ services:
       SUPABASE_ANON_KEY: ${ANON_KEY}
       SUPABASE_SERVICE_ROLE_KEY: ${SERVICE_ROLE_KEY}
       SUPABASE_DB_URL: postgres://postgres:${POSTGRES_PASSWORD}@db:5432/postgres
+      # Shared secret for the content-updates Discord bot webhook (update-content-update).
+      # Optional locally; the _tests for that function skip when unset.
+      CONTENT_UPDATE_KEY: ${CONTENT_UPDATE_KEY:-}
       VERIFY_JWT: "false"
     command:
       - start

--- a/docs/api-reference/openapi.json
+++ b/docs/api-reference/openapi.json
@@ -2723,7 +2723,7 @@
       "post": {
         "tags": ["Integrations"],
         "summary": "(Discord webhook) Approve, reject, or vote on a content update",
-        "description": "Service-to-service webhook for the WG Discord moderation bot. Authenticates via the shared `CONTENT_UPDATE_KEY` secret in the `Authorization: Bearer <secret>` header (NOT a user JWT or API key). When state=APPROVE, applies the underlying content change.",
+        "description": "Service-to-service webhook for the WG Discord moderation bot. Authenticates via the shared `CONTENT_UPDATE_KEY` secret, preferably in the `Authorization: Bearer <secret>` header (NOT a user JWT or API key); the legacy `auth_token` body field is also accepted for older bot deployments. When state=APPROVE, applies the underlying content change.",
         "operationId": "updateContentUpdate",
         "security": [],
         "requestBody": {
@@ -2734,6 +2734,7 @@
                 "type": "object",
                 "required": ["discord_msg_id", "discord_user_id", "discord_user_name", "state"],
                 "properties": {
+                  "auth_token": { "type": "string", "description": "Legacy transport for the shared secret; prefer the Authorization header." },
                   "discord_msg_id": { "type": "string" },
                   "discord_user_id": { "type": "string" },
                   "discord_user_name": { "type": "string" },

--- a/supabase/functions/_tests/update-content-update.test.ts
+++ b/supabase/functions/_tests/update-content-update.test.ts
@@ -71,6 +71,69 @@ Deno.test({
 });
 
 Deno.test({
+  name: 'update-content-update: accepts the shared key via legacy body auth_token (deployed bot format)',
+  ignore: skip,
+  async fn() {
+    const { userId } = await seed();
+    await withContentSource(userId, async (sourceId) => {
+      const msgId = `test-cu-${crypto.randomUUID()}`;
+      const cu = await seedContentUpdate({
+        user_id: userId,
+        type: 'trait',
+        ref_id: 1,
+        content_source_id: sourceId,
+        action: 'UPDATE',
+        data: { name: 'Anything' },
+        discord_msg_id: msgId,
+      });
+
+      try {
+        // The content-updates bot sends the key in the body, not the Authorization
+        // header. The header-only check (deployed 2026-07-12) rejected every bot call
+        // as "Invalid auth token", freezing all approvals/votes — this is the guard.
+        const res = await callFunction('update-content-update', {
+          auth_token: CONTENT_UPDATE_KEY,
+          discord_msg_id: msgId,
+          discord_user_id: 'voter-1',
+          discord_user_name: 'Voter One',
+          state: 'UPVOTE',
+        });
+        assertEquals(res.body?.status, 'success', `body-token auth must pass: ${JSON.stringify(res.body)}`);
+
+        const { data: after } = await admin
+          .from('content_update')
+          .select('upvotes')
+          .eq('id', cu.id)
+          .single();
+        assertEquals(after?.upvotes?.length, 1, 'upvote should be recorded');
+      } finally {
+        await admin.from('content_update').delete().eq('id', cu.id);
+      }
+    });
+  },
+});
+
+Deno.test({
+  name: 'update-content-update: rejects a wrong key in both header and body',
+  ignore: skip,
+  async fn() {
+    const res = await callFunction(
+      'update-content-update',
+      {
+        auth_token: 'wrong-key',
+        discord_msg_id: 'irrelevant',
+        discord_user_id: 'x',
+        discord_user_name: 'x',
+        state: 'UPVOTE',
+      },
+      { token: 'also-wrong' }
+    );
+    assertEquals(res.body?.status, 'fail');
+    assertEquals(res.body?.data?.message, 'Invalid auth token');
+  },
+});
+
+Deno.test({
   name: 'update-content-update: a failed apply is NOT marked approved (apply-then-approve regression)',
   ignore: skip,
   async fn() {

--- a/supabase/functions/update-content-update/index.ts
+++ b/supabase/functions/update-content-update/index.ts
@@ -19,15 +19,22 @@ serve(async (req: Request) => {
   return await connect(
     req,
     async (client, body, token) => {
-      let { discord_msg_id, discord_user_id, discord_user_name, state } = body as {
+      let { auth_token, discord_msg_id, discord_user_id, discord_user_name, state } = body as {
+        auth_token?: string;
         discord_msg_id: string;
         discord_user_id: string;
         discord_user_name: string;
         state: 'APPROVE' | 'REJECT' | 'UPVOTE' | 'DOWNVOTE';
       };
 
+      // Accept the shared key from the Authorization header OR the legacy `auth_token`
+      // body field. The deployed content-updates bot sends it in the body; when the
+      // header-only check shipped (May 2026 change, deployed 2026-07-12) every bot call
+      // was rejected as "Invalid auth token" and all approvals/votes silently or loudly
+      // failed. Keep both until every caller sends the header, then drop the body path.
       // @ts-ignore
-      if (token !== Deno.env.get('CONTENT_UPDATE_KEY')) {
+      const expectedKey = Deno.env.get('CONTENT_UPDATE_KEY');
+      if (!expectedKey || (token !== expectedKey && auth_token !== expectedKey)) {
         return {
           status: 'fail',
           data: { message: 'Invalid auth token' },


### PR DESCRIPTION
## Summary

**Every content-update approval, rejection, and vote from the Discord bot has failed with "Invalid auth token" since the July 12 functions deploy.** The moderation queue is frozen (14+ updates stuck PENDING, none approved since July 10) and each retry floods the update's Discord thread with another warning message pinging the approver.

## Root cause

A May 3 change (33c6cba7) moved this webhook's auth from the legacy body `auth_token` field to the Authorization header. The deployed bot still sends the key in the body — its own code carries a `TODO: Should be in a header`. The change sat undeployed for two months, so nothing broke until the audit PRs (#253–#255) shipped the accumulated function changes on July 12. The new bot deployed the same day then made each failed approve visible: it removes the moderator's ✅ and posts a "failed to apply, please retry" warning, so every retry produced another ping (30+ in one thread).

Verified against prod: the deployed function build matches this repo, its runtime env and service-role client are healthy (probed via a temporary env-check function, since deleted), the write replays cleanly against a schema-identical local DB, and the gate returns `Invalid auth token` for exactly the credential shapes the bot can send.

## Fix

Accept the shared `CONTENT_UPDATE_KEY` from the Authorization header **or** the legacy `auth_token` body field, and reject everything when the secret itself is unset (previously an unset secret plus a token-less request compared `undefined === undefined` and passed). The body path unfreezes the currently-deployed bot the moment this function deploys; the bot-side counterpart (send the header, deduplicate warnings, remove the em dash from the warning copy) is in the content-updates-bot repo PR.

## Verification

- `CONTENT_UPDATE_KEY` is now wired into the local compose stack, so the two previously-skipped approve-flow tests actually run: apply-then-approve ordering and the failed-apply-not-marked-approved regression both pass.
- New tests: body-token auth succeeds (deployed bot format) and records the vote; wrong key in both header and body fails with `Invalid auth token`.
- Full API suite: **30 passed, 0 failed** against the compose stack.
- OpenAPI spec documents the legacy body field.

## Deploy note

This needs a functions deploy to take effect (`supabase functions deploy update-content-update`). Once deployed, the stuck approvals (e.g. Student of Perfection Dedication, #39427) can be retried with a single ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)