### PR TITLE
fix: kill /undefined requests, surface failed saves, retry 5xx, structured failure logs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -56,6 +56,9 @@ jobs:
             `ANON_KEY=${sign('anon')}`,
             `SERVICE_ROLE_KEY=${sign('service_role')}`,
             `POSTGRES_PASSWORD=${crypto.randomBytes(16).toString('hex')}`,
+            // Shared secret for the content-updates webhook; minting one lets the
+            // update-content-update tests run in CI instead of skipping.
+            `CONTENT_UPDATE_KEY=${crypto.randomBytes(24).toString('hex')}`,
             `PUBLIC_SUPABASE_URL=http://localhost:8000`,
             `SITE_URL=http://localhost:3000`,
             `VITE_ENV=production`,

--- a/frontend/src/process/content/content-store.ts
+++ b/frontend/src/process/content/content-store.ts
@@ -374,6 +374,16 @@ export async function fetchContent<T = Record<string, any>>(
     trait: 'find-trait',
   };
 
+  // Runtime guard: TypeScript can't stop a caller passing a drawer type or an
+  // ability-block subtype ('feat', 'action', ...) that isn't a real ContentType.
+  // The map lookup below then yields undefined and the request literally went to
+  // `/functions/v1/undefined` in prod. Fail loudly and locally instead — the fix
+  // at the call site is convertToContentType().
+  if (!FETCH_REQUEST_MAP[type]) {
+    console.error(`[CONTENT-STORE] fetchContent called with unknown content type '${type}'`, data);
+    return [] as T[];
+  }
+
   // Make sure any cache persisted by a previous session/tab is loaded before we check the
   // in-memory stores, so a reload can hit the cache instead of re-fetching from the network.
   await hydrationPromise;

