### PR TITLE
fix(drawers): error + retry instead of infinite spinner on failed loads

### DIFF
--- a/frontend/src/drawers/DrawerLoadState.tsx
+++ b/frontend/src/drawers/DrawerLoadState.tsx
@@ -1,0 +1,68 @@
+import { Box, Button, Loader, Stack, Text } from '@mantine/core';
+import { IconRefresh } from '@tabler/icons-react';
+
+/**
+ * Shared load/failure state for content drawers.
+ *
+ * Content drawers fetch their record by id and, until this component, rendered a bare
+ * <Loader> whenever the record was falsy. But `makeRequest` returns `null` on a failed
+ * fetch (network/timeout/HTTP error), which react-query treats as a *successful* query
+ * with null data — so `isError` never fired and the drawer spun forever with a blank
+ * title, no error, and no way to retry. That was the single most common dead-end when
+ * reading game content.
+ *
+ * Rendering this instead distinguishes the two cases by the query's fetching state:
+ *  - still fetching  -> the spinner (unchanged from before)
+ *  - settled + empty -> a short message and a Retry button (calls the query's refetch)
+ *
+ * Pass the query's `isFetching` as `loading` and its `refetch` as `onRetry`.
+ */
+export default function DrawerLoadState(props: { loading: boolean; onRetry?: () => void }) {
+  if (props.loading) {
+    return (
+      <Loader
+        type='bars'
+        style={{
+          position: 'absolute',
+          top: '35%',
+          left: '50%',
+          transform: 'translate(-50%, -50%)',
+        }}
+      />
+    );
+  }
+
+  return (
+    <Box
+      style={{
+        position: 'absolute',
+        top: '35%',
+        left: '50%',
+        transform: 'translate(-50%, -50%)',
+        width: '80%',
+        maxWidth: 320,
+      }}
+    >
+      <Stack align='center' gap={8}>
+        <Text ta='center' fw={600}>
+          Couldn’t load this content
+        </Text>
+        <Text ta='center' size='sm' c='dimmed'>
+          Something went wrong fetching it. Check your connection and try again.
+        </Text>
+        {props.onRetry && (
+          <Button
+            variant='light'
+            size='compact-sm'
+            radius='xl'
+            mt={4}
+            leftSection={<IconRefresh size='0.9rem' />}
+            onClick={() => props.onRetry?.()}
+          >
+            Retry
+          </Button>
+        )}
+      </Stack>
+    </Box>
+  );
+}

--- a/frontend/src/drawers/types/ActionDrawer.tsx
+++ b/frontend/src/drawers/types/ActionDrawer.tsx
@@ -18,6 +18,7 @@ import {
   sortObjectByName,
 } from '@operations/operation-utils';
 import { useQuery } from '@tanstack/react-query';
+import DrawerLoadState from '@drawers/DrawerLoadState';
 import { AbilityBlock } from '@schemas/content';
 import { Operation, OperationSelect, OperationSelectFilters, OperationSelectOptionCustom } from '@schemas/operations';
 import { toLabel } from '@utils/strings';
