### PR TITLE
perf(pwa): stop wiping cache + service worker on every load

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -25,19 +25,36 @@ const queryClient = new QueryClient();
 // depends on (e.g. the request manager) can import it without a circular dependency.
 export { supabase };
 
-// Fixes cache issues on refresh
+// One-time legacy cache cleanup.
+//
+// Earlier builds cleared ALL Cache Storage and unregistered the service worker on EVERY
+// load. That defeated the workbox precache entirely, so the ~10 MB app bundle was
+// re-downloaded from the network on every single visit. We keep a one-shot version of that
+// cleanup so any client still carrying a stale SW / cache from that era gets flushed once,
+// then never again — after that the precache (revisioned, with cleanupOutdatedCaches)
+// serves instantly and handles per-deploy invalidation itself.
 (async () => {
-  // Clear the cache on startup
-  const keys = await caches.keys();
-  for (const key of keys) {
-    caches.delete(key);
+  const LEGACY_FLUSH_KEY = 'wg-legacy-cache-flushed-v1';
+  try {
+    if (localStorage.getItem(LEGACY_FLUSH_KEY)) return;
+  } catch {
+    return; // storage unavailable (private mode) — skip rather than wipe every load
   }
-
-  // Unregister our service worker
-  if ('serviceWorker' in navigator) {
-    navigator.serviceWorker.ready.then(async (registration) => {
-      const result = await registration.unregister();
-    });
+  try {
+    const keys = await caches.keys();
+    await Promise.all(keys.map((key) => caches.delete(key)));
+    if ('serviceWorker' in navigator) {
+      const registrations = await navigator.serviceWorker.getRegistrations();
+      await Promise.all(registrations.map((r) => r.unregister()));
+    }
+  } catch {
+    // best-effort; don't block app startup on cleanup
+  } finally {
+    try {
+      localStorage.setItem(LEGACY_FLUSH_KEY, '1');
+    } catch {
+      /* ignore */
+    }
   }
 })();
 


### PR DESCRIPTION
## Problem

`main.tsx` cleared all Cache Storage and unregistered the service worker on **every** page load. That completely defeated the workbox precache — the ~10 MB app bundle (3.9 MB gzipped) was re-downloaded from the network on every single visit, and the PWA never actually functioned.

## Fix

Run that cleanup **once per browser** (guarded by a `localStorage` flag) so any client still carrying a stale SW/cache from that era gets flushed a single time, then let the precache serve on subsequent loads. Workbox already handles per-deploy invalidation (revisioned precache + `cleanupOutdatedCaches`, `registerType: 'prompt'`), so the every-load wipe was pure overhead. The cleanup is now also best-effort and skips when storage is unavailable (private mode) instead of wiping every load.

## Validation

`tsc` passes. The steady-state PWA behavior is unchanged (workbox owns it); this only stops the redundant per-load wipe. The full returning-visitor speedup and cross-deploy update behavior become observable once this is deployed to prod — worth a quick check that a returning visit no longer refetches the whole bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)