### PR TITLE
feat(scripts): simple content Zod validator

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -36,3 +36,6 @@ bun.lockb
 # Test data
 public_user.csv
 cypress/screenshots
+
+# validate-content build output
+scripts/.dist/

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,8 @@
     "cy:open": "cypress open",
     "cy:run": "cypress run",
     "cy:e2e": "CYPRESS_BASE_URL=http://localhost:3000 CYPRESS_TEST_EMAIL=test@wanderersguide.app CYPRESS_TEST_PASSWORD=test1234 cypress run",
-    "cy:e2e:open": "CYPRESS_BASE_URL=http://localhost:3000 CYPRESS_TEST_EMAIL=test@wanderersguide.app CYPRESS_TEST_PASSWORD=test1234 cypress open"
+    "cy:e2e:open": "CYPRESS_BASE_URL=http://localhost:3000 CYPRESS_TEST_EMAIL=test@wanderersguide.app CYPRESS_TEST_PASSWORD=test1234 cypress open",
+    "validate:content": "esbuild scripts/validate-content.ts --bundle --platform=node --format=esm --target=node20 --outfile=scripts/.dist/validate.mjs && node scripts/.dist/validate.mjs"
   },
   "dependencies": {
     "@mantine/carousel": "^9.0.0",

--- a/frontend/scripts/validate-content.ts
+++ b/frontend/scripts/validate-content.ts
@@ -1,0 +1,90 @@
+/**
+ * Validate a JSON object against a Wanderer's Guide content Zod schema.
+ *
+ * Pass the content type as the first argument and the JSON on stdin, or give a
+ * file path as the second argument. Prints VALID, or INVALID plus the Zod errors
+ * (same formatting the app logs). If the JSON is an array, each element is checked.
+ *
+ * Exit code: 0 = all valid, 1 = something invalid, 2 = bad usage / unparseable JSON.
+ *
+ *   echo '{"id":1, ...}' | npm run validate:content -- spell
+ *   npm run validate:content -- spell ./some-spell.json
+ */
+
+import { z } from 'zod';
+import {
+  AbilityBlockSchema,
+  AncestrySchema,
+  ArchetypeSchema,
+  BackgroundSchema,
+  ClassArchetypeSchema,
+  ClassSchema,
+  ContentSourceSchema,
+  CreatureSchema,
+  ItemSchema,
+  LanguageSchema,
+  SpellSchema,
+  TraitSchema,
+  VersatileHeritageSchema,
+} from '../src/schemas/content';
+import { formatZodError } from '../src/schemas/shared';
+import { readFileSync } from 'node:fs';
+
+const SCHEMAS: Record<string, z.ZodTypeAny> = {
+  trait: TraitSchema,
+  item: ItemSchema,
+  spell: SpellSchema,
+  class: ClassSchema,
+  archetype: ArchetypeSchema,
+  'versatile-heritage': VersatileHeritageSchema,
+  'class-archetype': ClassArchetypeSchema,
+  'ability-block': AbilityBlockSchema,
+  creature: CreatureSchema,
+  ancestry: AncestrySchema,
+  background: BackgroundSchema,
+  language: LanguageSchema,
+  'content-source': ContentSourceSchema,
+};
+
+const type = process.argv[2];
+const file = process.argv[3];
+const schema = SCHEMAS[type];
+
+if (!schema) {
+  console.error('Usage: validate:content <type> [file.json]   (JSON is read from stdin if no file)');
+  console.error(`Types: ${Object.keys(SCHEMAS).join(', ')}`);
+  process.exit(2);
+}
+
+let raw: string;
+try {
+  // fd 0 = stdin, so `echo '{...}' | ... ` works with no file argument.
+  raw = readFileSync(file ?? 0, 'utf8');
+} catch (e) {
+  console.error(`Could not read ${file ?? 'stdin'}: ${(e as Error).message}`);
+  process.exit(2);
+}
+
+let data: unknown;
+try {
+  data = JSON.parse(raw);
+} catch (e) {
+  console.error(`Not valid JSON: ${(e as Error).message}`);
+  process.exit(2);
+}
+
+const items = Array.isArray(data) ? data : [data];
+let anyInvalid = false;
+
+items.forEach((item, i) => {
+  const label = Array.isArray(data) ? `[${i}] ` : '';
+  const result = schema.safeParse(item);
+  if (result.success) {
+    console.log(`${label}VALID`);
+  } else {
+    anyInvalid = true;
+    console.log(`${label}INVALID: ${formatZodError(item, result.error)}`);
+  }
+});
+
+process.exit(anyInvalid ? 1 : 0);


### PR DESCRIPTION
Two things for keeping content data valid against the app's Zod schemas:

## 1. The validator — `npm run validate:content`

A tiny, executable script (`frontend/scripts/validate-content.ts`): pipe it a JSON object (or give a file path) plus a content type, and it tells you if it passes the app's Zod schema, and if not, exactly which fields failed.

```bash
echo '{"id":1, ...}' | npm run validate:content -- spell
npm run validate:content -- item ./some-item.json
```

- Reads JSON from stdin or a file; validates a single object or each element of an array.
- Prints `VALID`, or `INVALID: <field errors>` (same `formatZodError` the app uses).
- Exit code 0 (valid) / 1 (invalid) / 2 (bad usage) so it's scriptable.
- No database, no writes, no AI — just runs the object through the schema.

## 2. The `/fix-content-issues` command

A Claude slash command (`.claude/commands/fix-content-issues.md`) that codifies the repeatable content-data-fix workflow around the validator: sweep every content table through it, classify each failure as a schema fix (code) vs a data fix (DB), and repair data issues safely — **validate before every write, re-validate from the DB after**, fix toward canonical working rows, and defer game-balance/semantic judgment calls to the content author instead of guessing. Optionally scoped: `/fix-content-issues item,ability-block`.

Replaces the heavier audit/fix tooling (PRs #261 and #262, now closed) with this validator + workflow-command pairing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)