### PR TITLE
perf(search): collapse the spotlight's serial request waterfall (+ 9h content cache TTL)

### DIFF
--- a/frontend/src/auth/user-manager.ts
+++ b/frontend/src/auth/user-manager.ts
@@ -1,8 +1,20 @@
 import { makeRequest } from '@requests/request-manager';
 import { PublicUser } from '@schemas/content';
+import { supabase } from '../supabase-client';
 
 export async function getPublicUser(id?: string) {
   try {
+    if (!id) {
+      // Fetching "the current user" without a session always resolves to null, but it
+      // still cost a full get-user round-trip — and hot paths (e.g. fetchContentSources
+      // during spotlight search) call this on every invocation, so signed-out visitors
+      // paid it repeatedly. getSession() is a local storage read when signed out, so
+      // this short-circuit is free; signed-in behavior is unchanged.
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+      if (!session) return null;
+    }
     const user = await makeRequest<PublicUser>(
       'get-user',
       {

--- a/frontend/src/nav/SearchSpotlight.tsx
+++ b/frontend/src/nav/SearchSpotlight.tsx
@@ -25,7 +25,7 @@ import {
   IconSwords,
   IconUsers,
 } from '@tabler/icons-react';
-import { AbilityBlockType, Character, ContentType, Creature, Item } from '@schemas/content';
+import { AbilityBlockType, Character, ContentSource, ContentType, Creature, Item } from '@schemas/content';
 import { DrawerType } from '@schemas/index';
 import { isPlayable } from '@utils/character';
 import { determineCompanionType } from '@utils/creature';
@@ -40,6 +40,35 @@ import { useAtom, useAtomValue } from 'jotai';
 import stripMd from 'remove-markdown';
 
 const MAX_QUERY_LENGTH = 100;
+
+// ---- Spotlight request memos ----
+// The spotlight re-runs its whole pipeline every time the (debounced) query settles,
+// but only the content search actually depends on the query text. The accessible
+// content sources and the user's character list don't change while someone types, so
+// memoize them briefly — otherwise every keystroke-settled search paid for a get-user
+// + find-content-source resolution and a full find-character fetch on top of the
+// actual search request, all serially (multi-second searches).
+const SPOTLIGHT_MEMO_TTL_MS = 1000 * 60; // 1 min
+
+let sourcesMemo: { key: string; fetchedAt: number; promise: Promise<ContentSource[]> } | null = null;
+function fetchSpotlightSources(): Promise<ContentSource[]> {
+  // Key on the resolved default-sources value: opening a sheet/builder redefines the
+  // default sources, and a stale memo would search the wrong content set.
+  const key = JSON.stringify(getDefaultSources('INFO'));
+  const now = Date.now();
+  if (sourcesMemo && sourcesMemo.key === key && now - sourcesMemo.fetchedAt < SPOTLIGHT_MEMO_TTL_MS) {
+    return sourcesMemo.promise;
+  }
+  const promise = fetchContentSources(getDefaultSources('INFO')).then((sources) => {
+    // Never memoize a failed/empty resolution — that would blank search for a minute.
+    if (sources.length === 0) sourcesMemo = null;
+    return sources;
+  });
+  sourcesMemo = { key, fetchedAt: now, promise };
+  return promise;
+}
+
+let characterMemo: { userId: string; fetchedAt: number; characters: Character[] } | null = null;
 
 export default function SearchSpotlight() {
   const theme = useMantineTheme();
@@ -279,9 +308,16 @@ async function activateQueryPipeline(
   const query = (rawQuery.length > MAX_QUERY_LENGTH ? rawQuery.slice(0, MAX_QUERY_LENGTH) : rawQuery).trim();
   let actions: SpotlightActionData[] = [];
   if (query && query.length >= 3) {
-    actions = [...actions, ...(await queryResults(query, openDrawer, openCreatureDrawer, theme))];
-    actions = [...actions, ...(await fetchBooks(query, openDrawer, theme))];
-    actions = [...actions, ...(await fetchCharacters(query, navigate, theme, session))];
+    // These three lookups are independent — run them concurrently. They used to run
+    // serially, so every search paid content search + books + characters back-to-back,
+    // which (with the per-request source/user resolution) is what made spotlight
+    // results take multiple seconds to appear.
+    const [contentActions, bookActions, characterActions] = await Promise.all([
+      queryResults(query, openDrawer, openCreatureDrawer, theme),
+      fetchBooks(query, openDrawer, theme),
+      fetchCharacters(query, navigate, theme, session),
+    ]);
+    actions = [...actions, ...contentActions, ...bookActions, ...characterActions];
     // Add more here.
 
     // Put exact matches first and preserve order of other results.
@@ -325,8 +361,8 @@ async function queryResults(
 
   // Traditional search
   const queryDbSearch = async () => {
-    // Gets the current default sources
-    const sources = await fetchContentSources(getDefaultSources('INFO'));
+    // Gets the current default sources (memoized — see fetchSpotlightSources)
+    const sources = await fetchSpotlightSources();
 
     // Fetch search results
     const searchData =
@@ -410,7 +446,7 @@ async function fetchBooks(
   openDrawer: DrawerStateSet,
   theme: MantineTheme
 ): Promise<SpotlightActionData[]> {
-  const sources = await fetchContentSources(getDefaultSources('INFO'));
+  const sources = await fetchSpotlightSources();
   return sources.map((source) => {
     return {
       id: `content-source-${source.id}`,
@@ -439,13 +475,33 @@ async function fetchCharacters(
   theme: MantineTheme,
   session: Session | null
 ): Promise<SpotlightActionData[]> {
-  const characters = await makeRequest<Character[]>(
-    'find-character',
-    {
-      user_id: session?.user.id,
-    },
-    false
-  );
+  // Signed-out visitors have no characters — skip the request entirely. This used to
+  // fire find-character with user_id undefined on every search, which drops the filter
+  // and runs an unfiltered RLS-scoped scan (measured at 3+ seconds) to return nothing.
+  if (!session) return [];
+
+  let characters: Character[] | null = null;
+  const now = Date.now();
+  if (
+    characterMemo &&
+    characterMemo.userId === session.user.id &&
+    now - characterMemo.fetchedAt < SPOTLIGHT_MEMO_TTL_MS
+  ) {
+    characters = characterMemo.characters;
+  } else {
+    characters = await makeRequest<Character[]>(
+      'find-character',
+      {
+        user_id: session.user.id,
+      },
+      false
+    );
+    // Only memoize successful fetches; a transient failure shouldn't hide the
+    // user's characters from search results for a whole minute.
+    if (characters) {
+      characterMemo = { userId: session.user.id, fetchedAt: now, characters };
+    }
+  }
   return (characters ?? []).map((character) => {
     const level = getEntityLevel(character);
     const heritage = ''; //character.details?.heritage?.name ?? '';

--- a/frontend/src/process/content/content-store.ts
+++ b/frontend/src/process/content/content-store.ts
@@ -147,7 +147,7 @@ const CONTENT_CACHE_KEY = 'content-store';
 const CONTENT_CACHE_VERSION = 1;
 // How long a persisted cache is trusted before it's dropped and re-fetched. Content changes
 // rarely; this bounds how stale a cached client can be (and resetContentStore() clears it on demand).
-const CONTENT_CACHE_TTL_MS = 1000 * 60 * 60 * 24; // 24h
+const CONTENT_CACHE_TTL_MS = 1000 * 60 * 60 * 9; // 9h
 
 type PersistedContentCache = {
   version: number;


### PR DESCRIPTION
## Problem

Spotlight searches took multiple seconds. A measured signed-out search for "fireball" ran this fully serial waterfall (plus the 400ms input debounce):

| Request | Duration | Why it existed |
|---|---|---|
| get-user | 852ms | sources resolution calls getPublicUser(), which never caches a signed-out null |
| search-data | 529ms | the actual search |
| get-user (again) | 275ms | fetchBooks re-resolves sources, same uncached call |
| find-character | 3,222ms | fired with user_id undefined: the filter drops, an unfiltered RLS-scoped scan runs, and it ends in an HTTP 400 |

Total: ~4.9s of network per settled keystroke.

The DB layer is NOT the bottleneck: every content table has a search_tsv GIN index and pg_stat_statements shows the search queries at 3-13ms mean. No search-engine change (e.g. Elasticsearch) is warranted.

## Changes

**SearchSpotlight.tsx**
- Run the three pipeline stages (content search, books, characters) concurrently instead of serially
- Memoize the spotlight's source resolution for 60s, keyed on the resolved default-sources value (a sheet/builder redefining sources invalidates it); empty resolutions are never memoized
- Memoize the character list for 60s; failed fetches are never memoized
- Skip find-character entirely when signed out

**user-manager.ts**
- getPublicUser() short-circuits to null when there is no session (local getSession check, no network). Signed-in behavior is unchanged.

**content-store.ts** (separate commit)
- Persisted content cache TTL lowered from 24h to 9h, so server-side content changes (e.g. Discord-approved content updates) reach cached clients within 9 hours instead of a full day.

## After

One request (search-data) per search, ~0.5-1s to results. Verified in the browser against prod APIs: the waterfall is gone, results render correctly (exact match first), and `tsc` passes.

## Notes

- Server-side search-data still fans out into 12 REST calls internally; under peak load its p90 is ~1.7s. If slowness complaints persist after this ships, collapsing those into a single Postgres RPC is the next lever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)