### PR TITLE
perf(images): lazy-load the image-picker grid (P8)

### DIFF
--- a/frontend/src/modals/SelectImageModal.tsx
+++ b/frontend/src/modals/SelectImageModal.tsx
@@ -42,7 +42,14 @@ export default function SelectImageModal({
             context.closeModal(id);
           }}
         >
-          <Avatar src={option.url} size={115} radius={'md'} />
+          {/* Grid of remote images: defer the off-screen ones and decode off the main
+              thread so opening the picker doesn't fetch/decode every option at once. */}
+          <Avatar
+            src={option.url}
+            size={115}
+            radius={'md'}
+            imageProps={{ loading: 'lazy', decoding: 'async' }}
+          />
         </UnstyledButton>
       </HoverCard.Target>
       <HoverCard.Dropdown py={5} px={10}>


### PR DESCRIPTION
`SelectImageModal` renders a `SimpleGrid` of remote portrait/background options as Avatars; opening it fetched + decoded every option at once. Added `loading=lazy` + `decoding=async` via Mantine Avatar's `imageProps`.

**Scope note (honesty):** this is the only genuine remote-image grid in the app. The audit's P8 assumed big remote-image lists (portraits, item art), but in practice the app's images are small **bundled** assets (coin/dice/social-login icons) or deliberate CSS `BackgroundImage`s that can't take a `loading` attribute. So this is a small, correct improvement rather than a large win.

tsc passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)