### PR TITLE
fix(content): item meta_data nullable numerics + single-row repair tool

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,8 @@
     "cy:run": "cypress run",
     "cy:e2e": "CYPRESS_BASE_URL=http://localhost:3000 CYPRESS_TEST_EMAIL=test@wanderersguide.app CYPRESS_TEST_PASSWORD=test1234 cypress run",
     "cy:e2e:open": "CYPRESS_BASE_URL=http://localhost:3000 CYPRESS_TEST_EMAIL=test@wanderersguide.app CYPRESS_TEST_PASSWORD=test1234 cypress open",
-    "audit:content": "esbuild scripts/audit-content/audit-content.ts --bundle --platform=node --format=esm --target=node20 --outfile=scripts/audit-content/.dist/audit.mjs && node scripts/audit-content/.dist/audit.mjs"
+    "audit:content": "esbuild scripts/audit-content/audit-content.ts --bundle --platform=node --format=esm --target=node20 --outfile=scripts/audit-content/.dist/audit.mjs && node scripts/audit-content/.dist/audit.mjs",
+    "fix:content": "esbuild scripts/audit-content/fix-content.ts --bundle --platform=node --format=esm --target=node20 --outfile=scripts/audit-content/.dist/fix.mjs && node scripts/audit-content/.dist/fix.mjs"
   },
   "dependencies": {
     "@mantine/carousel": "^9.0.0",

--- a/frontend/scripts/audit-content/README.md
+++ b/frontend/scripts/audit-content/README.md
@@ -75,6 +75,37 @@ Add new ones in `computeSafeFix()` — keep each conservative and always re-vali
   every failure with `id`, `name`, failing `paths`, the Zod summary, and any computed
   `fix`. Grep-friendly for triage. (git-ignored.)
 
+## Repairing a single row — `npm run fix:content`
+
+The write half, for **data fixes** (a malformed value in a specific row, as opposed
+to a schema fix which is a code change). It fetches one row, applies the registered
+repair rules for its type, re-validates against the Zod schema, shows the before/after
+diff, and — only with `--apply` — writes the changed columns back, then re-reads and
+re-validates from the DB to confirm.
+
+```bash
+# dry-run: fetch → repair → validate → show diff (writes nothing)
+SUPABASE_PAT=sbp_... npm run fix:content -- --type class --id 160
+
+# write it, then re-validate from the DB
+SUPABASE_PAT=sbp_... npm run fix:content -- --type class --id 160 --apply
+
+# batch several ids of one type
+SUPABASE_PAT=sbp_... npm run fix:content -- --type item --ids 22524,22539 --apply
+```
+
+**Guarantee:** a row is written only if it FULLY validates after the repair, and only
+the columns that actually changed are sent — so a fix can never leave a row worse than
+the auditor found it. Repair rules live in the `REPAIRS` array in `fix-content.ts`;
+each is conservative and the re-validation gate is the real safety net.
+
+Rules shipped so far:
+- `class`: a `setValue MAX_HEALTH_CLASS_PER_LEVEL` with a null value → the PF2e median
+  (8), flagged so the content owner can adjust. (Null HP-per-level is a live bug: that
+  class's characters get no class HP.)
+- `item`: empty string `""` in a numeric `meta_data` leaf (`attack_bonus`,
+  `charges.max`, `starfinder.usage`) → null.
+
 ## Classifying a finding (schema fix vs data fix)
 
 - **Schema fix** — the DB legitimately stores that shape and the schema is too strict.

--- a/frontend/scripts/audit-content/fix-content.ts
+++ b/frontend/scripts/audit-content/fix-content.ts
@@ -1,0 +1,254 @@
+/**
+ * Single-row content repair — the write half of the audit pipeline.
+ *
+ * Fetches ONE content row, applies the registered repair rules for its type,
+ * re-validates the result against the same Zod schema the app uses, shows the
+ * exact before/after diff, and (only with --apply) writes the changed columns
+ * back to the database.
+ *
+ * This is for DATA fixes — a genuinely malformed value in a specific row — as
+ * opposed to schema fixes (which are code changes to the Zod schemas). The
+ * guarantee: a row is only written if it FULLY validates after the repair, so a
+ * fix can never make a row worse than the auditor found it.
+ *
+ * Auth: one Supabase PAT in `SUPABASE_PAT` (self-serves the service_role key).
+ *
+ * Usage (from frontend/):
+ *   SUPABASE_PAT=sbp_... npm run fix:content -- --type class --id 160          # dry-run
+ *   SUPABASE_PAT=sbp_... npm run fix:content -- --type class --id 160 --apply  # write
+ *   SUPABASE_PAT=sbp_... npm run fix:content -- --type item --ids 12764,12765 --apply
+ */
+
+import { z } from 'zod';
+import {
+  AbilityBlockSchema,
+  AncestrySchema,
+  ArchetypeSchema,
+  BackgroundSchema,
+  ClassArchetypeSchema,
+  ClassSchema,
+  ContentSourceSchema,
+  CreatureSchema,
+  ItemSchema,
+  LanguageSchema,
+  SpellSchema,
+  TraitSchema,
+  VersatileHeritageSchema,
+} from '../../src/schemas/content';
+import { formatZodError } from '../../src/schemas/shared';
+
+// ─── Targets ─────────────────────────────────────────────────────────────────
+
+interface Target {
+  table: string;
+  schema: z.ZodTypeAny;
+}
+const TARGETS: Record<string, Target> = {
+  trait: { table: 'trait', schema: TraitSchema },
+  item: { table: 'item', schema: ItemSchema },
+  spell: { table: 'spell', schema: SpellSchema },
+  class: { table: 'class', schema: ClassSchema },
+  archetype: { table: 'archetype', schema: ArchetypeSchema },
+  'versatile-heritage': { table: 'versatile_heritage', schema: VersatileHeritageSchema },
+  'class-archetype': { table: 'class_archetype', schema: ClassArchetypeSchema },
+  'ability-block': { table: 'ability_block', schema: AbilityBlockSchema },
+  creature: { table: 'creature', schema: CreatureSchema },
+  ancestry: { table: 'ancestry', schema: AncestrySchema },
+  background: { table: 'background', schema: BackgroundSchema },
+  language: { table: 'language', schema: LanguageSchema },
+  'content-source': { table: 'content_source', schema: ContentSourceSchema },
+};
+
+// ─── Repair rules ────────────────────────────────────────────────────────────
+//
+// A rule mutates a cloned row in place and pushes human-readable notes for every
+// change. Rules must be conservative and reversible-in-spirit; the re-validation
+// gate below is the real safety net — a repaired row that still doesn't validate
+// is never written.
+
+/** Median class HP-per-level across all classes; the safest default for a broken one. */
+const DEFAULT_CLASS_HP_PER_LEVEL = 8;
+
+type Repair = (type: string, row: Record<string, any>, notes: string[]) => void;
+
+const REPAIRS: Repair[] = [
+  // A `setValue MAX_HEALTH_CLASS_PER_LEVEL` with a null value = the class has no HP
+  // per level, so its characters get no class HP (a live bug). Restore a number.
+  // 8 is the PF2e median; flagged so the content owner can adjust if it should differ.
+  function fixNullClassHp(type, row, notes) {
+    if (type !== 'class') return;
+    for (const op of row.operations ?? []) {
+      if (
+        op?.type === 'setValue' &&
+        op?.data?.variable === 'MAX_HEALTH_CLASS_PER_LEVEL' &&
+        (op.data.value === null || op.data.value === undefined)
+      ) {
+        op.data.value = DEFAULT_CLASS_HP_PER_LEVEL;
+        notes.push(
+          `operations[${row.operations.indexOf(op)}].data.value: null → ${DEFAULT_CLASS_HP_PER_LEVEL} ` +
+            `(MAX_HEALTH_CLASS_PER_LEVEL; PF2e median — confirm if this class should differ)`
+        );
+      }
+    }
+  },
+
+  // Empty strings in numeric meta_data fields (attack_bonus, charges.max, starfinder.usage).
+  // These are now nullable in the schema, so "" → null makes them valid and semantically
+  // correct ("no value"). Only touches these specific known-numeric leaves.
+  function fixEmptyNumericMeta(type, row, notes) {
+    if (type !== 'item' || !row.meta_data) return;
+    const md = row.meta_data;
+    const setNull = (obj: any, key: string, path: string) => {
+      if (obj && obj[key] === '') {
+        obj[key] = null;
+        notes.push(`meta_data.${path}: "" → null`);
+      }
+    };
+    setNull(md, 'attack_bonus', 'attack_bonus');
+    if (md.charges) setNull(md.charges, 'max', 'charges.max');
+    if (md.charges) setNull(md.charges, 'current', 'charges.current');
+    if (md.starfinder) setNull(md.starfinder, 'usage', 'starfinder.usage');
+  },
+];
+
+// ─── Supabase access (same single-PAT flow as the auditor) ───────────────────
+
+const PROJECT_REF = process.env.SUPABASE_PROJECT_REF ?? 'fdrjqcyjklatdrmjdnys';
+const PAT = process.env.SUPABASE_PAT;
+const MGMT = 'https://api.supabase.com';
+
+async function resolveDbAccess(): Promise<{ restUrl: string; serviceKey: string }> {
+  if (!PAT) {
+    console.error('Set SUPABASE_PAT. Aborting.');
+    process.exit(2);
+  }
+  const res = await fetch(`${MGMT}/v1/projects/${PROJECT_REF}/api-keys`, {
+    headers: { Authorization: `Bearer ${PAT}`, 'User-Agent': 'wg-content-fix/1.0' },
+  });
+  if (!res.ok) {
+    console.error(`Management API rejected the PAT (HTTP ${res.status}).`);
+    process.exit(2);
+  }
+  const keys = (await res.json()) as Array<{ name: string; api_key: string }>;
+  const serviceKey = keys.find((k) => k.name === 'service_role')?.api_key;
+  if (!serviceKey) {
+    console.error('No service_role key for this project.');
+    process.exit(2);
+  }
+  return { restUrl: `https://${PROJECT_REF}.supabase.co/rest/v1`, serviceKey };
+}
+
+async function fetchRow(db: { restUrl: string; serviceKey: string }, table: string, id: number) {
+  const res = await fetch(`${db.restUrl}/${table}?id=eq.${id}&select=*`, {
+    headers: { apikey: db.serviceKey, Authorization: `Bearer ${db.serviceKey}` },
+  });
+  if (!res.ok) throw new Error(`fetch ${table} id=${id} → HTTP ${res.status}`);
+  const rows = (await res.json()) as Record<string, any>[];
+  return rows[0] ?? null;
+}
+
+async function patchRow(
+  db: { restUrl: string; serviceKey: string },
+  table: string,
+  id: number,
+  patch: Record<string, any>
+) {
+  const res = await fetch(`${db.restUrl}/${table}?id=eq.${id}`, {
+    method: 'PATCH',
+    headers: {
+      apikey: db.serviceKey,
+      Authorization: `Bearer ${db.serviceKey}`,
+      'Content-Type': 'application/json',
+      Prefer: 'return=minimal',
+    },
+    body: JSON.stringify(patch),
+  });
+  if (!res.ok) throw new Error(`PATCH ${table} id=${id} → HTTP ${res.status}: ${await res.text()}`);
+}
+
+// ─── Main ────────────────────────────────────────────────────────────────────
+
+async function main() {
+  const argv = process.argv.slice(2);
+  let type = '';
+  const ids: number[] = [];
+  let apply = false;
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--type') type = argv[++i];
+    else if (argv[i] === '--id') ids.push(parseInt(argv[++i], 10));
+    else if (argv[i] === '--ids') ids.push(...argv[++i].split(',').map((s) => parseInt(s.trim(), 10)));
+    else if (argv[i] === '--apply') apply = true;
+  }
+  const target = TARGETS[type];
+  if (!target || ids.length === 0) {
+    console.error('Usage: --type <contentType> --id <n> [--ids a,b] [--apply]');
+    console.error(`Known types: ${Object.keys(TARGETS).join(', ')}`);
+    process.exit(2);
+  }
+
+  const db = await resolveDbAccess();
+  console.log(`\nRepair — ${type} — ${apply ? 'APPLY (writing)' : 'DRY-RUN'}\n`);
+
+  let fixed = 0;
+  let skipped = 0;
+  for (const id of ids) {
+    const row = await fetchRow(db, target.table, id);
+    if (!row) {
+      console.log(`  ${type} id=${id}: not found`);
+      continue;
+    }
+
+    const before = target.schema.safeParse(row);
+    if (before.success) {
+      console.log(`  ${type} id=${id} "${row.name ?? ''}": already valid, nothing to do`);
+      continue;
+    }
+
+    // Repair a clone, then re-validate.
+    const candidate = structuredClone(row);
+    const notes: string[] = [];
+    for (const repair of REPAIRS) repair(type, candidate, notes);
+
+    const after = target.schema.safeParse(candidate);
+    console.log(`  ${type} id=${id} "${row.name ?? ''}":`);
+    console.log(`    was invalid: ${formatZodError(row, before.error)}`);
+    if (notes.length === 0) {
+      console.log('    no repair rule matched — needs manual review');
+      skipped++;
+      continue;
+    }
+    for (const n of notes) console.log(`    fix: ${n}`);
+    if (!after.success) {
+      console.log(`    STILL invalid after fix — NOT writing: ${formatZodError(candidate, after.error)}`);
+      skipped++;
+      continue;
+    }
+    console.log('    validates after fix ✓');
+
+    // Only write the columns that actually changed.
+    const patch: Record<string, any> = {};
+    for (const key of Object.keys(candidate)) {
+      if (JSON.stringify(candidate[key]) !== JSON.stringify(row[key])) patch[key] = candidate[key];
+    }
+    console.log(`    changed columns: ${Object.keys(patch).join(', ')}`);
+
+    if (apply) {
+      await patchRow(db, target.table, id, patch);
+      // Read back and re-validate to confirm the write landed and is valid.
+      const confirmed = await fetchRow(db, target.table, id);
+      const ok = target.schema.safeParse(confirmed).success;
+      console.log(`    written; re-validated from DB: ${ok ? 'valid ✓' : 'STILL INVALID ✗'}`);
+      fixed++;
+    } else {
+      console.log('    (dry-run — pass --apply to write)');
+      fixed++;
+    }
+  }
+
+  console.log(`\n${apply ? 'Applied' : 'Would fix'}: ${fixed}, skipped (needs review): ${skipped}`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/frontend/src/schemas/content.ts
+++ b/frontend/src/schemas/content.ts
@@ -157,14 +157,14 @@ export interface Item {
     category?: z.infer<typeof ItemMetaCategorySchema> | '';
     group?: z.infer<typeof ItemMetaGroupSchema> | '';
     damage?: { damageType?: string; dice?: number | string; die?: string | null; extra?: string } | null;
-    attack_bonus?: number;
+    attack_bonus?: number | null;
     ac_bonus?: number;
     check_penalty?: number | string;
     speed_penalty?: number | string;
     dex_cap?: number;
     strength?: number | null;
     bulk: { capacity?: number | string; held_or_stowed?: number | string; ignored?: number | string };
-    charges?: { current?: number; max?: number };
+    charges?: { current?: number | null; max?: number | null };
     container_default_items?: { id: number; name: string; quantity: number }[];
     hardness?: number | string;
     hp?: number | string;
@@ -184,17 +184,17 @@ export interface Item {
     };
     starfinder?: {
       capacity?: string;
-      usage?: number;
+      usage?: number | null;
       grade?: 'COMMERCIAL' | 'TACTICAL' | 'ADVANCED' | 'SUPERIOR' | 'ELITE' | 'ULTIMATE' | 'PARAGON' | null;
       slots?: { name: string; id: number; upgrade?: Item }[];
     };
     foundry?: {
       rules?: Record<string, any> | any[];
       tags?: Record<string, any>;
-      bonus?: number;
-      bonus_damage?: number;
+      bonus?: number | null;
+      bonus_damage?: number | null;
       container_id?: string | null;
-      splash_damage?: number;
+      splash_damage?: number | null;
       stack_group?: string;
       items?: Record<string, any>[];
     };
@@ -248,7 +248,7 @@ export const ItemSchema: z.ZodType<Item> = z.lazy(() =>
           })
           .nullable()
           .optional(),
-        attack_bonus: z.number().optional(),
+        attack_bonus: z.number().nullable().optional(),
         ac_bonus: z.number().optional(),
         check_penalty: z.union([z.number(), z.string()]).optional(),
         speed_penalty: z.union([z.number(), z.string()]).optional(),
@@ -261,8 +261,8 @@ export const ItemSchema: z.ZodType<Item> = z.lazy(() =>
         }),
         charges: z
           .object({
-            current: z.number().optional(),
-            max: z.number().optional(),
+            current: z.number().nullable().optional(),
+            max: z.number().nullable().optional(),
           })
           .optional(),
         container_default_items: z
@@ -299,7 +299,7 @@ export const ItemSchema: z.ZodType<Item> = z.lazy(() =>
         starfinder: z
           .object({
             capacity: z.string().optional(),
-            usage: z.number().optional(),
+            usage: z.number().nullable().optional(),
             grade: z
               .enum(['COMMERCIAL', 'TACTICAL', 'ADVANCED', 'SUPERIOR', 'ELITE', 'ULTIMATE', 'PARAGON'])
               .optional()
@@ -319,10 +319,10 @@ export const ItemSchema: z.ZodType<Item> = z.lazy(() =>
           .object({
             rules: z.union([z.record(z.string(), z.any()), z.array(z.any())]).optional(),
             tags: z.record(z.string(), z.any()).optional(),
-            bonus: z.number().optional(),
-            bonus_damage: z.number().optional(),
+            bonus: z.number().nullable().optional(),
+            bonus_damage: z.number().nullable().optional(),
             container_id: z.string().nullable().optional(),
-            splash_damage: z.number().optional(),
+            splash_damage: z.number().nullable().optional(),
             stack_group: z.string().optional(),
             items: z.array(z.record(z.string(), z.any())).optional(),
           })


### PR DESCRIPTION
Acts on what the content audit ([#261](https://github.com/wanderers-guide/wanderers-guide/pull/261)) found, splitting each finding into the right kind of fix — schema (code) vs data (DB write). Stacked on #261.

## Schema fix — item `meta_data` nullable numerics

`ItemSchema.meta_data` numeric leaves that legitimately store `null` now accept it: `attack_bonus`, `charges.current/max`, `starfinder.usage`, `foundry.bonus/bonus_damage/splash_damage`. Interface and Zod kept in sync. Purely more-permissive — typecheck clean, item drawer renders clean, no `[CONTENT-SCHEMA]` warnings.

## New tool — `npm run fix:content` (the write half)

Fetch one row → apply the registered repair rules for its type → re-validate against the app's Zod schema → show the exact diff → **only with `--apply`** PATCH the changed columns, then re-read and re-validate from the DB.

**Guarantee:** a row is written only if it *fully validates after the repair*, and only changed columns are sent — a fix can never leave a row worse than the auditor found it. Repair rules live in a small `REPAIRS` registry; the re-validation gate is the real safety net.

```bash
SUPABASE_PAT=sbp_... npm run fix:content -- --type class --id 160          # dry-run
SUPABASE_PAT=sbp_... npm run fix:content -- --type class --id 160 --apply  # write + re-verify
```

## Applied to prod with this tool (each re-validated from the DB)

- **class Sanguivate (#160)**: `setValue MAX_HEALTH_CLASS_PER_LEVEL` was `null` — the class gave its characters no class HP (a live bug). Repaired to 8 (PF2e median; flagged for the owner to confirm). **`class` table → 110/110 valid.**
- **14 items**: empty-string `attack_bonus`/`charges.max` → null. **`item` table 8603 → 8621 valid.**

The 5 remaining item failures are stale embedded `base_item_content` snapshots — grouped with the creature embedded-snapshot work below.

## Deferred (tracked, not bundled here)

- **Creature schema**: failures are dominated by embedded *partial* snapshots — `inventory.items[].item` and `abilities_base[]`. `InventoryItem` is shared with characters, so tolerating creature snapshots ripples across the sheet/encounters/PDF/operations (~31 consumer edits). Needs its own PR + full app verification. (I verified the modeling: `character.*` combat columns are NOT NULL, `creature.*` are nullable.)
- **6 malformed `select` operations** (4 ability-block, 2 background): a junk `optionsFilters.value:{value:null}` and options mislabeled `ADJ_VALUE` that are really `CUSTOM`. Repairing correctly needs operation-model judgment — writing wrong operation data to prod is riskier than leaving 6 rows.

## Verification

Frontend typecheck clean; full audit re-run confirms class 110/110 and item 8621/8626; public sheet + item drawer render with no new console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)