### PR TITLE
Content cache invalidation via per-source change tokens

### DIFF
--- a/data/create-db-docker.sh
+++ b/data/create-db-docker.sh
@@ -72,4 +72,18 @@ SQL
 echo "==> Installing auth → public_user trigger"
 run_psql < "$SCRIPT_DIR/auth-trigger.sql"
 
+# 7. Apply migrations. schema.sql is a prod dump that lags whatever landed in
+#    supabase/migrations since the last db_dump.yml refresh, so replaying them
+#    is the only way local/CI matches prod (e.g. the secret-column grants, the
+#    content updated_at triggers). This must run LAST: step 5's blanket GRANT
+#    would undo any column-level grants a migration sets up.
+#    Requirement this imposes: every migration must stay re-runnable over a
+#    schema that already contains it (if not exists / or replace / revoke+grant),
+#    which all current migrations follow.
+echo "==> Applying migrations from supabase/migrations"
+for migration in "$SCRIPT_DIR"/../supabase/migrations/*.sql; do
+  echo "    -> $(basename "$migration")"
+  run_psql_quiet < "$migration"
+done
+
 echo "==> Done. Project schema and content data loaded."

--- a/docs/api-reference/content/get-content-versions.mdx
+++ b/docs/api-reference/content/get-content-versions.mdx
@@ -1,0 +1,5 @@
+---
+title: "Get content source change tokens"
+description: "Returns the updated_at change token for each requested content source, for cheap client cache-freshness checks."
+openapi: "POST /get-content-versions"
+---

--- a/docs/api-reference/openapi.json
+++ b/docs/api-reference/openapi.json
@@ -156,6 +156,11 @@
         "properties": {
           "id": { "type": "integer" },
           "created_at": { "type": "string", "format": "date-time" },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Server-maintained change timestamp, bumped by a database trigger on every real edit. Lets clients detect content changes."
+          },
           "name": { "type": "string" },
           "description": { "type": "string" },
           "content_source_id": { "type": "integer" },
@@ -179,6 +184,11 @@
         "properties": {
           "id": { "type": "integer" },
           "created_at": { "type": "string", "format": "date-time" },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Server-maintained change timestamp, bumped by a database trigger on every real edit. Lets clients detect content changes."
+          },
           "name": { "type": "string" },
           "rank": { "type": "integer", "minimum": 0, "maximum": 10 },
           "traditions": { "type": "array", "items": { "type": "string" } },
@@ -207,6 +217,11 @@
         "properties": {
           "id": { "type": "integer" },
           "created_at": { "type": "string", "format": "date-time" },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Server-maintained change timestamp, bumped by a database trigger on every real edit. Lets clients detect content changes."
+          },
           "name": { "type": "string" },
           "price": {
             "type": "object",
@@ -240,6 +255,11 @@
         "properties": {
           "id": { "type": "integer" },
           "created_at": { "type": "string", "format": "date-time" },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Server-maintained change timestamp, bumped by a database trigger on every real edit. Lets clients detect content changes."
+          },
           "operations": { "type": "array", "items": { "$ref": "#/components/schemas/Operation" } },
           "name": { "type": "string" },
           "actions": { "$ref": "#/components/schemas/ActionCost" },
@@ -267,6 +287,11 @@
         "properties": {
           "id": { "type": "integer" },
           "created_at": { "type": "string", "format": "date-time" },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Server-maintained change timestamp, bumped by a database trigger on every real edit. Lets clients detect content changes."
+          },
           "name": { "type": "string" },
           "rarity": { "$ref": "#/components/schemas/Rarity" },
           "description": { "type": "string" },
@@ -283,6 +308,11 @@
         "properties": {
           "id": { "type": "integer" },
           "created_at": { "type": "string", "format": "date-time" },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Server-maintained change timestamp, bumped by a database trigger on every real edit. Lets clients detect content changes."
+          },
           "name": { "type": "string" },
           "rarity": { "$ref": "#/components/schemas/Rarity" },
           "description": { "type": "string" },
@@ -297,6 +327,11 @@
         "properties": {
           "id": { "type": "integer" },
           "created_at": { "type": "string", "format": "date-time" },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Server-maintained change timestamp, bumped by a database trigger on every real edit. Lets clients detect content changes."
+          },
           "name": { "type": "string" },
           "rarity": { "$ref": "#/components/schemas/Rarity" },
           "description": { "type": "string" },
@@ -314,6 +349,11 @@
         "properties": {
           "id": { "type": "integer" },
           "created_at": { "type": "string", "format": "date-time" },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Server-maintained change timestamp, bumped by a database trigger on every real edit. Lets clients detect content changes."
+          },
           "class_id": { "type": "integer" },
           "archetype_id": { "type": "integer" },
           "name": { "type": "string" },
@@ -346,6 +386,11 @@
         "properties": {
           "id": { "type": "integer" },
           "created_at": { "type": "string", "format": "date-time" },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Server-maintained change timestamp, bumped by a database trigger on every real edit. Lets clients detect content changes."
+          },
           "name": { "type": "string" },
           "rarity": { "$ref": "#/components/schemas/Rarity" },
           "description": { "type": "string" },
@@ -362,6 +407,11 @@
         "properties": {
           "id": { "type": "integer" },
           "created_at": { "type": "string", "format": "date-time" },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Server-maintained change timestamp, bumped by a database trigger on every real edit. Lets clients detect content changes."
+          },
           "name": { "type": "string" },
           "rarity": { "$ref": "#/components/schemas/Rarity" },
           "description": { "type": "string" },
@@ -378,6 +428,11 @@
         "properties": {
           "id": { "type": "integer" },
           "created_at": { "type": "string", "format": "date-time" },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Server-maintained change timestamp, bumped by a database trigger on every real edit. Lets clients detect content changes."
+          },
           "name": { "type": "string" },
           "speakers": { "type": "string" },
           "script": { "type": "string" },
@@ -393,6 +448,11 @@
         "properties": {
           "id": { "type": "integer" },
           "created_at": { "type": "string", "format": "date-time" },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Server-maintained change timestamp, bumped by a database trigger on every real edit. Lets clients detect content changes."
+          },
           "name": { "type": "string" },
           "level": { "type": "integer" },
           "rarity": { "$ref": "#/components/schemas/Rarity" },
@@ -511,6 +571,11 @@
         "properties": {
           "id": { "type": "integer" },
           "created_at": { "type": "string", "format": "date-time" },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Server-maintained change timestamp, bumped by a database trigger on every real edit. Lets clients detect content changes."
+          },
           "name": { "type": "string" },
           "foundry_id": { "type": "string" },
           "url": { "type": "string" },
@@ -2503,6 +2568,59 @@
                       "properties": {
                         "source": { "$ref": "#/components/schemas/ContentSource" },
                         "count": { "type": "integer" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/get-content-versions": {
+      "post": {
+        "tags": ["Content"],
+        "summary": "Get content source change tokens",
+        "description": "Returns the server-maintained `updated_at` change token for each requested content source. Clients that persist the content corpus locally compare these tokens against their cached copies on page load and refetch when any differ. The response is intentionally minimal (id and updated_at only) so warm-cache page loads stay cheap.",
+        "operationId": "getContentVersions",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["ids"],
+                "properties": {
+                  "ids": {
+                    "type": "array",
+                    "items": { "type": "integer" },
+                    "minItems": 1,
+                    "maxItems": 500,
+                    "description": "Content source ids to check (at most 500)."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "JSend success.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": { "type": "string", "enum": ["success"] },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": { "type": "integer" },
+                          "updated_at": { "type": "string", "format": "date-time" }
+                        }
                       }
                     }
                   }

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -38,6 +38,7 @@
 					"api-reference/content/find-trait",
 					"api-reference/content/find-versatile-heritage",
 					"api-reference/content/find-content-source",
+					"api-reference/content/get-content-versions",
 					"api-reference/content/find-content-update",
 					"api-reference/content/create-spell",
 					"api-reference/content/create-item",

--- a/frontend/src/pages/CharactersPage.tsx
+++ b/frontend/src/pages/CharactersPage.tsx
@@ -69,6 +69,7 @@ import { useAtom, useAtomValue } from 'jotai';
 export function Component() {
   setPageTitle(`Characters`);
   const session = useAtomValue(sessionState);
+  const queryClient = useQueryClient();
 
   const { data, isLoading, refetch } = useQuery({
     queryKey: [`find-character`],
@@ -124,6 +125,12 @@ export function Component() {
   const handleCreateCharacter = async () => {
     const character = await createCharacter();
     if (character) {
+      // We navigate away immediately, so the list query stays cached. With the
+      // global staleTime (main.tsx), coming back within that window would render
+      // the pre-creation list — the new character invisible for up to a minute
+      // (and the e2e cleanup, which returns here to delete it, never finds it).
+      // Mark the list stale so the next mount refetches.
+      queryClient.invalidateQueries({ queryKey: ['find-character'] });
       navigate(`/builder/${character.id}`);
     }
     setLoadingCreateCharacter(false);

--- a/frontend/src/process/content/content-store.ts
+++ b/frontend/src/process/content/content-store.ts
@@ -144,10 +144,13 @@ function setStoredIds(type: ContentType, data: Record<string, any>, value: any) 
 
 const CONTENT_CACHE_KEY = 'content-store';
 // Bump to invalidate every client's persisted cache (e.g. when the content shape changes).
-const CONTENT_CACHE_VERSION = 1;
-// How long a persisted cache is trusted before it's dropped and re-fetched. Content changes
-// rarely; this bounds how stale a cached client can be (and resetContentStore() clears it on demand).
-const CONTENT_CACHE_TTL_MS = 1000 * 60 * 60 * 9; // 9h
+// v2: source rows carry the updated_at change token; v1 blobs predate it and would fail
+// every freshness check, so retire them once via the version gate instead.
+const CONTENT_CACHE_VERSION = 2;
+// Backstop only: staleness is normally caught by the per-source change-token check against
+// get-content-versions on load (see verifyPersistedContentVersions). The TTL exists for the
+// cases where that check cannot run (offline, endpoint unreachable, >500 sources).
+const CONTENT_CACHE_TTL_MS = 1000 * 60 * 60 * 24; // 24h
 
 type PersistedContentCache = {
   version: number;
@@ -160,6 +163,52 @@ type PersistedContentCache = {
 // lookups share a single in-flight request instead of each hitting the network.
 const inFlightFetches = new Map<string, Promise<any>>();
 
+// One freshness verdict per page load. resetContentStore() re-arms hydration (App mount
+// plus several pages call it), so without memoization every re-hydration would fire its
+// own network check — and a re-hydration racing an in-flight 'stale' verdict could fill
+// the stores from a blob the check is about to condemn. Blobs persisted during THIS page
+// lifetime (savedAt >= PAGE_LOAD_AT) are fresh-from-network by construction and skip the
+// check entirely.
+const PAGE_LOAD_AT = Date.now();
+let versionCheckPromise: Promise<'ok' | 'stale'> | null = null;
+
+/**
+ * Compare a persisted blob's per-source change tokens against the server.
+ *
+ * Each cached content-source row carries `updated_at` — a token the DB bumps whenever
+ * that source OR any content inside it changes (migration 20260718000000). One tiny
+ * request (~5 KB) answers "did anything I cached change?" without downloading content.
+ *
+ * Fail-open by design: if the check cannot run or errors (offline, endpoint not yet
+ * deployed, migration not yet applied), the cache is trusted and the TTL remains the
+ * backstop — this is what makes every rollout order safe. A cached source with NO token
+ * (pre-migration blob) compares as `undefined` vs a server string and reads as stale.
+ */
+async function verifyPersistedContentVersions(rec: PersistedContentCache): Promise<'ok' | 'stale'> {
+  const sourceMap = rec.idStore instanceof Map ? rec.idStore.get('content-source') : undefined;
+  const sources = sourceMap instanceof Map ? ([...sourceMap.values()].filter(isTruthy) as ContentSource[]) : [];
+  // Nothing to compare against (or too many for one call): fall back to the TTL.
+  if (sources.length === 0 || sources.length > 500) return 'ok';
+
+  const result = await makeRequest<{ id: number; updated_at: string }[]>(
+    'get-content-versions',
+    { ids: sources.map((s) => s.id) },
+    false
+  );
+  if (!Array.isArray(result)) return 'ok';
+
+  const serverTokens = new Map(result.map((r) => [r.id, r.updated_at]));
+  for (const source of sources) {
+    // Missing on the server = the source was deleted; token mismatch = something in it
+    // changed. Raw string comparison on purpose — tokens are opaque, never date-parsed.
+    if (serverTokens.get(source.id) !== source.updated_at) {
+      console.log('[CONTENT-CACHE] Source', source.id, 'changed on the server; dropping persisted cache');
+      return 'stale';
+    }
+  }
+  return 'ok';
+}
+
 async function hydrateContentCache(): Promise<void> {
   try {
     const rec = await idbGet<PersistedContentCache>(CONTENT_CACHE_KEY);
@@ -167,6 +216,21 @@ async function hydrateContentCache(): Promise<void> {
     if (rec.version !== CONTENT_CACHE_VERSION || Date.now() - rec.savedAt > CONTENT_CACHE_TTL_MS) {
       await idbDelete(CONTENT_CACHE_KEY);
       return;
+    }
+    // Freshness gate: only hydrate a blob from a previous page load after its change
+    // tokens check out against the server (see verifyPersistedContentVersions).
+    if (rec.savedAt < PAGE_LOAD_AT) {
+      versionCheckPromise ??= verifyPersistedContentVersions(rec);
+      if ((await versionCheckPromise) === 'stale') {
+        // Re-read before deleting: a slow check can lose the race against a fresh
+        // persist (network fetch + the 10s debounce), and deleting THAT blob would
+        // force a pointless cold load on the next visit.
+        const current = await idbGet<PersistedContentCache>(CONTENT_CACHE_KEY);
+        if (current && current.savedAt === rec.savedAt) {
+          await idbDelete(CONTENT_CACHE_KEY);
+        }
+        return;
+      }
     }
     // Fill the in-memory maps WITHOUT overwriting anything already present. Hydration can
     // resolve after a network fetch has already populated fresher data (it races a 2.5s

--- a/frontend/src/schemas/content.ts
+++ b/frontend/src/schemas/content.ts
@@ -60,6 +60,7 @@ export type {
 export const TraitSchema = z.object({
   id: z.number(),
   created_at: z.string(),
+  updated_at: z.string().optional(),
   name: z.string(),
   description: z.string(),
   meta_data: z
@@ -136,6 +137,7 @@ export type CastingSource = z.infer<typeof CastingSourceSchema>;
 export interface Item {
   id: number;
   created_at: string;
+  updated_at?: string;
   name: string;
   price: { cp?: number | string; sp?: number | string; gp?: number | string; pp?: number | string } | null;
   bulk: string | null;
@@ -211,6 +213,7 @@ export const ItemSchema: z.ZodType<Item> = z.lazy(() =>
   z.object({
     id: z.number(),
     created_at: z.string(),
+    updated_at: z.string().optional(),
     name: z.string(),
     price: z
       .object({
@@ -380,6 +383,7 @@ export type Inventory = z.infer<typeof InventorySchema>;
 export const SpellSchema = z.object({
   id: z.number(),
   created_at: z.string(),
+  updated_at: z.string().optional(),
   name: z.string(),
   rank: z.number(),
   traditions: z.array(z.string()),
@@ -423,6 +427,7 @@ export type Spell = z.infer<typeof SpellSchema>;
 export const AbilityBlockSchema = z.object({
   id: z.number(),
   created_at: z.string(),
+  updated_at: z.string().optional(),
   operations: z.array(OperationSchema).nullable(),
   name: z.string(),
   actions: ActionCostSchema,
@@ -459,6 +464,7 @@ export type AbilityBlock = z.infer<typeof AbilityBlockSchema>;
 export const ClassSchema = z.object({
   id: z.number(),
   created_at: z.string(),
+  updated_at: z.string().optional(),
   name: z.string(),
   rarity: RaritySchema,
   description: z.string(),
@@ -477,6 +483,7 @@ export type Class = z.infer<typeof ClassSchema>;
 export const ClassArchetypeSchema = z.object({
   id: z.number(),
   created_at: z.string(),
+  updated_at: z.string().optional(),
   class_id: z.number(),
   archetype_id: z.number().nullable(),
   name: z.string(),
@@ -507,6 +514,7 @@ export type ClassArchetype = z.infer<typeof ClassArchetypeSchema>;
 export const ArchetypeSchema = z.object({
   id: z.number(),
   created_at: z.string(),
+  updated_at: z.string().optional(),
   name: z.string(),
   rarity: RaritySchema,
   description: z.string(),
@@ -524,6 +532,7 @@ export type Archetype = z.infer<typeof ArchetypeSchema>;
 export const VersatileHeritageSchema = z.object({
   id: z.number(),
   created_at: z.string(),
+  updated_at: z.string().optional(),
   name: z.string(),
   rarity: RaritySchema,
   description: z.string(),
@@ -541,6 +550,7 @@ export type VersatileHeritage = z.infer<typeof VersatileHeritageSchema>;
 export const AncestrySchema = z.object({
   id: z.number(),
   created_at: z.string(),
+  updated_at: z.string().optional(),
   name: z.string(),
   rarity: RaritySchema,
   description: z.string(),
@@ -558,6 +568,7 @@ export type Ancestry = z.infer<typeof AncestrySchema>;
 export const BackgroundSchema = z.object({
   id: z.number(),
   created_at: z.string(),
+  updated_at: z.string().optional(),
   name: z.string(),
   rarity: RaritySchema,
   description: z.string(),
@@ -574,6 +585,7 @@ export type Background = z.infer<typeof BackgroundSchema>;
 export const LanguageSchema = z.object({
   id: z.number(),
   created_at: z.string(),
+  updated_at: z.string().optional(),
   name: z.string(),
   speakers: z.string().nullable(),
   script: z.string().nullable(),
@@ -750,6 +762,7 @@ export type LivingEntity = z.infer<typeof LivingEntitySchema>;
 export const CreatureSchema = LivingEntitySchema.extend({
   id: z.number(),
   created_at: z.string(),
+  updated_at: z.string().optional(),
   rarity: RaritySchema,
   details: z.object({
     image_url: z.string().optional(),
@@ -996,6 +1009,11 @@ export type PublicUser = z.infer<typeof PublicUserSchema>;
 export const ContentSourceSchema = z.object({
   id: z.number(),
   created_at: z.string(),
+  // Server-maintained change token (trigger-bumped on any edit to the source or its
+  // contents; migration 20260718000000). The persisted content cache compares these
+  // against get-content-versions on load, so this field MUST survive validation --
+  // zod strips unknown keys. Optional: embedded legacy snapshots predate the column.
+  updated_at: z.string().optional(),
   name: z.string(),
   foundry_id: z.string().nullable(),
   url: z.string().nullable(),

--- a/frontend/src/schemas/requests.ts
+++ b/frontend/src/schemas/requests.ts
@@ -47,6 +47,7 @@ export const RequestTypeSchema = z.enum([
   'create-content-update',
   'find-content-update',
   'get-content-source-stats',
+  'get-content-versions',
   'find-encounter',
   'create-encounter',
   'find-campaign',

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -238,6 +238,9 @@ verify_jwt = false
 [functions.get-content-source-stats]
 verify_jwt = false
 
+[functions.get-content-versions]
+verify_jwt = false
+
 [functions.get-user]
 verify_jwt = false
 

--- a/supabase/functions/_shared/content.d.ts
+++ b/supabase/functions/_shared/content.d.ts
@@ -105,6 +105,7 @@ interface PublicUser {
 interface Trait {
   id: number;
   created_at: string;
+  updated_at?: string;
   name: string;
   description: string;
   meta_data?: {
@@ -145,6 +146,7 @@ interface ContentUpdate {
 interface Item {
   id: number;
   created_at: string;
+  updated_at?: string;
   name: string;
   price?: {
     cp?: number;
@@ -172,6 +174,7 @@ interface Item {
 interface Spell {
   id: number;
   created_at: string;
+  updated_at?: string;
   name: string;
   rank: number;
   traditions: string[];
@@ -197,6 +200,7 @@ interface Spell {
 interface Class {
   id: number;
   created_at: string;
+  updated_at?: string;
   name: string;
   rarity: Rarity;
   description: string;
@@ -211,6 +215,7 @@ interface Class {
 interface ClassArchetype {
   id: number;
   created_at: string;
+  updated_at?: string;
   class_id: number;
   archetype_id?: number;
   name: string;
@@ -234,6 +239,7 @@ interface ClassArchetype {
 interface Archetype {
   id: number;
   created_at: string;
+  updated_at?: string;
   name: string;
   rarity: Rarity;
   description: string;
@@ -247,6 +253,7 @@ interface Archetype {
 interface VersatileHeritage {
   id: number;
   created_at: string;
+  updated_at?: string;
   name: string;
   rarity: Rarity;
   description: string;
@@ -260,6 +267,7 @@ interface VersatileHeritage {
 interface AbilityBlock {
   id: number;
   created_at: string;
+  updated_at?: string;
   operations?: Operation[];
   name: string;
   actions: ActionCost;
@@ -342,6 +350,7 @@ interface LivingEntity {
 interface Creature extends LivingEntity {
   id: number;
   created_at: string;
+  updated_at?: string;
   rarity: Rarity;
   details: {
     image_url?: string;
@@ -516,6 +525,7 @@ interface Encounter {
 interface ContentSource {
   id: number;
   created_at: string;
+  updated_at?: string;
   name: string;
   foundry_id?: string;
   url: string;
@@ -539,6 +549,7 @@ interface ContentSource {
 interface Ancestry {
   id: number;
   created_at: string;
+  updated_at?: string;
   name: string;
   rarity: Rarity;
   description: string;
@@ -552,6 +563,7 @@ interface Ancestry {
 type Background = {
   id: number;
   created_at: string;
+  updated_at?: string;
   name: string;
   rarity: Rarity;
   description: string;
@@ -563,6 +575,7 @@ type Background = {
 type Language = {
   id: number;
   created_at: string;
+  updated_at?: string;
   name: string;
   speakers: string;
   script: string;

--- a/supabase/functions/_shared/helpers.ts
+++ b/supabase/functions/_shared/helpers.ts
@@ -751,10 +751,13 @@ export async function insertData<T = Record<string, any>>(
     data.name = data.name.replace(/’/g, "'");
   }
 
-  // Delete forbidden keys
+  // Delete forbidden keys. updated_at is server-owned (trigger-maintained, see
+  // migration 20260718000000): an echoed stale value must never override the
+  // column default or the trigger's stamp.
   delete data.id;
   delete data.created_at;
   delete data.version;
+  delete data.updated_at;
 
   const { data: insertedData, error } = await client.from(tableName).insert(data).select();
   if (error) {
@@ -862,11 +865,14 @@ export async function updateData(
     delete data.uuid;
   }
 
-  // Delete forbidden keys
+  // Delete forbidden keys. updated_at is server-owned (trigger-maintained, see
+  // migration 20260718000000): the bot replays stored full-row payloads, and an
+  // echoed stale timestamp must never rewind a source's change token.
   delete data.id;
   delete data.created_at;
   delete data.content_source_id;
   delete data.user_id;
+  delete data.updated_at;
 
   let error: any = null;
   let dataResult: any = null;

--- a/supabase/functions/_tests/get-content-versions.test.ts
+++ b/supabase/functions/_tests/get-content-versions.test.ts
@@ -8,6 +8,12 @@ import { admin, assertSuccess, callFunction, seed, stackUnavailable, testUuid, w
 
 const skip = stackUnavailable();
 
+// The bot-path test drives the real update-content-update flow, which
+// authenticates the shared CONTENT_UPDATE_KEY. Skip (don't fail) when it isn't
+// configured, matching update-content-update.test.ts.
+const CONTENT_UPDATE_KEY = Deno.env.get('CONTENT_UPDATE_KEY') ?? '';
+const skipBot = skip || !CONTENT_UPDATE_KEY;
+
 /** Read a source's change token (updated_at) directly from the DB. */
 async function getSourceToken(sourceId: number): Promise<string> {
   const { data, error } = await admin
@@ -129,6 +135,124 @@ Deno.test({
       const { error: deleteError } = await admin.from('spell').delete().eq('id', spell.id);
       assert(!deleteError, `delete failed: ${deleteError?.message}`);
       assertNotEquals(await getSourceToken(sourceId), tokenAfterEdit, 'child DELETE must bump the source token');
+    });
+  },
+});
+
+Deno.test({
+  name: 'updated_at triggers: moving content between sources bumps BOTH source tokens',
+  ignore: skip,
+  async fn() {
+    const { userId } = await seed();
+
+    await withContentSource(userId, async (sourceA) => {
+      await withContentSource(userId, async (sourceB) => {
+        const spell = await insertTestSpell(sourceA, 'Migrating Spell');
+        const tokenA = await getSourceToken(sourceA);
+        const tokenB = await getSourceToken(sourceB);
+
+        const { error } = await admin.from('spell').update({ content_source_id: sourceB }).eq('id', spell.id);
+        assert(!error, `move failed: ${error?.message}`);
+
+        // The old source lost content and the new one gained it; subscribers of
+        // EITHER must see their cache invalidate.
+        assertNotEquals(await getSourceToken(sourceA), tokenA, 'old source must bump on move-out');
+        assertNotEquals(await getSourceToken(sourceB), tokenB, 'new source must bump on move-in');
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: 'updated_at is server-owned: an echoed stale value via the HTTP create path is ignored',
+  ignore: skip,
+  async fn() {
+    const { userId, apiKey } = await seed();
+
+    await withContentSource(userId, async (sourceId) => {
+      // A client (or replayed payload) sending its own updated_at must never win:
+      // insertData strips it, so the column default stamps the row.
+      const poisoned = '2000-01-01T00:00:00+00:00';
+      const result = await callFunction(
+        'create-spell',
+        {
+          name: 'Echo Test Spell',
+          description: 'Test spell.',
+          rank: 1,
+          traditions: ['arcane'],
+          traits: [],
+          content_source_id: sourceId,
+          version: '1.0.0',
+          updated_at: poisoned,
+        },
+        { token: apiKey }
+      );
+      const created = assertSuccess<{ id: number }>(result, 'create-spell should succeed');
+
+      const { data: row } = await admin.from('spell').select('updated_at').eq('id', created.id).single();
+      assert(row?.updated_at, 'row should carry updated_at');
+      assertNotEquals(row.updated_at, poisoned, 'echoed updated_at must not be written');
+      assert(new Date(row.updated_at).getFullYear() >= 2026, 'updated_at must be a fresh server stamp');
+    });
+  },
+});
+
+Deno.test({
+  name: 'updated_at triggers: a real bot APPROVE apply bumps the source token and ignores an echoed stale updated_at',
+  ignore: skipBot,
+  async fn() {
+    const { userId } = await seed();
+
+    await withContentSource(userId, async (sourceId) => {
+      const { data: trait } = await admin
+        .from('trait')
+        .insert({ name: 'Token Before', description: 'old desc', content_source_id: sourceId, uuid: testUuid() })
+        .select()
+        .single();
+      assert(trait, 'seed trait');
+      const tokenBefore = await getSourceToken(sourceId);
+
+      // The bot replays stored full-row payloads, so a stale updated_at echo in
+      // the approved data is the realistic shape of the token-rewind hazard.
+      const poisoned = '2000-01-01T00:00:00+00:00';
+      const msgId = `test-cv-${crypto.randomUUID()}`;
+      const { data: cu, error: cuError } = await admin
+        .from('content_update')
+        .insert({
+          upvotes: [],
+          downvotes: [],
+          status: { state: 'PENDING' },
+          user_id: userId,
+          type: 'trait',
+          ref_id: trait.id,
+          content_source_id: sourceId,
+          action: 'UPDATE',
+          data: { name: 'Token After', description: 'new desc', updated_at: poisoned },
+          discord_msg_id: msgId,
+        })
+        .select()
+        .single();
+      assert(cu && !cuError, `seed content_update failed: ${cuError?.message}`);
+
+      try {
+        await callFunction(
+          'update-content-update',
+          { discord_msg_id: msgId, discord_user_id: 'mod-1', discord_user_name: 'Mod One', state: 'APPROVE' },
+          { token: CONTENT_UPDATE_KEY }
+        );
+
+        // Assert on DB state (the embeddings step may fail locally but runs after
+        // the writes commit), matching update-content-update.test.ts.
+        const { data: after } = await admin.from('trait').select('name, updated_at').eq('id', trait.id).single();
+        assertEquals(after?.name, 'Token After', 'bot apply should update the trait');
+        assertNotEquals(after?.updated_at, poisoned, 'echoed updated_at must not rewind the row');
+        assertNotEquals(after?.updated_at, trait.updated_at, 'bot apply must stamp the row');
+
+        assertNotEquals(await getSourceToken(sourceId), tokenBefore, 'bot apply must bump the source token');
+      } finally {
+        await admin.from('content_update').delete().eq('id', cu.id);
+        await admin.from('trait').delete().eq('id', trait.id);
+      }
     });
   },
 });

--- a/supabase/functions/_tests/get-content-versions.test.ts
+++ b/supabase/functions/_tests/get-content-versions.test.ts
@@ -1,0 +1,134 @@
+// Covers the get-content-versions freshness probe and the updated_at trigger
+// machinery from migration 20260718000000: stamp-on-edit, no-op suppression
+// (idempotent bot re-applies must not move tokens), and the child-to-source
+// roll-up that powers client cache invalidation.
+
+import { assert, assertEquals, assertNotEquals } from 'https://deno.land/std@0.203.0/assert/mod.ts';
+import { admin, assertSuccess, callFunction, seed, stackUnavailable, testUuid, withContentSource } from './seed.ts';
+
+const skip = stackUnavailable();
+
+/** Read a source's change token (updated_at) directly from the DB. */
+async function getSourceToken(sourceId: number): Promise<string> {
+  const { data, error } = await admin
+    .from('content_source')
+    .select('updated_at')
+    .eq('id', sourceId)
+    .single();
+  if (error || !data?.updated_at) throw error ?? new Error(`no updated_at for source ${sourceId}`);
+  return data.updated_at as string;
+}
+
+/** Insert a minimal spell into the given source, returning the row. */
+async function insertTestSpell(sourceId: number, name: string) {
+  const { data: spell, error } = await admin
+    .from('spell')
+    .insert({
+      name,
+      description: 'Test spell.',
+      rank: 1,
+      traditions: ['arcane'],
+      traits: [],
+      content_source_id: sourceId,
+      uuid: testUuid(),
+      version: '1.0.0',
+    })
+    .select()
+    .single();
+  if (error || !spell) throw error ?? new Error('failed to insert test spell');
+  return spell;
+}
+
+Deno.test({
+  name: 'get-content-versions: rejects missing, empty, oversized, and non-numeric ids',
+  ignore: skip,
+  async fn() {
+    const { apiKey } = await seed();
+
+    for (const body of [
+      {},
+      { ids: [] },
+      { ids: Array.from({ length: 501 }, (_, i) => i + 1) },
+      { ids: ['1', '2'] },
+      { ids: [1, NaN] },
+    ]) {
+      const result = await callFunction('get-content-versions', body, { token: apiKey });
+      assertEquals(result.status, 200, `unexpected HTTP status for ${JSON.stringify(body).slice(0, 60)}`);
+      assertEquals(result.body?.status, 'fail', `expected JSend fail for ${JSON.stringify(body).slice(0, 60)}`);
+    }
+  },
+});
+
+Deno.test({
+  name: 'get-content-versions: returns id/updated_at pairs for existing sources only',
+  ignore: skip,
+  async fn() {
+    const { userId, apiKey } = await seed();
+
+    await withContentSource(userId, async (sourceId) => {
+      const result = await callFunction(
+        'get-content-versions',
+        { ids: [sourceId, 999999999] },
+        { token: apiKey }
+      );
+      const data = assertSuccess<Array<{ id: number; updated_at: string }>>(result);
+      assert(Array.isArray(data), `expected array, got ${JSON.stringify(data)?.slice(0, 120)}`);
+      assertEquals(data.length, 1, 'bogus id must not produce an entry');
+      assertEquals(data[0].id, sourceId);
+      assert(typeof data[0].updated_at === 'string' && data[0].updated_at.length > 0);
+      // Only the token pair, never full source rows — the endpoint exists to be tiny.
+      assertEquals(Object.keys(data[0]).sort(), ['id', 'updated_at']);
+    });
+  },
+});
+
+Deno.test({
+  name: 'updated_at triggers: child insert, real update, and delete bump the source token; no-op update does not',
+  ignore: skip,
+  async fn() {
+    const { userId } = await seed();
+
+    await withContentSource(userId, async (sourceId) => {
+      const tokenAtStart = await getSourceToken(sourceId);
+
+      // INSERT bumps the parent.
+      const spell = await insertTestSpell(sourceId, 'Token Test Spell');
+      const tokenAfterInsert = await getSourceToken(sourceId);
+      assertNotEquals(tokenAfterInsert, tokenAtStart, 'child INSERT must bump the source token');
+
+      // No-op UPDATE (identical values, the idempotent bot re-apply shape) bumps nothing.
+      const { error: noopError } = await admin
+        .from('spell')
+        .update({ name: 'Token Test Spell', description: 'Test spell.' })
+        .eq('id', spell.id);
+      assert(!noopError, `no-op update failed: ${noopError?.message}`);
+      const { data: spellAfterNoop } = await admin
+        .from('spell')
+        .select('updated_at')
+        .eq('id', spell.id)
+        .single();
+      assertEquals(spellAfterNoop?.updated_at, spell.updated_at, 'no-op update must not stamp the row');
+      assertEquals(await getSourceToken(sourceId), tokenAfterInsert, 'no-op update must not bump the source token');
+
+      // Real UPDATE stamps the row and bumps the parent.
+      const { error: updateError } = await admin
+        .from('spell')
+        .update({ description: 'Edited test spell.' })
+        .eq('id', spell.id);
+      assert(!updateError, `update failed: ${updateError?.message}`);
+      const { data: spellAfterEdit } = await admin
+        .from('spell')
+        .select('updated_at')
+        .eq('id', spell.id)
+        .single();
+      assertNotEquals(spellAfterEdit?.updated_at, spell.updated_at, 'real update must stamp the row');
+      const tokenAfterEdit = await getSourceToken(sourceId);
+      assertNotEquals(tokenAfterEdit, tokenAfterInsert, 'real update must bump the source token');
+
+      // DELETE bumps the parent.
+      const { error: deleteError } = await admin.from('spell').delete().eq('id', spell.id);
+      assert(!deleteError, `delete failed: ${deleteError?.message}`);
+      assertNotEquals(await getSourceToken(sourceId), tokenAfterEdit, 'child DELETE must bump the source token');
+    });
+  },
+});

--- a/supabase/functions/_tests/seed.ts
+++ b/supabase/functions/_tests/seed.ts
@@ -134,16 +134,25 @@ export async function callFunction(
   // loaded CI runner that first call can 5xx with a boot error even though the stack
   // is healthy, which made e2e flaky (a test would fail on whichever function it hit
   // first). Retry 5xx a couple times with a pause; real assertions run on the reply.
+  // A dying cold worker can also cut the connection mid-response, which surfaces as a
+  // THROWN TypeError from fetch()/res.text() rather than a 5xx status ("error reading
+  // a body from connection") — treat that exactly like a boot 5xx and retry it too.
   const MAX_TRIES = 3;
   let res: Response = undefined as unknown as Response;
   let text = '';
   for (let attempt = 1; attempt <= MAX_TRIES; attempt++) {
-    res = await fetch(`${FUNCTIONS_URL}/${name}`, {
-      method: 'POST',
-      headers,
-      body: JSON.stringify(body ?? {}),
-    });
-    text = await res.text();
+    try {
+      res = await fetch(`${FUNCTIONS_URL}/${name}`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(body ?? {}),
+      });
+      text = await res.text();
+    } catch (err) {
+      if (attempt === MAX_TRIES) throw err;
+      await new Promise((r) => setTimeout(r, 1500 * attempt));
+      continue;
+    }
     if (res.status < 500 || attempt === MAX_TRIES) break;
     await new Promise((r) => setTimeout(r, 1500 * attempt));
   }

--- a/supabase/functions/get-content-versions/index.ts
+++ b/supabase/functions/get-content-versions/index.ts
@@ -1,0 +1,51 @@
+// @ts-ignore
+import { serve } from 'std/server';
+import { TableName, connect } from '../_shared/helpers.ts';
+
+/**
+ * Freshness probe for the client's persisted content cache.
+ *
+ * Returns the change token (`updated_at`, trigger-maintained per migration
+ * 20260718000000) for each requested content source. A cached client compares
+ * these against the tokens stored in its IndexedDB corpus blob on page load and
+ * drops the cache on any mismatch. Called once per page load by warm-cache
+ * clients, so the response must stay tiny: id + updated_at only, never full
+ * source rows (~5 KB vs ~247 KB for the official source set).
+ */
+serve(async (req: Request) => {
+  return await connect(req, async (client, body) => {
+    const { ids } = body as { ids?: unknown };
+
+    // Validate strictly: this is a public endpoint (verify_jwt = false).
+    if (
+      !Array.isArray(ids) ||
+      ids.length === 0 ||
+      ids.length > 500 ||
+      !ids.every((id) => typeof id === 'number' && Number.isFinite(id))
+    ) {
+      return {
+        status: 'fail',
+        data: { message: 'ids must be a non-empty array of at most 500 numbers.' },
+      };
+    }
+
+    // Column-selected direct query instead of fetchData: fetchData selects '*'
+    // (the whole 247 KB source set) and this endpoint exists to be cheap.
+    const { data, error } = await client
+      .from('content_source' satisfies TableName)
+      .select('id, updated_at')
+      .in('id', ids);
+    if (error) {
+      console.error('Error fetching content versions:', error);
+      return {
+        status: 'error',
+        message: 'Failed to fetch content versions.',
+      };
+    }
+
+    return {
+      status: 'success',
+      data: data ?? [],
+    };
+  });
+});

--- a/supabase/migrations/20260718000000_content_updated_at.sql
+++ b/supabase/migrations/20260718000000_content_updated_at.sql
@@ -1,0 +1,134 @@
+-- Change-tracking for the content corpus, powering client cache invalidation.
+--
+-- Adds `updated_at` to all 13 content tables and rolls every child-table change up
+-- into `content_source.updated_at`, giving each source a single "this source or
+-- anything in it last changed at T" token. Because the tracking lives in triggers,
+-- EVERY writer participates automatically: edge functions, the content-update bot
+-- (github role), admin tools, and manual SQL. No app code has to remember anything.
+--
+-- Clients persist the content corpus in IndexedDB (frontend content-store.ts) and
+-- compare their cached per-source tokens against `get-content-versions` on load;
+-- any mismatch drops the cache. See PR for the client half.
+--
+-- Safe to deploy independently of the app: until the client ships, the column is
+-- simply an extra field on find-* responses that old clients ignore.
+
+-- ─── 1. updated_at on all 13 content tables ──────────────────────────────────
+-- Same pattern as 20260625000000_character_updated_at.sql: add nullable, backfill
+-- from created_at (rows haven't been "updated" since), then default + NOT NULL.
+
+do $$
+declare
+  t text;
+begin
+  foreach t in array array[
+    'ability_block', 'ancestry', 'archetype', 'background', 'class',
+    'class_archetype', 'content_source', 'creature', 'item', 'language',
+    'spell', 'trait', 'versatile_heritage'
+  ] loop
+    execute format('alter table public.%I add column if not exists updated_at timestamptz', t);
+    execute format('update public.%I set updated_at = coalesce(updated_at, created_at, now()) where updated_at is null', t);
+    execute format('alter table public.%I alter column updated_at set default now()', t);
+    execute format('alter table public.%I alter column updated_at set not null', t);
+  end loop;
+end $$;
+
+-- ─── 2. Row-level stamp: BEFORE UPDATE on all 13 tables ──────────────────────
+-- Bumps updated_at on real changes only. The no-op guard matters twice over:
+--  * the content-update bot re-applies payloads idempotently; a write that changes
+--    nothing must not move tokens (or every client cache would invalidate for free);
+--  * the parent-bump UPDATE below explicitly sets updated_at = now() and changes
+--    nothing else, so the guard's RETURN NEW passes that explicit value through
+--    untouched (no special-case trigger needed for content_source).
+
+create or replace function public.set_content_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  if (to_jsonb(new) - 'updated_at') is not distinct from (to_jsonb(old) - 'updated_at') then
+    return new;
+  end if;
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+do $$
+declare
+  t text;
+begin
+  foreach t in array array[
+    'ability_block', 'ancestry', 'archetype', 'background', 'class',
+    'class_archetype', 'content_source', 'creature', 'item', 'language',
+    'spell', 'trait', 'versatile_heritage'
+  ] loop
+    execute format('drop trigger if exists %I on public.%I', t || '_set_updated_at', t);
+    execute format(
+      'create trigger %I before update on public.%I for each row execute function public.set_content_updated_at()',
+      t || '_set_updated_at', t
+    );
+  end loop;
+end $$;
+
+-- ─── 3. Parent bump: AFTER INSERT/UPDATE/DELETE on the 12 child tables ───────
+-- SECURITY DEFINER is load-bearing: the bump runs with the CALLER's privileges
+-- otherwise, and content_source UPDATE policies don't cover every child-writer
+-- (notably the bot's github role) — the bump would silently match zero rows and
+-- the invalidation signal would be lost, which is exactly the bug this migration
+-- exists to fix. The table owner bypasses (non-FORCE) RLS.
+--
+-- OLD/NEW are only assigned for the relevant TG_OP (referencing the wrong one
+-- raises at runtime and would abort the write), hence the branching.
+
+create or replace function public.bump_content_source_updated_at()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  sids bigint[];
+begin
+  if tg_op = 'INSERT' then
+    sids := array[new.content_source_id];
+  elsif tg_op = 'DELETE' then
+    sids := array[old.content_source_id];
+  else
+    -- Idempotent re-apply (row unchanged apart from updated_at): no signal.
+    if (to_jsonb(new) - 'updated_at') is not distinct from (to_jsonb(old) - 'updated_at') then
+      return null;
+    end if;
+    -- Both ids so moving content between sources bumps the old AND new source.
+    sids := array[old.content_source_id, new.content_source_id];
+  end if;
+
+  -- id = any(array[null]) matches nothing, which quietly covers the nullable
+  -- language.content_source_id. The updated_at predicate dedupes bulk writes:
+  -- now() is transaction-stable, so N child rows written in one transaction
+  -- produce exactly one parent row-version instead of N.
+  update public.content_source
+    set updated_at = now()
+    where id = any (sids)
+      and updated_at is distinct from now();
+
+  return null;
+end;
+$$;
+
+do $$
+declare
+  t text;
+begin
+  foreach t in array array[
+    'ability_block', 'ancestry', 'archetype', 'background', 'class',
+    'class_archetype', 'creature', 'item', 'language',
+    'spell', 'trait', 'versatile_heritage'
+  ] loop
+    execute format('drop trigger if exists %I on public.%I', t || '_bump_source_updated_at', t);
+    execute format(
+      'create trigger %I after insert or update or delete on public.%I for each row execute function public.bump_content_source_updated_at()',
+      t || '_bump_source_updated_at', t
+    );
+  end loop;
+end $$;


### PR DESCRIPTION
## Why

The IndexedDB content cache (added June 26) has no invalidation signal. Content-update bot applies (~9 edits/day), homebrew edits as seen by subscribers and the author's other devices, and admin tool writes all serve stale for the full TTL, and a page refresh does not fix it because the refresh re-hydrates the stale blob. Full audit in the session that produced this PR: user data (inventories, encounter combatants, characters) embeds copies and was never affected; the gap is exactly the shared content corpus.

## How

**DB, migration `20260718000000_content_updated_at.sql`**
- `updated_at` on all 13 content tables (backfilled from `created_at`, then default + NOT NULL), following the `character_updated_at` pattern.
- A shared BEFORE UPDATE trigger stamps rows on real changes only. No-op writes, such as idempotent bot re-applies, do not move tokens.
- An AFTER INSERT/UPDATE/DELETE trigger on the 12 child tables rolls every change up into `content_source.updated_at`, so each source carries one token meaning "this source or anything in it last changed at T". SECURITY DEFINER so RLS can never silently swallow the bump (the bot's `github` role matches no `content_source` UPDATE policy). Bulk imports coalesce to one bump per source per transaction via the tx-stable `now()` predicate.
- Because tracking is in triggers, every writer participates automatically: edge functions, the bot, admin tools, manual SQL, and anything added later.

**Server**
- New `get-content-versions` endpoint: POST `{ids: number[]}` (max 500) returns `[{id, updated_at}]`, about 5 KB versus 247 KB for full source rows. `verify_jwt = false` like the other public content reads.
- `insertData`/`updateData` now strip `updated_at` so replayed full-row payloads cannot rewind a token.

**Client**
- On load, a persisted corpus blob is hydrated only after one token check against the server; a mismatch or a deleted source drops the blob and the normal cold fetch takes over.
- Fail-open: if the check cannot run (offline, endpoint or migration not deployed yet), the cache is trusted, which makes every deploy order safe. TTL raised to 24h as the backstop for exactly those cases; cache version bumped to 2 to retire token-less blobs once.
- One check per page load (memoized across the repeated `resetContentStore` re-hydrations), and a stale verdict re-reads before deleting so it can never clobber a blob that was just re-persisted from fresh data.

## Verification

- Full API test suite on the local compose stack: 36 passed, 0 failed (2 pre-existing failures were the local DB lagging the July 17 secret-column migrations; applying them locally cleared both).
- New tests cover endpoint validation, response shape, and the trigger matrix (insert bumps, no-op does not, real update bumps row + source, delete bumps).
- psql assertions: explicit token writes persist, bulk inserts land one tx-stable token, NULL-source `language` rows write cleanly, whole-source deletes cascade.
- Browser end-to-end on the local stack: warm reload makes exactly one `get-content-versions` call and zero corpus fetches; a psql edit to Fireball bumped source 3's token and the next reload dropped + refetched exactly once (re-persisted blob carries the new token verbatim); the following reload hydrates again. All 87 cached source rows carry token strings (the zod passthrough works).
- Rollout rehearsal against prod, where neither migration nor endpoint exists: the check fails, the cache is trusted, the public sheet renders normally.

## Rollout (after merge)

1. Apply the migration to prod off-peak (backfill rewrites the large content tables).
2. Deploy `get-content-versions` from clean `origin/main`, preserving verify_jwt config.
3. Live-verify: endpoint returns pairs; a trivial content edit bumps its source token; a warm client drops once and shows the edit.

Each stage is independently safe in any order thanks to the fail-open client.

**Accepted limitation**: checks run at page load; a tab that never reloads serves its in-session content until refreshed. That matches the bug being fixed ("refresh doesn't help").

Note: `data/schema.sql` intentionally not hand-edited; the `db_dump.yml` workflow refreshes it from prod after the migration lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)