--- a/frontend/src/process/content/content-utils.tsx
+++ b/frontend/src/process/content/content-utils.tsx
@@ -47,7 +47,9 @@ export function toText(html: any) {
 export function convertToContentType(type: ContentType | AbilityBlockType): ContentType {
   // Handle special cases for DrawerTypes
   // @ts-ignore
-  if (type === 'cast-spell') return 'spell';
+  if (type === 'cast-spell' || type === 'add-spell') return 'spell';
+  // @ts-ignore
+  if (type === 'inv-item') return 'item';
   return (isAbilityBlockType(type) ? 'ability-block' : type) satisfies ContentType;
 }
 export function isAbilityBlockType(value: any): value is AbilityBlockType {

--- a/frontend/src/request/request-manager.ts
+++ b/frontend/src/request/request-manager.ts
@@ -80,12 +80,19 @@ export async function makeRequest<T = Record<string, any>>(
 
     lastError = error;
 
-    // Only retry genuine transient network errors. Timeouts and HTTP errors
-    // (4xx/5xx, including 429 rate-limits) are NOT retried — retrying them amplifies
+    // Retry genuine transients only:
+    //  - network-level failures (fetch/relay errors), and
+    //  - gateway errors (502/503/504), which in practice are edge-function cold
+    //    starts or worker restarts — the request FAILED COMPLETELY and a single
+    //    spaced retry is safe and usually succeeds.
+    // Timeouts and other HTTP errors (4xx incl. 429 rate limits, and 500s, which
+    // mean the function itself errored) are NOT retried — retrying those amplifies
     // load exactly when the backend is already struggling.
     const isTransientNetwork =
       error instanceof FunctionsFetchError || error instanceof FunctionsRelayError;
-    if (attempt < MAX_ATTEMPTS && isTransientNetwork) {
+    const isGatewayError =
+      error instanceof FunctionsHttpError && [502, 503, 504].includes(error.context?.status);
+    if (attempt < MAX_ATTEMPTS && (isTransientNetwork || isGatewayError)) {
       // Backoff with jitter so many clients don't retry in lockstep.
       await sleep(250 * attempt + Math.random() * 250);
       continue;
@@ -100,19 +107,28 @@ export async function makeRequest<T = Record<string, any>>(
     }
     try {
       const errorMessage = await lastError.context.json();
-      console.error('Request Function returned an error', errorMessage);
+      console.error(`Request to '${type}' failed (HTTP ${lastError.context?.status})`, errorMessage);
     } catch {
-      console.error('Request Function returned an HTTP error');
+      console.error(`Request to '${type}' failed (HTTP ${lastError.context?.status})`);
     }
   } else if (lastError instanceof FunctionsRelayError) {
-    console.error('Request Relay error:', lastError.message);
+    console.error(`Request to '${type}' relay error:`, lastError.message);
   } else if (lastError instanceof FunctionsFetchError) {
-    console.error('Request Fetch error:', lastError.message);
+    console.error(`Request to '${type}' fetch error:`, lastError.message);
   } else if (lastError) {
-    console.error('Request error:', lastError?.message ?? lastError);
+    console.error(`Request to '${type}' error:`, lastError?.message ?? lastError);
   }
 
   return null;
+}
+
+/**
+ * Whether the one-per-page-load "session expired" notification has been shown.
+ * Callers can use this to skip their own generic failure toasts when the real
+ * cause (a dead session) has already been communicated.
+ */
+export function hasSessionExpiredNotice() {
+  return notifiedSessionExpired;
 }
 
 /**

--- a/frontend/src/utils/use-character.tsx
+++ b/frontend/src/utils/use-character.tsx
@@ -8,7 +8,7 @@ import { useDebouncedCallback, useDebouncedValue, useDidUpdate, usePrevious } fr
 import { showNotification } from '@mantine/notifications';
 import { executeOperations } from '@operations/operations.main';
 import { confirmHealth } from '@pages/character_sheet/entity-handler';
-import { makeRequest } from '@requests/request-manager';
+import { hasSessionExpiredNotice, makeRequest } from '@requests/request-manager';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import { Character, ContentPackage, OperationCharacterResultPackage } from '@schemas/content';
 import { saveCalculatedStats } from '@variables/calculated-stats';
@@ -397,6 +397,12 @@ export default function useCharacter(
         ...data,
         ...(expected_updated_at ? { expected_updated_at } : {}),
       });
+      // makeRequest returns null for every failure (HTTP error, timeout, JSend
+      // error envelope). Throw so onError runs — otherwise a failed save was
+      // indistinguishable from a successful one and users lost edits silently.
+      if (resData === null) {
+        throw new Error(`update-character failed for character ${characterId}`);
+      }
       // Forbidden: RLS lets this session read the character but not write it.
       if (resData && !isArray(resData) && (resData as any).__forbidden) {
         return { forbidden: true, conflict: false, server: null as Character | null };
@@ -462,8 +468,13 @@ export default function useCharacter(
         console.log('> Fetched updated character: #', getUpdateHash(character), 'vs.', getUpdateHash(result.server));
       }
     },
-    onError: () => {
+    onError: (error) => {
+      console.error('Character save failed:', error);
+      // If the real cause is a dead session, that persistent notification already
+      // explains it; a generic "check your connection" toast would just confuse.
+      if (hasSessionExpiredNotice()) return;
       showNotification({
+        id: 'character-save-failed',
         icon: <IconAlertCircle />,
         title: 'Failed to save character',
         message: 'Your changes could not be saved. Please check your connection and try again.',

--- a/supabase/functions/_shared/helpers.ts
+++ b/supabase/functions/_shared/helpers.ts
@@ -15,6 +15,24 @@ import type {
   Trait,
 } from './content';
 
+/**
+ * Structured, one-line JSON log for failure/anomaly paths, so incidents are
+ * queryable from `function_logs` (e.g. `event_message like '%"evt":"save_conflict"%'`).
+ * Never pass secrets or full row payloads in `fields` — ids, reasons, and error
+ * codes are enough to diagnose.
+ */
+export function logEvent(
+  level: 'info' | 'warn' | 'error',
+  fn: string,
+  event: string,
+  fields?: Record<string, unknown>
+) {
+  const line = JSON.stringify({ evt: event, fn, ...(fields ?? {}) });
+  if (level === 'error') console.error(line);
+  else if (level === 'warn') console.warn(line);
+  else console.log(line);
+}
+
 export async function connect<T = Record<string, any>>(
   req: Request,
   executeFn: (
@@ -127,6 +145,11 @@ export async function connect<T = Record<string, any>>(
       //
     }
   } catch (error) {
+    // Structured line first (queryable), full error object second (details).
+    logEvent('error', new URL(req.url).pathname.split('/').pop() ?? 'unknown', 'unhandled_error', {
+      message: (error as any)?.message ?? String(error),
+      code: (error as any)?.code,
+    });
     console.error(error);
     return new Response(
       JSON.stringify({

--- a/supabase/functions/_tests/seed.ts
+++ b/supabase/functions/_tests/seed.ts
@@ -130,12 +130,24 @@ export async function callFunction(
   };
   if (opts?.token) headers['Authorization'] = `Bearer ${opts.token}`;
 
-  const res = await fetch(`${FUNCTIONS_URL}/${name}`, {
-    method: 'POST',
-    headers,
-    body: JSON.stringify(body ?? {}),
-  });
-  const text = await res.text();
+  // Each edge function gets its own worker, cold-started on first invocation. On a
+  // loaded CI runner that first call can 5xx with a boot error even though the stack
+  // is healthy, which made e2e flaky (a test would fail on whichever function it hit
+  // first). Retry 5xx a couple times with a pause; real assertions run on the reply.
+  const MAX_TRIES = 3;
+  let res: Response = undefined as unknown as Response;
+  let text = '';
+  for (let attempt = 1; attempt <= MAX_TRIES; attempt++) {
+    res = await fetch(`${FUNCTIONS_URL}/${name}`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body ?? {}),
+    });
+    text = await res.text();
+    if (res.status < 500 || attempt === MAX_TRIES) break;
+    await new Promise((r) => setTimeout(r, 1500 * attempt));
+  }
+
   let parsed: unknown;
   try {
     parsed = JSON.parse(text);

--- a/supabase/functions/update-character/index.ts
+++ b/supabase/functions/update-character/index.ts
@@ -1,6 +1,6 @@
 // @ts-ignore
 import { serve } from 'std/server';
-import { connect, fetchData, updateData } from '../_shared/helpers.ts';
+import { connect, fetchData, logEvent, updateData } from '../_shared/helpers.ts';
 import type { Character } from '../_shared/content';
 
 serve(async (req: Request) => {
@@ -84,6 +84,7 @@ serve(async (req: Request) => {
         if (!row) {
           // The caller can't even see the row (deleted, or no read access) — there is
           // nothing to merge and retrying will never succeed.
+          logEvent('warn', 'update-character', 'save_forbidden', { id, reason: 'NOT_VISIBLE' });
           return {
             status: 'success',
             data: { __forbidden: true, reason: 'NOT_VISIBLE' },
@@ -92,6 +93,7 @@ serve(async (req: Request) => {
         if (row.updated_at === expected_updated_at) {
           // The token still matches the row, so the UPDATE wasn't raced — it was
           // filtered by RLS. The caller can read but not write this character.
+          logEvent('warn', 'update-character', 'save_forbidden', { id, reason: 'WRITE_DENIED' });
           return {
             status: 'success',
             data: { __forbidden: true, reason: 'WRITE_DENIED' },
@@ -99,11 +101,17 @@ serve(async (req: Request) => {
         }
         // The row really did change since the caller's snapshot. Don't overwrite —
         // return the current server row so the client can merge and retry.
+        logEvent('info', 'update-character', 'save_conflict', {
+          id,
+          expected: expected_updated_at,
+          actual: row.updated_at,
+        });
         return {
           status: 'success',
           data: { __conflict: true, character: row },
         };
       } else {
+        logEvent('error', 'update-character', 'save_failed', { id, result: status });
         return {
           status: 'error',
           message: status,

--- a/supabase/functions/update-content-update/index.ts
+++ b/supabase/functions/update-content-update/index.ts
@@ -7,6 +7,7 @@ import {
   fetchData,
   handleAssociatedTrait,
   insertData,
+  logEvent,
   updateData,
 } from '../_shared/helpers.ts';
 import type { ContentUpdate, PublicUser } from '../_shared/content';
@@ -35,6 +36,14 @@ serve(async (req: Request) => {
       // @ts-ignore
       const expectedKey = Deno.env.get('CONTENT_UPDATE_KEY');
       if (!expectedKey || (token !== expectedKey && auth_token !== expectedKey)) {
+        // Log which transports were present (never the values) — this exact failure
+        // mode was invisible for two days because rejected calls left no log line.
+        logEvent('warn', 'update-content-update', 'auth_rejected', {
+          keyConfigured: !!expectedKey,
+          hadHeaderToken: !!token,
+          hadBodyToken: !!auth_token,
+          state,
+        });
         return {
           status: 'fail',
           data: { message: 'Invalid auth token' },
@@ -57,6 +66,7 @@ serve(async (req: Request) => {
       const update = results.length > 0 ? results[0] : null;
 
       if (!update) {
+        logEvent('warn', 'update-content-update', 'update_not_found', { discord_msg_id, state });
         return {
           status: 'error',
           message: 'Content update not found',
@@ -214,6 +224,14 @@ serve(async (req: Request) => {
           data: true,
         };
       } else {
+        // The state change did NOT apply (the request stays un-approved / un-voted).
+        logEvent('error', 'update-content-update', 'apply_failed', {
+          updateId: update.id,
+          contentType: update.type,
+          action: update.action,
+          state,
+          result,
+        });
         return {
           status: 'error',
           message: result,


### PR DESCRIPTION
## Summary

Follow-up batch driven by prod log analysis, covering the three issues flagged today plus the "clear logs when things fail" requirement.

### 1. `/functions/v1/undefined` requests (real users, ~16/day)
`fetchContent` builds the endpoint from a `ContentType -> RequestType` map, and a runtime type outside that union produced a request to a function literally named `undefined`. There's now a guard that fails loudly and locally (`console.error` names the offending type and payload) instead of hitting the network, and `convertToContentType` learns the remaining content-backed drawer types (`inv-item`, `add-spell`). If anything still passes a bad type, the console log now identifies it instead of a mystery 404 in prod.

### 2. Silent save failures (~656 failed `update-character` calls / 20h)
`makeRequest` returns `null` for every failure and the save mutation treated that like success, so the "Failed to save character" toast was dead code. A null result now throws, `onError` fires, and users see the failure. When the persistent "Session expired" notice already explains the real cause, the generic toast is suppressed to avoid double-toasting.

### 3. Transient 502/503/504s (~60/20h)
Gateway errors are edge-function cold starts or worker restarts: the request failed completely, so one spaced, jittered retry is safe. 4xx (including 429) and 500 remain non-retried, preserving the anti-retry-storm design. The e2e test helper gets the same treatment, which fixes the flaky e2e runs where whichever function a test hit first could 500 on cold boot.

### 4. Structured failure logging (the observability ask)
New `logEvent()` helper emits one-line JSON on every failure path, queryable straight from `function_logs`:
- `update-character`: `save_conflict`, `save_forbidden` (with reason), `save_failed`
- `update-content-update`: `auth_rejected` (transports present, never values), `update_not_found`, `apply_failed`
- `connect()` catch-all: `unhandled_error` with function name and error code

The content-update outage went undiagnosed for two days precisely because rejected calls left zero log lines; with these, one log query names the failing stage.

### CI
- e2e flakiness: cold-start 5xx retry in the test helper (see 3).
- The e2e workflow now mints a `CONTENT_UPDATE_KEY`, so the four update-content-update tests run in CI instead of skipping.
- Note: the failing **Update schema** workflow is a stale `DB_URI` repo secret (pg_dump gets "password authentication failed" against the prod pooler; failing since at least July 12 with no recent success). Only a maintainer can refresh that secret; no code change fixes it.

## Verification
- Frontend typecheck clean; full API suite **30/30** against the local compose stack.
- Structured log lines confirmed flowing in the functions container during the test run (`save_forbidden`, `auth_rejected`, `unhandled_error` with PG error code).
- Public sheet loads clean in-browser with no regressions or spurious toasts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)