### PR TITLE
fix(content-update): make approval idempotent

### DIFF
--- a/supabase/functions/_tests/update-content-update.test.ts
+++ b/supabase/functions/_tests/update-content-update.test.ts
@@ -71,6 +71,76 @@ Deno.test({
 });
 
 Deno.test({
+  name: 'update-content-update: concurrent duplicate APPROVEs apply once and all report success',
+  ignore: skip,
+  async fn() {
+    // Regression guard for the duplicate-invocation race: the Discord bot fired one
+    // approval 3x in the same second, one insert won and the others hit the unique
+    // constraint and failed, so the bot showed a false "didn't apply". With the atomic
+    // claim, exactly one invocation applies and the rest no-op as success.
+    const { userId } = await seed();
+    await withContentSource(userId, async (sourceId) => {
+      const uniqueName = `Concurrent ${crypto.randomUUID().slice(0, 8)}`;
+      const msgId = `test-cu-${crypto.randomUUID()}`;
+      const cu = await seedContentUpdate({
+        user_id: userId,
+        type: 'trait',
+        ref_id: null,
+        content_source_id: sourceId,
+        action: 'CREATE',
+        data: { name: uniqueName, description: 'concurrent create' },
+        discord_msg_id: msgId,
+      });
+
+      try {
+        const N = 4;
+        const results = await Promise.all(
+          Array.from({ length: N }, (_, i) =>
+            callFunction(
+              'update-content-update',
+              {
+                discord_msg_id: msgId,
+                discord_user_id: `mod-${i}`,
+                discord_user_name: `Mod ${i}`,
+                state: 'APPROVE',
+              },
+              { token: CONTENT_UPDATE_KEY }
+            )
+          )
+        );
+
+        // No false failures: every concurrent invocation reports success.
+        for (const r of results) {
+          assertEquals(
+            r.body?.status,
+            'success',
+            `all concurrent approvals should succeed, got ${JSON.stringify(r.body)}`
+          );
+        }
+
+        // Exactly one record created — the racing inserts did NOT produce duplicates.
+        const { data: rows } = await admin
+          .from('trait')
+          .select('id')
+          .eq('content_source_id', sourceId)
+          .ilike('name', uniqueName);
+        assertEquals(rows?.length, 1, `expected exactly one record, found ${rows?.length}`);
+
+        const { data: cuAfter } = await admin
+          .from('content_update')
+          .select('status')
+          .eq('id', cu.id)
+          .single();
+        assertEquals(cuAfter?.status?.state, 'APPROVED', 'request should be approved');
+      } finally {
+        await admin.from('trait').delete().eq('content_source_id', sourceId).ilike('name', uniqueName);
+        await admin.from('content_update').delete().eq('id', cu.id);
+      }
+    });
+  },
+});
+
+Deno.test({
   name: 'update-content-update: accepts the shared key via legacy body auth_token (deployed bot format)',
   ignore: skip,
   async fn() {

--- a/supabase/functions/update-content-update/index.ts
+++ b/supabase/functions/update-content-update/index.ts
@@ -88,73 +88,114 @@ serve(async (req: Request) => {
             message: 'Invalid content type',
           };
 
+        // Idempotency claim. The Discord bot can fire the same approval more than once
+        // (duplicate reaction events, or multiple bot instances) — we've observed a single
+        // approval invoking this function 3x in the same second. Without a guard each
+        // invocation applied the change independently: one insert won and the others hit
+        // the unique constraint and failed, so the bot surfaced a false "didn't apply"
+        // even though the record WAS created. Atomically transition the request to
+        // APPROVED, but only if it isn't already. Postgres serializes concurrent updates
+        // on the row, so exactly one invocation matches the `!= APPROVED` filter and wins
+        // the claim; the rest match zero rows and no-op as success below.
+        const { data: claimed } = await client
+          .from('content_update')
+          .update({
+            status: { state: 'APPROVED', discord_user_id, discord_user_name },
+          })
+          .eq('id', update.id)
+          .neq('status->>state', 'APPROVED')
+          .select('id');
+
+        if (!claimed || claimed.length === 0) {
+          // Already approved by a concurrent or earlier invocation — nothing to do.
+          logEvent('info', 'update-content-update', 'approve_deduped', { updateId: update.id });
+          return { status: 'success', data: true };
+        }
+
+        // We own the claim. Apply the content change below; if it fails we revert the
+        // claim so the request is not left falsely APPROVED and can be retried.
+        const revertClaim = async () => {
+          await updateData(client, 'content_update', update.id, { status: { state: 'PENDING' } });
+        };
+
+        // Apply the content change. Wrapped in try/catch because the data helpers THROW on
+        // DB errors (e.g. updateData throws on a constraint violation) rather than returning
+        // a status — without catching, the throw would skip the revert below and leave the
+        // request falsely APPROVED (the very bug the claim/revert exists to prevent).
         let content_id = update.ref_id;
-        if (update.action === 'UPDATE' && update.ref_id) {
-          if (update.data.trait_id) {
-            // Update the associated trait's name & description
-            const trait_id = await handleAssociatedTrait(
-              client,
-              update.ref_id,
-              update.type,
-              update.data.name,
-              update.content_source_id
-            );
-            console.log('updated -> trait_id', trait_id);
-          }
+        try {
+          if (update.action === 'UPDATE' && update.ref_id) {
+            if (update.data.trait_id) {
+              // Update the associated trait's name & description
+              const trait_id = await handleAssociatedTrait(
+                client,
+                update.ref_id,
+                update.type,
+                update.data.name,
+                update.content_source_id
+              );
+              console.log('updated -> trait_id', trait_id);
+            }
 
-          const updateRes = await updateData(client, tableName, update.ref_id, update.data);
-          result = updateRes.status;
-        } else if (update.action === 'CREATE') {
-          let trait_id = null;
-          if (update.data.trait_id) {
-            // Create the associated trait
-            trait_id = await handleAssociatedTrait(
-              client,
-              undefined,
-              update.type,
-              update.data.name,
-              update.content_source_id
-            );
-            console.log('created -> trait_id', trait_id);
-          }
+            const updateRes = await updateData(client, tableName, update.ref_id, update.data);
+            result = updateRes.status;
+          } else if (update.action === 'CREATE') {
+            let trait_id = null;
+            if (update.data.trait_id) {
+              // Create the associated trait
+              trait_id = await handleAssociatedTrait(
+                client,
+                undefined,
+                update.type,
+                update.data.name,
+                update.content_source_id
+              );
+              console.log('created -> trait_id', trait_id);
+            }
 
-          const newData = await insertData(
-            client,
-            tableName,
-            {
-              ...update.data,
-              trait_id: trait_id ? trait_id : undefined,
-              content_source_id: update.content_source_id,
-            },
-            update.data?.type
-          );
-          result = newData ? 'SUCCESS' : 'ERROR_UNKNOWN';
-          console.log('created -> content_id', newData?.id);
-          content_id = newData?.id;
-        } else if (update.action === 'DELETE' && update.ref_id) {
-          result = await deleteData(client, tableName, update.ref_id);
-        } else {
-          return {
-            status: 'error',
-            message: 'Invalid update action',
-          };
+            const newData = await insertData(
+              client,
+              tableName,
+              {
+                ...update.data,
+                trait_id: trait_id ? trait_id : undefined,
+                content_source_id: update.content_source_id,
+              },
+              update.data?.type
+            );
+            result = newData ? 'SUCCESS' : 'ERROR_UNKNOWN';
+            console.log('created -> content_id', newData?.id);
+            content_id = newData?.id;
+          } else if (update.action === 'DELETE' && update.ref_id) {
+            result = await deleteData(client, tableName, update.ref_id);
+          } else {
+            // Invalid action — release the claim so the request returns to PENDING.
+            await revertClaim();
+            return {
+              status: 'error',
+              message: 'Invalid update action',
+            };
+          }
+        } catch (applyError) {
+          // The apply threw (e.g. a constraint violation). Release the claim so the
+          // request returns to PENDING (not falsely APPROVED) and can be retried.
+          await revertClaim();
+          logEvent('error', 'update-content-update', 'apply_threw', {
+            updateId: update.id,
+            contentType: update.type,
+            action: update.action,
+            message: (applyError as { message?: string })?.message ?? `${applyError}`,
+          });
+          return { status: 'error', message: 'ERROR_UNKNOWN' };
         }
 
         console.log('content_id', content_id, 'result', result);
 
-        // Only now that the content change has actually committed do we mark the request
-        // APPROVED, refresh the contributor's tier, and (re)generate embeddings. If the
-        // apply failed, the request is deliberately left un-approved (so it is not shown
-        // as applied and can be retried) and we fall through to the error response below.
+        // The request was already marked APPROVED by the claim above. If the content write
+        // actually succeeded, refresh the contributor's tier and (re)generate embeddings.
+        // If it failed, revert the claim to PENDING (so it is not shown as applied and can
+        // be retried) and fall through to the error response below.
         if (result === 'SUCCESS') {
-          await updateData(client, 'content_update', update.id, {
-            status: {
-              state: 'APPROVED',
-              discord_user_id: discord_user_id,
-              discord_user_name: discord_user_name,
-            },
-          });
-
           // If they've reached the threshold, update their tier
           const contentUpdates: ContentUpdate[] = await fetchData<ContentUpdate>(
             client,
@@ -180,6 +221,11 @@ serve(async (req: Request) => {
           if (content_id) {
             await populateCollection(client, 'name', update.type, [content_id]);
           }
+        } else {
+          // The content write failed after we claimed the request — revert it to PENDING
+          // so it is not left falsely APPROVED and can be retried. Falls through to the
+          // error response below (result !== 'SUCCESS').
+          await revertClaim();
         }
       } else if (state === 'REJECT') {
         const updateRes = await updateData(client, 'content_update', update.id, {


### PR DESCRIPTION
## What happened today

A single approval invoked `update-content-update` **3× in the same second** — content-update 39443. One insert won (created heritage id 57655), the other two hit the unique constraint and **failed**, so the bot surfaced a false "didn't apply" even though the record was created. There is exactly **one** record in the DB — no duplicate — and it was genuinely an `action: CREATE` (so "added instead of updated" was the submission type).

## Root cause

The Discord bot fired the same reaction multiple times (duplicate events, or multiple bot instances), and nothing deduplicated it. This race is pre-existing, but it got **visible** after the apply-then-approve + failure-surfacing changes — those exposed the race without deduplicating it. That's the regression: false failures you didn't see before.

## Fix

Atomically **claim** the request before applying: conditionally set `status` to APPROVED only if it isn't already. Postgres serializes the row update, so exactly one concurrent invocation matches the `!= APPROVED` filter and wins; the rest match zero rows and no-op as success. The winner applies; if the apply **fails or throws** (the data helpers throw on constraint errors), the claim is reverted to PENDING so the request is never left falsely APPROVED and can be retried.

## Testing

New test fires **4 concurrent APPROVEs** for one request and asserts: exactly one record created, all invocations report success, request ends APPROVED. The existing "failed apply is not marked approved" guard still passes (now via revert). All 5 content-update tests green on the local stack. Deployed to prod (v129, verify_jwt preserved).

## Still worth checking (bot side)

The server is now robust regardless, but the bot firing 3× is wasteful and points at **multiple bot instances on Render** — a Discord bot should run as a single instance (each instance opens its own gateway connection and receives every reaction). Worth confirming the Render service is scaled to 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)