### PR TITLE
fix(auth): surface expired sessions instead of zombie logged-in state

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -30,3 +30,6 @@ EMAIL_AUTOCONFIRM=true
 STUDIO_PORT=54323
 DEFAULT_ORG_NAME=Default
 DEFAULT_PROJECT_NAME=Wanderer's Guide
+
+# Shared secret for the content-updates Discord bot webhook (update-content-update tests)
+CONTENT_UPDATE_KEY=pick-any-shared-secret

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -136,6 +136,9 @@ services:
       SUPABASE_ANON_KEY: ${ANON_KEY}
       SUPABASE_SERVICE_ROLE_KEY: ${SERVICE_ROLE_KEY}
       SUPABASE_DB_URL: postgres://postgres:${POSTGRES_PASSWORD}@db:5432/postgres
+      # Shared secret for the content-updates Discord bot webhook (update-content-update).
+      # Optional locally; the _tests for that function skip when unset.
+      CONTENT_UPDATE_KEY: ${CONTENT_UPDATE_KEY:-}
       VERIFY_JWT: "false"
     command:
       - start

--- a/docs/api-reference/openapi.json
+++ b/docs/api-reference/openapi.json
@@ -2723,7 +2723,7 @@
       "post": {
         "tags": ["Integrations"],
         "summary": "(Discord webhook) Approve, reject, or vote on a content update",
-        "description": "Service-to-service webhook for the WG Discord moderation bot. Authenticates via the shared `CONTENT_UPDATE_KEY` secret in the `Authorization: Bearer <secret>` header (NOT a user JWT or API key). When state=APPROVE, applies the underlying content change.",
+        "description": "Service-to-service webhook for the WG Discord moderation bot. Authenticates via the shared `CONTENT_UPDATE_KEY` secret, preferably in the `Authorization: Bearer <secret>` header (NOT a user JWT or API key); the legacy `auth_token` body field is also accepted for older bot deployments. When state=APPROVE, applies the underlying content change.",
         "operationId": "updateContentUpdate",
         "security": [],
         "requestBody": {
@@ -2734,6 +2734,7 @@
                 "type": "object",
                 "required": ["discord_msg_id", "discord_user_id", "discord_user_name", "state"],
                 "properties": {
+                  "auth_token": { "type": "string", "description": "Legacy transport for the shared secret; prefer the Authorization header." },
                   "discord_msg_id": { "type": "string" },
                   "discord_user_id": { "type": "string" },
                   "discord_user_name": { "type": "string" },

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,7 +18,8 @@ import {
 } from '@mantine/core';
 import { useMediaQuery, usePrevious } from '@mantine/hooks';
 import { ModalsProvider } from '@mantine/modals';
-import { Notifications } from '@mantine/notifications';
+import { Notifications, showNotification } from '@mantine/notifications';
+import { clearUserData, getCachedPublicUser } from '@auth/user-manager';
 import SearchSpotlight from '@nav/SearchSpotlight';
 import { IconBrush } from '@tabler/icons-react';
 import { getBackgroundImageFromURL } from '@utils/background-images';
@@ -95,12 +96,47 @@ export default function App() {
 
     supabase.auth.getSession().then(({ data: { session } }) => {
       setSession(session);
+      // Cold load with a dead session (expired from inactivity while the tab was
+      // closed): supabase-js clears its stored session without a SIGNED_OUT event,
+      // so catch the "cached user but no session" mismatch here too.
+      if (!session && getCachedPublicUser()) {
+        clearUserData();
+        if (!window.location.pathname.startsWith('/login')) {
+          showNotification({
+            id: 'session-expired',
+            title: 'Session expired',
+            message: 'You have been signed out due to inactivity. Please sign in again to save your changes.',
+            color: 'yellow',
+            autoClose: false,
+          });
+        }
+      }
     });
 
     const {
       data: { subscription },
-    } = supabase.auth.onAuthStateChange((_event, session) => {
+    } = supabase.auth.onAuthStateChange((event, session) => {
       setSession(session);
+
+      if (event === 'SIGNED_OUT') {
+        // The session ended. If the cached user data is still present, this was NOT an
+        // intentional logout (that path runs localStorage.clear() first) — the session
+        // expired or was revoked while the user was browsing. Guarded routes redirect to
+        // login on their own, but public pages (sheet, builder, home) kept rendering a
+        // logged-in-looking UI whose every write silently failed. Clear the stale cache
+        // and tell the user, so "logged out but the site never says so" can't happen.
+        const hadUser = !!getCachedPublicUser();
+        clearUserData();
+        if (hadUser && !window.location.pathname.startsWith('/login')) {
+          showNotification({
+            id: 'session-expired',
+            title: 'Session expired',
+            message: 'You have been signed out due to inactivity. Please sign in again to save your changes.',
+            color: 'yellow',
+            autoClose: false,
+          });
+        }
+      }
     });
 
     return () => subscription.unsubscribe();

--- a/frontend/src/auth/user-manager.ts
+++ b/frontend/src/auth/user-manager.ts
@@ -12,9 +12,13 @@ export async function getPublicUser(id?: string) {
     );
 
     if (!id) {
-      // Only store if we're fetching the current user
-      if (typeof localStorage !== 'undefined') {
-        localStorage.setItem('user-data', JSON.stringify(user ?? {}));
+      // Only store if we're fetching the current user. A FAILED fetch (user = null,
+      // e.g. because the session expired mid-visit) must not overwrite the cache: it
+      // used to store '{}', and since an empty object is truthy, getCachedPublicUser()
+      // then reported a logged-in user forever — the UI acted signed-in while every
+      // request silently failed.
+      if (typeof localStorage !== 'undefined' && user) {
+        localStorage.setItem('user-data', JSON.stringify(user));
       }
     }
     return user;
@@ -27,7 +31,15 @@ export async function getPublicUser(id?: string) {
 export function getCachedPublicUser(): PublicUser | null {
   if (typeof localStorage !== 'undefined') {
     const data = localStorage.getItem('user-data');
-    return data ? JSON.parse(data) : null;
+    if (!data) return null;
+    const user = JSON.parse(data) as PublicUser | Record<string, never>;
+    // Self-heal caches poisoned by the old '{}' write: an entry without an id is not
+    // a real user and must read as logged-out.
+    if (!user || !('id' in user)) {
+      localStorage.removeItem('user-data');
+      return null;
+    }
+    return user as PublicUser;
   } else {
     return null;
   }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -8,7 +8,6 @@ import '@mantine/dates/styles.css';
 import '@mantine/charts/styles.css';
 
 import { AuthRouteWrapper } from '@auth/AuthedRouteWrapper.tsx';
-import { createClient } from '@supabase/supabase-js';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
@@ -17,14 +16,14 @@ import App from './App.tsx';
 import './index.css';
 import { ErrorPage } from './pages/ErrorPage.tsx';
 import { MantineProvider } from '@mantine/core';
+import { supabase } from './supabase-client.ts';
 
 const queryClient = new QueryClient();
 
-export const supabase = createClient(
-  /*<Database>*/
-  import.meta.env.VITE_SUPABASE_URL,
-  import.meta.env.VITE_SUPABASE_KEY
-);
+// Re-exported for the many existing `import { supabase } from '../main'` call sites.
+// The client itself lives in supabase-client.ts so modules that main.tsx transitively
+// depends on (e.g. the request manager) can import it without a circular dependency.
+export { supabase };
 
 // Fixes cache issues on refresh
 (async () => {

--- a/frontend/src/request/request-manager.ts
+++ b/frontend/src/request/request-manager.ts
@@ -1,12 +1,8 @@
-import { FunctionsHttpError, FunctionsRelayError, FunctionsFetchError, createClient } from '@supabase/supabase-js';
+import { FunctionsHttpError, FunctionsRelayError, FunctionsFetchError } from '@supabase/supabase-js';
 import { JSendResponse, RequestType } from '@schemas/requests';
 import { logError, throwError } from '@utils/error-handling';
-
-const supabase = createClient(
-  /*<Database>*/
-  import.meta.env.VITE_SUPABASE_URL,
-  import.meta.env.VITE_SUPABASE_KEY
-);
+import { showNotification } from '@mantine/notifications';
+import { supabase } from '../supabase-client';
 
 // A single logical request makes at most MAX_ATTEMPTS network calls, and we retry
 // ONLY genuine transient network failures — never timeouts or HTTP errors. This is
@@ -23,6 +19,35 @@ const MAX_ATTEMPTS = 2;
 const DEFAULT_TIMEOUT_MS = 30000;
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Only surface the "session expired" notification once per page load; a dead
+// session makes MANY concurrent requests fail and each would otherwise toast.
+let notifiedSessionExpired = false;
+
+/**
+ * After a request fails with an auth-shaped error, check whether the underlying
+ * session is actually gone (e.g. expired from inactivity while the tab was open).
+ * The auth listener in App.tsx handles the common case; this is the safety net for
+ * requests that raced the sign-out event. Tells the user instead of failing silently.
+ */
+async function checkForExpiredSession() {
+  if (notifiedSessionExpired) return;
+  const hadUser = !!localStorage.getItem('user-data');
+  if (!hadUser) return;
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  if (session) return;
+  notifiedSessionExpired = true;
+  localStorage.removeItem('user-data');
+  showNotification({
+    id: 'session-expired',
+    title: 'Session expired',
+    message: 'You have been signed out due to inactivity. Please sign in again to save your changes.',
+    color: 'yellow',
+    autoClose: false,
+  });
+}
 
 export async function makeRequest<T = Record<string, any>>(
   type: RequestType,
@@ -69,6 +94,10 @@ export async function makeRequest<T = Record<string, any>>(
   }
 
   if (lastError instanceof FunctionsHttpError) {
+    // 401/403 with a missing session = the user's session silently expired.
+    if (lastError.context?.status === 401 || lastError.context?.status === 403) {
+      await checkForExpiredSession();
+    }
     try {
       const errorMessage = await lastError.context.json();
       console.error('Request Function returned an error', errorMessage);

--- a/frontend/src/supabase-client.ts
+++ b/frontend/src/supabase-client.ts
@@ -1,0 +1,17 @@
+import { createClient } from '@supabase/supabase-js';
+
+/**
+ * The single shared Supabase client for the entire app.
+ *
+ * There must be exactly ONE client: each `createClient()` runs its own token
+ * auto-refresh loop and keeps its own in-memory session. When the app had two
+ * (main.tsx and request-manager.ts), the second client could hold a stale
+ * access token after the first refreshed (or vice versa), and auth events from
+ * one never reached listeners on the other — so a session that died from
+ * inactivity was noticed by one client while the rest of the app kept acting
+ * logged in with dead credentials.
+ */
+export const supabase = createClient(
+  import.meta.env.VITE_SUPABASE_URL,
+  import.meta.env.VITE_SUPABASE_KEY
+);

--- a/supabase/functions/_tests/update-content-update.test.ts
+++ b/supabase/functions/_tests/update-content-update.test.ts
@@ -71,6 +71,69 @@ Deno.test({
 });
 
 Deno.test({
+  name: 'update-content-update: accepts the shared key via legacy body auth_token (deployed bot format)',
+  ignore: skip,
+  async fn() {
+    const { userId } = await seed();
+    await withContentSource(userId, async (sourceId) => {
+      const msgId = `test-cu-${crypto.randomUUID()}`;
+      const cu = await seedContentUpdate({
+        user_id: userId,
+        type: 'trait',
+        ref_id: 1,
+        content_source_id: sourceId,
+        action: 'UPDATE',
+        data: { name: 'Anything' },
+        discord_msg_id: msgId,
+      });
+
+      try {
+        // The content-updates bot sends the key in the body, not the Authorization
+        // header. The header-only check (deployed 2026-07-12) rejected every bot call
+        // as "Invalid auth token", freezing all approvals/votes — this is the guard.
+        const res = await callFunction('update-content-update', {
+          auth_token: CONTENT_UPDATE_KEY,
+          discord_msg_id: msgId,
+          discord_user_id: 'voter-1',
+          discord_user_name: 'Voter One',
+          state: 'UPVOTE',
+        });
+        assertEquals(res.body?.status, 'success', `body-token auth must pass: ${JSON.stringify(res.body)}`);
+
+        const { data: after } = await admin
+          .from('content_update')
+          .select('upvotes')
+          .eq('id', cu.id)
+          .single();
+        assertEquals(after?.upvotes?.length, 1, 'upvote should be recorded');
+      } finally {
+        await admin.from('content_update').delete().eq('id', cu.id);
+      }
+    });
+  },
+});
+
+Deno.test({
+  name: 'update-content-update: rejects a wrong key in both header and body',
+  ignore: skip,
+  async fn() {
+    const res = await callFunction(
+      'update-content-update',
+      {
+        auth_token: 'wrong-key',
+        discord_msg_id: 'irrelevant',
+        discord_user_id: 'x',
+        discord_user_name: 'x',
+        state: 'UPVOTE',
+      },
+      { token: 'also-wrong' }
+    );
+    assertEquals(res.body?.status, 'fail');
+    assertEquals(res.body?.data?.message, 'Invalid auth token');
+  },
+});
+
+Deno.test({
   name: 'update-content-update: a failed apply is NOT marked approved (apply-then-approve regression)',
   ignore: skip,
   async fn() {

--- a/supabase/functions/update-content-update/index.ts
+++ b/supabase/functions/update-content-update/index.ts
@@ -19,15 +19,22 @@ serve(async (req: Request) => {
   return await connect(
     req,
     async (client, body, token) => {
-      let { discord_msg_id, discord_user_id, discord_user_name, state } = body as {
+      let { auth_token, discord_msg_id, discord_user_id, discord_user_name, state } = body as {
+        auth_token?: string;
         discord_msg_id: string;
         discord_user_id: string;
         discord_user_name: string;
         state: 'APPROVE' | 'REJECT' | 'UPVOTE' | 'DOWNVOTE';
       };
 
+      // Accept the shared key from the Authorization header OR the legacy `auth_token`
+      // body field. The deployed content-updates bot sends it in the body; when the
+      // header-only check shipped (May 2026 change, deployed 2026-07-12) every bot call
+      // was rejected as "Invalid auth token" and all approvals/votes silently or loudly
+      // failed. Keep both until every caller sends the header, then drop the body path.
       // @ts-ignore
-      if (token !== Deno.env.get('CONTENT_UPDATE_KEY')) {
+      const expectedKey = Deno.env.get('CONTENT_UPDATE_KEY');
+      if (!expectedKey || (token !== expectedKey && auth_token !== expectedKey)) {
         return {
           status: 'fail',
           data: { message: 'Invalid auth token' },


### PR DESCRIPTION
## Summary

Users whose session expires (14 days of inactivity per the auth config, a normal between-games gap) ended up in a zombie state: the site kept acting logged in while every save and write silently failed, with no logout and no message. Prod logs quantify it: **~656 failed `update-character` calls and ~1,787 dead-token `/auth/v1/user` rejections in a 20-hour window**, all with `Invalid Refresh Token: Session Expired (Inactivity)` on the auth service.

## Root causes

1. **Poisoned user cache**: a failed `getPublicUser()` fetch wrote `'{}'` to the `user-data` localStorage cache. An empty object is truthy, so `getCachedPublicUser()` reported a logged-in user forever.
2. **No reaction to session death on public routes**: the guarded routes redirect via `AuthRouteWrapper`, but the sheet/builder/home are public. supabase-js correctly cleared the dead session, and nothing told the user or cleaned the cache.
3. **Two supabase clients** (main.tsx + request-manager.ts), each with its own refresh loop and in-memory session. One could hold dead credentials while the other looked fine, and auth events from one never reached the app's listener.

## Fix

- Single shared client in `supabase-client.ts` (main.tsx re-exports it, so all existing `import { supabase } from '../main'` sites keep working).
- `App.tsx` handles session death both mid-visit (`SIGNED_OUT` event) and on cold load (stored session already dead): clears the cached user and shows a persistent "Session expired, please sign in again" notification. Intentional logout stays silent because that path runs `localStorage.clear()` before the event fires.
- `getPublicUser()` never overwrites the cache on a failed fetch; `getCachedPublicUser()` self-heals old poisoned `'{}'` entries.
- `makeRequest()` fires the same expired-session flow (once per page load) if a 401/403 response coincides with a missing session, as a safety net for requests that race the event.

## Verification

Seeded a dead session + cached user in localStorage in the running app:
- **Before**: sheet rendered logged-in-looking UI, silent failures, cache stayed poisoned.
- **After**: "Session expired" notification shows on the sheet (public route) on both cold load and mid-visit expiry; the supabase token and user cache are both cleared; anonymous browsing and the guarded-route login redirect are unaffected. Frontend typecheck clean.

Note: branch is stacked on #257 (which is stacked on #256); merge those first and this diff reduces to its own commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)