### PR TITLE
Sign out silently on cold load with a dead session

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -98,18 +98,13 @@ export default function App() {
       setSession(session);
       // Cold load with a dead session (expired from inactivity while the tab was
       // closed): supabase-js clears its stored session without a SIGNED_OUT event,
-      // so catch the "cached user but no session" mismatch here too.
+      // so catch the "cached user but no session" mismatch here too. Clear silently,
+      // with no toast: the page renders signed-out from the very first paint, so
+      // announcing "you've been signed out" on arrival is just noise. (The mid-visit
+      // expiry paths below still notify, because there the user may be mid-edit with
+      // unsaved work at stake.)
       if (!session && getCachedPublicUser()) {
         clearUserData();
-        if (!window.location.pathname.startsWith('/login')) {
-          showNotification({
-            id: 'session-expired',
-            title: 'Session expired',
-            message: 'You have been signed out due to inactivity. Please sign in again to save your changes.',
-            color: 'yellow',
-            autoClose: false,
-          });
-        }
       }
     });
 


### PR DESCRIPTION
## Summary
- Opening the site with an expired session used to show a persistent "Session expired" toast on arrival. The page already renders signed-out from the first paint in that case, so the toast was noise. The stale cached user is now cleared silently.
- The two mid-visit expiry notifications (the SIGNED_OUT auth listener and the request-manager 401/403 safety net) are intentionally unchanged: there the user may be mid-edit with unsaved work at stake, and the notice prevents saves from failing with a misleading generic error.

## Verification
- Seeded a cached user in localStorage with no auth session, reloaded: no toast, cache cleared, page renders signed-out normally (header shows Sign in / Register).

🤖 Generated with [Claude Code](https://claude.com/claude-code)