### PR TITLE
fix(builder): stop schema validation blanking custom-select options

### DIFF
--- a/frontend/src/schemas/operations.ts
+++ b/frontend/src/schemas/operations.ts
@@ -310,32 +310,48 @@ export type OperationSelectFilters = z.infer<typeof OperationSelectFiltersSchema
 
 // ─── Select Option non-recursive variants (inferred) ─────────────────────────
 
-export const OperationSelectOptionAbilityBlockSchema = z.object({
-  id: z.string(),
-  type: z.literal('ABILITY_BLOCK'),
-  operation: OperationGiveAbilityBlockSchema,
-});
+// NOTE ON `.passthrough()`: inside a PREDEFINED select with `optionType: 'CUSTOM'`, each
+// option carries a custom-display overlay — `title`, `description`, and nested `operations`
+// — *in addition to* its base `type`/`operation` (e.g. Witchwarper's key-attribute options
+// are `type: 'ADJ_VALUE'` but still hold a `title` of "Charisma"/"Intelligence"). The render
+// pipeline (`getCustomPredefinedList`) derives the option's visible label from that `title`.
+// Without `.passthrough()`, Zod validation at the content-cache boundary (`validateAndWarn`)
+// strips those unknown keys, leaving the option label `undefined` and the select renders as
+// blank rows. Passthrough preserves the overlay so custom selects display their options.
+export const OperationSelectOptionAbilityBlockSchema = z
+  .object({
+    id: z.string(),
+    type: z.literal('ABILITY_BLOCK'),
+    operation: OperationGiveAbilityBlockSchema,
+  })
+  .passthrough();
 export type OperationSelectOptionAbilityBlock = z.infer<typeof OperationSelectOptionAbilityBlockSchema>;
 
-export const OperationSelectOptionSpellSchema = z.object({
-  id: z.string(),
-  type: z.literal('SPELL'),
-  operation: OperationGiveSpellSchema,
-});
+export const OperationSelectOptionSpellSchema = z
+  .object({
+    id: z.string(),
+    type: z.literal('SPELL'),
+    operation: OperationGiveSpellSchema,
+  })
+  .passthrough();
 export type OperationSelectOptionSpell = z.infer<typeof OperationSelectOptionSpellSchema>;
 
-export const OperationSelectOptionLanguageSchema = z.object({
-  id: z.string(),
-  type: z.literal('LANGUAGE'),
-  operation: OperationGiveLanguageSchema,
-});
+export const OperationSelectOptionLanguageSchema = z
+  .object({
+    id: z.string(),
+    type: z.literal('LANGUAGE'),
+    operation: OperationGiveLanguageSchema,
+  })
+  .passthrough();
 export type OperationSelectOptionLanguage = z.infer<typeof OperationSelectOptionLanguageSchema>;
 
-export const OperationSelectOptionAdjValueSchema = z.object({
-  id: z.string(),
-  type: z.literal('ADJ_VALUE'),
-  operation: OperationAdjValueSchema,
-});
+export const OperationSelectOptionAdjValueSchema = z
+  .object({
+    id: z.string(),
+    type: z.literal('ADJ_VALUE'),
+    operation: OperationAdjValueSchema,
+  })
+  .passthrough();
 export type OperationSelectOptionAdjValue = z.infer<typeof OperationSelectOptionAdjValueSchema>;
 
 // ─── Recursive types — must be declared manually for z.lazy() ────────────────


### PR DESCRIPTION
## Problem

Custom predefined selects render with **blank option rows** — no labels:

- Witchwarper key attribute — "Select an Attribute" (#246, #249)
- Oracular Samsaran heritage tradition (#247)
- Witch Greater/Major Lesson type (#248, #237)

…and any other select using `optionType: 'CUSTOM'`.

## Root cause

Each option in a custom select carries a display overlay — `title`, `description`, and nested `operations` — **in addition to** its base `type`/`operation` (e.g. the Witchwarper options are `type: 'ADJ_VALUE'` but still hold a `title` of "Charisma"/"Intelligence"). The render pipeline (`getCustomPredefinedList`) derives each option's visible label from that `title`.

But the four select-option schemas in `schemas/operations.ts` were strict `z.object({ id, type, operation })`. When content is loaded, `validateAndWarn` runs a Zod parse at the content-cache boundary, and Zod's default **strips undeclared keys** — so `title`/`description`/`operations` were deleted. The option's label became `undefined`, and the select rendered blank.

Free-boost selects were unaffected because they label off the attribute *variable*, not `title`.

The data is correct in the DB and in the raw API response; the label only vanished on the client mid-validation — which is why it wasn't visible in a static code read.

## Fix

Add `.passthrough()` to the four option schemas (`OperationSelectOption{AbilityBlock,Spell,Language,AdjValue}Schema`) so the custom overlay survives validation. One file, `frontend/src/schemas/operations.ts`. Typechecks clean.

## Verification

Reproduced and fixed live in the character builder against real content:

- Before: "Select an Attribute" modal shows two blank rows.
- After: modal shows **Charisma** and **Intelligence**.
- Confirmed at the data layer too — the option `title`s now survive validation (`["Charisma","Intelligence"]`).

## Deploy

Frontend-only change → ships via the **frontend deploy** (`npm run deploy` / gh-pages), not an edge-function deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)