@@ -32,7 +33,7 @@ export function ActionDrawerTitle(props: { data: { id?: number; action?: Ability
 
   const [_drawer, openDrawer] = useAtom(drawerState);
 
-  const { data: _action } = useQuery({
+  const { data: _action, isFetching, refetch } = useQuery({
     queryKey: [`find-action-${id}`, { id }],
     queryFn: async ({ queryKey }) => {
       // @ts-ignore
@@ -81,7 +82,7 @@ export function ActionDrawerTitle(props: { data: { id?: number; action?: Ability
 export function ActionDrawerContent(props: { data: { id?: number; action?: AbilityBlock; showOperations?: boolean } }) {
   const id = props.data.id;
 
-  const { data: _action } = useQuery({
+  const { data: _action, isFetching, refetch } = useQuery({
     queryKey: [`find-action-${id}`, { id }],
     queryFn: async ({ queryKey }) => {
       // @ts-ignore
@@ -95,15 +96,7 @@ export function ActionDrawerContent(props: { data: { id?: number; action?: Abili
 
   if (!action) {
     return (
-      <Loader
-        type='bars'
-        style={{
-          position: 'absolute',
-          top: '35%',
-          left: '50%',
-          transform: 'translate(-50%, -50%)',
-        }}
-      />
+      <DrawerLoadState loading={isFetching} onRetry={refetch} />
     );
   }
 

--- a/frontend/src/drawers/types/AncestryDrawer.tsx
+++ b/frontend/src/drawers/types/AncestryDrawer.tsx
@@ -30,6 +30,7 @@ import { IMPRINT_BG_COLOR, IMPRINT_BORDER_COLOR } from '@constants/data';
 import { addedAncestryLanguages, getAdjustedAncestryOperations } from '@operations/operation-controller';
 import { IconChevronsDown, IconChevronsUp, IconHelpCircle } from '@tabler/icons-react';
 import { useQuery } from '@tanstack/react-query';
+import DrawerLoadState from '@drawers/DrawerLoadState';
 import { AbilityBlock, Ancestry, Character, Language } from '@schemas/content';
 import { DrawerType } from '@schemas/index';
 import { OperationResult } from '@schemas/operations';
@@ -46,7 +47,7 @@ export function AncestryDrawerTitle(props: { data: { id?: number; ancestry?: Anc
 
   const [_drawer, openDrawer] = useAtom(drawerState);
 
-  const { data: _ancestry } = useQuery({
+  const { data: _ancestry, isFetching, refetch } = useQuery({
     queryKey: [`find-ancestry-${id}`, { id }],
     queryFn: async ({ queryKey }) => {
       // @ts-ignore
@@ -94,7 +95,7 @@ export function AncestryDrawerContent(props: {
 }) {
   const id = props.data.id;
 
-  const { data } = useQuery({
+  const { data, isFetching, refetch } = useQuery({
     queryKey: [`find-ancestry-details-${id}`, { id }],
     queryFn: async ({ queryKey }) => {
       // @ts-ignore
@@ -174,15 +175,7 @@ export function AncestryDrawerContent(props: {
 
   if (!data || !data.ancestry || !data.abilityBlocks) {
     return (
-      <Loader
-        type='bars'
-        style={{
-          position: 'absolute',
-          top: '35%',
-          left: '50%',
-          transform: 'translate(-50%, -50%)',
-        }}
-      />
+      <DrawerLoadState loading={isFetching} onRetry={refetch} />
     );
   }
 

--- a/frontend/src/drawers/types/ArchetypeDrawer.tsx
+++ b/frontend/src/drawers/types/ArchetypeDrawer.tsx
@@ -20,6 +20,7 @@ import {
   Title,
 } from '@mantine/core';
 import { useQuery } from '@tanstack/react-query';
+import DrawerLoadState from '@drawers/DrawerLoadState';
 import { AbilityBlock, Archetype } from '@schemas/content';
 import { groupBy } from 'lodash-es';
 import { useState } from 'react';
@@ -30,7 +31,7 @@ export function ArchetypeDrawerTitle(props: { data: { id?: number; archetype?: A
 
   const [_drawer, openDrawer] = useAtom(drawerState);
 
-  const { data: _archetype } = useQuery({
+  const { data: _archetype, isFetching, refetch } = useQuery({
     queryKey: [`find-archetype-${id}`, { id }],
     queryFn: async ({ queryKey }) => {
       // @ts-ignore
@@ -78,7 +79,7 @@ export function ArchetypeDrawerContent(props: {
 }) {
   const id = props.data.id;
 
-  const { data } = useQuery({
+  const { data, isFetching, refetch } = useQuery({
     queryKey: [`find-archetype-details-${id}`, { id }],
     queryFn: async ({ queryKey }) => {
       // @ts-ignore
@@ -153,15 +154,7 @@ export function ArchetypeDrawerContent(props: {
 
   if (!data || !data.archetype || !data.abilityBlocks) {
     return (
-      <Loader
-        type='bars'
-        style={{
-          position: 'absolute',
-          top: '35%',
-          left: '50%',
-          transform: 'translate(-50%, -50%)',
-        }}
-      />
+      <DrawerLoadState loading={isFetching} onRetry={refetch} />
     );
   }
 

--- a/frontend/src/drawers/types/BackgroundDrawer.tsx
+++ b/frontend/src/drawers/types/BackgroundDrawer.tsx
@@ -8,6 +8,7 @@ import { Anchor, Box, Button, Group, Image, Loader, Stack, Text, Title, useManti
 import { IMPRINT_BG_COLOR, IMPRINT_BORDER_COLOR } from '@constants/data';
 import { OperationResult } from '@schemas/operations';
 import { useQuery } from '@tanstack/react-query';
+import DrawerLoadState from '@drawers/DrawerLoadState';
 import { Background, Character } from '@schemas/content';
 import { DrawerType } from '@schemas/index';
 import { getStatBlockDisplay } from '@variables/initial-stats-display';
@@ -24,7 +25,7 @@ export function BackgroundDrawerTitle(props: {
 
   const [_drawer, openDrawer] = useAtom(drawerState);
 
-  const { data: _background } = useQuery({
+  const { data: _background, isFetching, refetch } = useQuery({
     queryKey: [`find-background-${id}`, { id }],
     queryFn: async ({ queryKey }) => {
       // @ts-ignore
@@ -72,7 +73,7 @@ export function BackgroundDrawerContent(props: {
 }) {
   const id = props.data.id;
 
-  const { data } = useQuery({
+  const { data, isFetching, refetch } = useQuery({
     queryKey: [`find-background-details-${id}`, { id }],
     queryFn: async ({ queryKey }) => {
       // @ts-ignore
@@ -89,15 +90,7 @@ export function BackgroundDrawerContent(props: {
 
   if (!data || !data.background) {
     return (
-      <Loader
-        type='bars'
-        style={{
-          position: 'absolute',
-          top: '35%',
-          left: '50%',
-          transform: 'translate(-50%, -50%)',
-        }}
-      />
+      <DrawerLoadState loading={isFetching} onRetry={refetch} />
     );
   }
 

--- a/frontend/src/drawers/types/ClassArchetypeDrawer.tsx
+++ b/frontend/src/drawers/types/ClassArchetypeDrawer.tsx
@@ -23,6 +23,7 @@ import {
 } from '@mantine/core';
 import { IconArrowRight, IconCheck } from '@tabler/icons-react';
 import { useQuery } from '@tanstack/react-query';
+import DrawerLoadState from '@drawers/DrawerLoadState';
 import { AbilityBlock, ClassArchetype } from '@schemas/content';
 import { toLabel } from '@utils/strings';
 import { groupBy } from 'lodash-es';
@@ -36,7 +37,7 @@ export function ClassArchetypeDrawerTitle(props: {
 
   const [_drawer, openDrawer] = useAtom(drawerState);
 
-  const { data: _archetype } = useQuery({
+  const { data: _archetype, isFetching, refetch } = useQuery({
     queryKey: [`find-class-archetype-${id}`, { id }],
     queryFn: async ({ queryKey }) => {
       // @ts-ignore
@@ -84,7 +85,7 @@ export function ClassArchetypeDrawerContent(props: {
 }) {
   const id = props.data.id;
 
-  const { data } = useQuery({
+  const { data, isFetching, refetch } = useQuery({
     queryKey: [`find-class-archetype-details-${id}`, { id }],
     queryFn: async ({ queryKey }) => {
       // @ts-ignore
@@ -239,15 +240,7 @@ export function ClassArchetypeDrawerContent(props: {
 
   if (!data || !data.archetype || !data.abilityBlocks) {
     return (
-      <Loader
-        type='bars'
-        style={{
-          position: 'absolute',
-          top: '35%',
-          left: '50%',
-          transform: 'translate(-50%, -50%)',
-        }}
-      />
+      <DrawerLoadState loading={isFetching} onRetry={refetch} />
     );
   }
 

--- a/frontend/src/drawers/types/ClassDrawer.tsx
+++ b/frontend/src/drawers/types/ClassDrawer.tsx
@@ -44,6 +44,7 @@ import {
   IconVocabulary,
 } from '@tabler/icons-react';
 import { useQuery } from '@tanstack/react-query';
+import DrawerLoadState from '@drawers/DrawerLoadState';
 import { AbilityBlock, Character, Class } from '@schemas/content';
 import { OperationSelect } from '@schemas/operations';
 import { getDisplay, getStatBlockDisplay, getStatDisplay } from '@variables/initial-stats-display';
@@ -58,7 +59,7 @@ export function ClassDrawerTitle(props: { data: { id?: number; class_?: Class; o
 
   const [_drawer, openDrawer] = useAtom(drawerState);
 
-  const { data: _class_ } = useQuery({
+  const { data: _class_, isFetching, refetch } = useQuery({
     queryKey: [`find-class-${id}`, { id }],
     queryFn: async ({ queryKey }) => {
       // @ts-ignore
@@ -106,7 +107,7 @@ export function ClassDrawerContent(props: {
 }) {
   const id = props.data.id;
 
-  const { data } = useQuery({
+  const { data, isFetching, refetch } = useQuery({
     queryKey: [`find-class-details-${id}`, { id }],
     queryFn: async ({ queryKey }) => {
       // @ts-ignore
@@ -184,15 +185,7 @@ export function ClassDrawerContent(props: {
 
   if (!data || !data.class_ || !data.abilityBlocks) {
     return (
-      <Loader
-        type='bars'
-        style={{
-          position: 'absolute',
-          top: '35%',
-          left: '50%',
-          transform: 'translate(-50%, -50%)',
-        }}
-      />
+      <DrawerLoadState loading={isFetching} onRetry={refetch} />
     );
   }
 

--- a/frontend/src/drawers/types/ClassFeatureDrawer.tsx
+++ b/frontend/src/drawers/types/ClassFeatureDrawer.tsx
@@ -7,6 +7,7 @@ import { fetchContentById } from '@content/content-store';
 import ShowOperationsButton from '@drawers/ShowOperationsButton';
 import { Title, Text, Image, Loader, Group, Divider, Stack, Box, Flex } from '@mantine/core';
 import { useQuery } from '@tanstack/react-query';
+import DrawerLoadState from '@drawers/DrawerLoadState';
 import { AbilityBlock } from '@schemas/content';
 import { DisplayOperationSelectionOptions } from './ActionDrawer';
 import ShowInjectedText from '@drawers/ShowInjectedText';
@@ -15,7 +16,7 @@ import { DisplayIcon } from '@common/IconDisplay';
 export function ClassFeatureDrawerTitle(props: { data: { id?: number; classFeature?: AbilityBlock } }) {
   const id = props.data.id;
 
-  const { data: _classFeature } = useQuery({
+  const { data: _classFeature, isFetching, refetch } = useQuery({
     queryKey: [`find-class-feature-${id}`, { id }],
     queryFn: async ({ queryKey }) => {
       // @ts-ignore
@@ -51,7 +52,7 @@ export function ClassFeatureDrawerContent(props: {
 }) {
   const id = props.data.id;
 
-  const { data: _classFeature } = useQuery({
+  const { data: _classFeature, isFetching, refetch } = useQuery({
     queryKey: [`find-class-feature-${id}`, { id }],
     queryFn: async ({ queryKey }) => {
       // @ts-ignore
@@ -65,15 +66,7 @@ export function ClassFeatureDrawerContent(props: {
 
   if (!classFeature) {
     return (
-      <Loader
-        type='bars'
-        style={{
-          position: 'absolute',
-          top: '35%',
-          left: '50%',
-          transform: 'translate(-50%, -50%)',
-        }}
-      />
+      <DrawerLoadState loading={isFetching} onRetry={refetch} />
     );
   }
 

--- a/frontend/src/drawers/types/ContentSourceDrawer.tsx
+++ b/frontend/src/drawers/types/ContentSourceDrawer.tsx
@@ -28,6 +28,7 @@ import UnlockHomebrewModal from '@modals/UnlockHomebrewModal';
 import { makeRequest } from '@requests/request-manager';
 import { IconExternalLink } from '@tabler/icons-react';
 import { useQuery } from '@tanstack/react-query';
+import DrawerLoadState from '@drawers/DrawerLoadState';
 import { AbilityBlockType, ContentSource, ContentType } from '@schemas/content';
 import { useEffect, useRef, useState } from 'react';
 import { useAtom } from 'jotai';
@@ -144,7 +145,7 @@ export function ContentSourceDrawerContent(props: {
   const [_creatureDrawer, openCreatureDrawer] = useAtom(creatureDrawerState);
   const [_feedbackData, setFeedbackData] = useAtom(feedbackState);
 
-  const { data: content } = useQuery({
+  const { data: content, isFetching, refetch } = useQuery({
     queryKey: [`find-content-source-package-${id}`, { id, source: props.data.source }],
     queryFn: async ({ queryKey }) => {
       // @ts-ignore
@@ -169,15 +170,7 @@ export function ContentSourceDrawerContent(props: {
 
   if (!content || !source) {
     return (
-      <Loader
-        type='bars'
-        style={{
-          position: 'absolute',
-          top: '35%',
-          left: '50%',
-          transform: 'translate(-50%, -50%)',
-        }}
-      />
+      <DrawerLoadState loading={isFetching} onRetry={refetch} />
     );
   }
 

--- a/frontend/src/drawers/types/CreatureDrawer.tsx
+++ b/frontend/src/drawers/types/CreatureDrawer.tsx
@@ -54,6 +54,7 @@ import {
   IconAlignBoxLeftMiddle,
 } from '@tabler/icons-react';
 import { useQuery } from '@tanstack/react-query';
+import DrawerLoadState from '@drawers/DrawerLoadState';
 import { Creature, OperationCreatureResultPackage, Trait } from '@schemas/content';
 import { getAnchorStyles } from '@utils/anchor';
 import { determineCompanionType, findCreatureTraits } from '@utils/creature';
@@ -70,7 +71,7 @@ import { exportVariableStore } from '@variables/variable-manager';
 export function CreatureDrawerTitle(props: { data: { id?: number; creature?: Creature } }) {
   const id = props.data.id;
 
-  const { data: _creature } = useQuery({
+  const { data: _creature, isFetching, refetch } = useQuery({
     queryKey: [`find-creature-${id}`, { id }],
     queryFn: async ({ queryKey }) => {
       // @ts-ignore
@@ -121,7 +122,7 @@ export function CreatureDrawerContent(props: {
   });
   const view = props.data.readOnly ? 'BLOCK' : drawerData.view;
 
-  const { data: content } = useQuery({
+  const { data: content, isFetching, refetch } = useQuery({
     queryKey: [`find-creature-details-${id}`, { id }],
     queryFn: async ({ queryKey }) => {
       // @ts-ignore
@@ -266,15 +267,7 @@ export function CreatureDrawerContent(props: {
 
   if (loading || !creature || !content) {
     return (
-      <Loader
-        type='bars'
-        style={{
-          position: 'absolute',
-          top: '35%',
-          left: '50%',
-          transform: 'translate(-50%, -50%)',
-        }}
-      />
+      <DrawerLoadState loading={isFetching} onRetry={refetch} />
     );
   }
 

--- a/frontend/src/drawers/types/FeatDrawer.tsx
+++ b/frontend/src/drawers/types/FeatDrawer.tsx
@@ -9,6 +9,7 @@ import { fetchAllPrereqs, fetchContentById } from '@content/content-store';
 import ShowOperationsButton from '@drawers/ShowOperationsButton';
 import { Title, Text, Loader, Group, Divider, Box, Anchor, useMantineTheme, Button } from '@mantine/core';
 import { useQuery } from '@tanstack/react-query';
+import DrawerLoadState from '@drawers/DrawerLoadState';
 import { AbilityBlock } from '@schemas/content';
 import { toLabel } from '@utils/strings';
 import { meetsPrerequisites } from '@variables/prereq-detection';
@@ -24,7 +25,7 @@ export function FeatDrawerTitle(props: { data: { id?: number; feat?: AbilityBloc
 
   const [_drawer, openDrawer] = useAtom(drawerState);
 
-  const { data: _feat } = useQuery({
+  const { data: _feat, isFetching, refetch } = useQuery({
     queryKey: [`find-feat-${id}`, { id }],
     queryFn: async ({ queryKey }) => {
       // @ts-ignore
@@ -86,7 +87,7 @@ export function FeatDrawerContent(props: { data: { id?: number; feat?: AbilityBl
   const character = useAtomValue(characterState);
   const DETECT_PREREQUS = character?.options?.auto_detect_prerequisites ?? false;
 
-  const { data: _feat } = useQuery({
+  const { data: _feat, isFetching, refetch } = useQuery({
     queryKey: [`find-feat-${id}`, { id }],
     queryFn: async ({ queryKey }) => {
       // @ts-ignore
@@ -100,15 +101,7 @@ export function FeatDrawerContent(props: { data: { id?: number; feat?: AbilityBl
 
   if (!feat) {
     return (
-      <Loader
-        type='bars'
-        style={{
-          position: 'absolute',
-          top: '35%',
-          left: '50%',
-          transform: 'translate(-50%, -50%)',
-        }}
-      />
+      <DrawerLoadState loading={isFetching} onRetry={refetch} />
     );
   }
 

--- a/frontend/src/drawers/types/ItemDrawer.tsx
+++ b/frontend/src/drawers/types/ItemDrawer.tsx
@@ -51,6 +51,7 @@ import {
 import { getHotkeyHandler } from '@mantine/hooks';
 import { IconHelpCircle } from '@tabler/icons-react';
 import { useQuery } from '@tanstack/react-query';
+import DrawerLoadState from '@drawers/DrawerLoadState';
 import { Item, ItemMetaGroupArmor, ItemMetaGroupWeapon } from '@schemas/content';
 import { StoreID } from '@schemas/variables';
 import { sign } from '@utils/numbers';
@@ -71,7 +72,7 @@ import { titleCase } from 'title-case';
 export function ItemDrawerTitle(props: { data: { id?: number; item?: Item } }) {
   const id = props.data.id;
 
-  const { data: _item } = useQuery({
+  const { data: _item, isFetching, refetch } = useQuery({
     queryKey: [`find-item-${id}`, { id }],
     queryFn: async ({ queryKey }) => {
       // @ts-ignore
@@ -118,7 +119,7 @@ export function ItemDrawerContent(props: {
   const [_drawer, openDrawer] = useAtom(drawerState);
   const theme = useMantineTheme();
 
-  const { data: _item } = useQuery({
+  const { data: _item, isFetching, refetch } = useQuery({
     queryKey: [`find-item-with-base-${id}`, { id }],
     queryFn: async ({ queryKey }) => {
       // @ts-ignore
@@ -146,15 +147,7 @@ export function ItemDrawerContent(props: {
 
   if (!item) {
     return (
-      <Loader
-        type='bars'
-        style={{
-          position: 'absolute',
-          top: '35%',
-          left: '50%',
-          transform: 'translate(-50%, -50%)',
-        }}
-      />
+      <DrawerLoadState loading={isFetching} onRetry={refetch} />
     );
   }
 

--- a/frontend/src/drawers/types/LanguageDrawer.tsx
+++ b/frontend/src/drawers/types/LanguageDrawer.tsx
@@ -6,12 +6,13 @@ import { fetchContentById } from '@content/content-store';
 import ShowInjectedText from '@drawers/ShowInjectedText';
 import { Title, Text, Image, Loader, Group, Divider, Stack, Box, Flex } from '@mantine/core';
 import { useQuery } from '@tanstack/react-query';
+import DrawerLoadState from '@drawers/DrawerLoadState';
 import { AbilityBlock, Language } from '@schemas/content';
 
 export function LanguageDrawerTitle(props: { data: { id?: number; language?: Language } }) {
   const id = props.data.id;
 
-  const { data: _language } = useQuery({
+  const { data: _language, isFetching, refetch } = useQuery({
     queryKey: [`find-language-${id}`, { id }],
     queryFn: async ({ queryKey }) => {
       // @ts-ignore
@@ -44,7 +45,7 @@ export function LanguageDrawerTitle(props: { data: { id?: number; language?: Lan
 export function LanguageDrawerContent(props: { data: { id?: number; language?: Language } }) {
   const id = props.data.id;
 
-  const { data: _language } = useQuery({
+  const { data: _language, isFetching, refetch } = useQuery({
     queryKey: [`find-language-${id}`, { id }],
     queryFn: async ({ queryKey }) => {
       // @ts-ignore
@@ -58,15 +59,7 @@ export function LanguageDrawerContent(props: { data: { id?: number; language?: L
 
   if (!language) {
     return (
-      <Loader
-        type='bars'
-        style={{
-          position: 'absolute',
-          top: '35%',
-          left: '50%',
-          transform: 'translate(-50%, -50%)',
-        }}
-      />
+      <DrawerLoadState loading={isFetching} onRetry={refetch} />
     );
   }
 

--- a/frontend/src/drawers/types/SpellDrawer.tsx
+++ b/frontend/src/drawers/types/SpellDrawer.tsx
@@ -12,6 +12,7 @@ import { Title, Text, Image, Loader, Group, Divider, Stack, Box, Flex } from '@m
 import { getEntityLevel } from '@utils/entity-utils';
 import { isCantrip, isFocusSpell, isRitual } from '@spells/spell-utils';
 import { useQuery } from '@tanstack/react-query';
+import DrawerLoadState from '@drawers/DrawerLoadState';
 import { AbilityBlock, LivingEntity, Spell } from '@schemas/content';
 import { convertCastToActionCost } from '@utils/actions';
 import { toLabel } from '@utils/strings';
@@ -23,7 +24,7 @@ export function SpellDrawerTitle(props: { data: { id?: number; spell?: Spell; en
   const _character = useAtomValue(characterState);
   const entity = props.data.entity ?? _character;
 
-  const { data: _spell } = useQuery({
+  const { data: _spell, isFetching, refetch } = useQuery({
     queryKey: [`find-spell-${id}`, { id }],
     queryFn: async ({ queryKey }) => {
       // @ts-ignore
@@ -82,7 +83,7 @@ export function SpellDrawerTitle(props: { data: { id?: number; spell?: Spell; en
 export function SpellDrawerContent(props: { data: { id?: number; spell?: Spell } }) {
   const id = props.data.id;
 
-  const { data: _spell } = useQuery({
+  const { data: _spell, isFetching, refetch } = useQuery({
     queryKey: [`find-spell-${id}`, { id }],
     queryFn: async ({ queryKey }) => {
       // @ts-ignore
@@ -96,15 +97,7 @@ export function SpellDrawerContent(props: { data: { id?: number; spell?: Spell }
 
   if (!spell) {
     return (
-      <Loader
-        type='bars'
-        style={{
-          position: 'absolute',
-          top: '35%',
-          left: '50%',
-          transform: 'translate(-50%, -50%)',
-        }}
-      />
+      <DrawerLoadState loading={isFetching} onRetry={refetch} />
     );
   }
 

--- a/frontend/src/drawers/types/TraitDrawer.tsx
+++ b/frontend/src/drawers/types/TraitDrawer.tsx
@@ -7,6 +7,7 @@ import { fetchContentById } from '@content/content-store';
 import ShowInjectedText from '@drawers/ShowInjectedText';
 import { Title, Text, Image, Loader, Group, Divider, Stack, Box, Flex } from '@mantine/core';
 import { useQuery } from '@tanstack/react-query';
+import DrawerLoadState from '@drawers/DrawerLoadState';
 import { AbilityBlock, Trait } from '@schemas/content';
 import { Operation } from '@schemas/operations';
 import { toLabel } from '@utils/strings';
@@ -14,7 +15,7 @@ import { toLabel } from '@utils/strings';
 export function TraitDrawerTitle(props: { data: { id?: number; trait?: Trait } }) {
   const id = props.data.id;
 
-  const { data: _trait } = useQuery({
+  const { data: _trait, isFetching, refetch } = useQuery({
     queryKey: [`find-trait-${id}`, { id }],
     queryFn: async ({ queryKey }) => {
       // @ts-ignore
@@ -45,7 +46,7 @@ export function TraitDrawerTitle(props: { data: { id?: number; trait?: Trait } }
 export function TraitDrawerContent(props: { data: { id?: number; trait?: Trait } }) {
   const id = props.data.id;
 
-  const { data: _trait } = useQuery({
+  const { data: _trait, isFetching, refetch } = useQuery({
     queryKey: [`find-trait-${id}`, { id }],
     queryFn: async ({ queryKey }) => {
       // @ts-ignore
@@ -59,15 +60,7 @@ export function TraitDrawerContent(props: { data: { id?: number; trait?: Trait }
 
   if (!trait) {
     return (
-      <Loader
-        type='bars'
-        style={{
-          position: 'absolute',
-          top: '35%',
-          left: '50%',
-          transform: 'translate(-50%, -50%)',
-        }}
-      />
+      <DrawerLoadState loading={isFetching} onRetry={refetch} />
     );
   }
 

--- a/frontend/src/drawers/types/VersatileHeritageDrawer.tsx
+++ b/frontend/src/drawers/types/VersatileHeritageDrawer.tsx
@@ -20,6 +20,7 @@ import {
   Title,
 } from '@mantine/core';
 import { useQuery } from '@tanstack/react-query';
+import DrawerLoadState from '@drawers/DrawerLoadState';
 import { AbilityBlock, VersatileHeritage } from '@schemas/content';
 import { groupBy } from 'lodash-es';
 import { useState } from 'react';
@@ -32,7 +33,7 @@ export function VersatileHeritageDrawerTitle(props: {
 
   const [_drawer, openDrawer] = useAtom(drawerState);
 
-  const { data: _versatileHeritage } = useQuery({
+  const { data: _versatileHeritage, isFetching, refetch } = useQuery({
     queryKey: [`find-versatile-heritage-${id}`, { id }],
     queryFn: async ({ queryKey }) => {
       // @ts-ignore
@@ -80,7 +81,7 @@ export function VersatileHeritageDrawerContent(props: {
 }) {
   const id = props.data.id;
 
-  const { data } = useQuery({
+  const { data, isFetching, refetch } = useQuery({
     queryKey: [`find-versatileHeritage-details-${id}`, { id }],
     queryFn: async ({ queryKey }) => {
       // @ts-ignore
@@ -153,15 +154,7 @@ export function VersatileHeritageDrawerContent(props: {
 
   if (!data || !data.versatileHeritage || !data.abilityBlocks) {
     return (
-      <Loader
-        type='bars'
-        style={{
-          position: 'absolute',
-          top: '35%',
-          left: '50%',
-          transform: 'translate(-50%, -50%)',
-        }}
-      />
+      <DrawerLoadState loading={isFetching} onRetry={refetch} />
     );
   }
 


### PR DESCRIPTION
## Problem

Content drawers fetch their record by id and rendered a bare `<Loader>` whenever the record was falsy. But `makeRequest` returns `null` on a failed fetch (network/timeout/HTTP error), which react-query treats as a **successful** query with null data — so `isError` never fired and the drawer spun **forever** with a blank title, no error, and no way to retry. This is the most common dead-end when reading game content (~15 drawer types: spell, item, feat, action, class-feature, trait, ancestry, background, class, creature, archetype, language, versatile-heritage, class-archetype, content-source).

## Fix

A shared `DrawerLoadState` distinguishes the two cases by the query's fetching state:
- **still fetching** → the spinner (unchanged from before)
- **settled + empty** → a short message and a **Retry** button (calls the query's `refetch`)

Each drawer passes its content query's `isFetching`/`refetch`. The happy path is unchanged **by construction** — the new branch only renders when the record is absent, which was already a dead spinner, so a working drawer can't regress.

## Validation

- `tsc` passes across all 15 drawers + the new component.
- Driven in the browser: a **bogus id** (`link_spell_99999999`) now shows "Couldn't load this content" + Retry instead of spinning forever; a **valid spell** still renders its full content (Fireball's damage, heightening, traits, etc.).

Note: the "Loading…" text in the drawer's title strip is a separate pre-existing DrawerBase title fallback (untouched here) — the content area, which this fixes, now resolves correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)