### PR TITLE
Invalidate the characters list after creating a character

### DIFF
--- a/frontend/src/pages/CharactersPage.tsx
+++ b/frontend/src/pages/CharactersPage.tsx
@@ -69,6 +69,7 @@ import { useAtom, useAtomValue } from 'jotai';
 export function Component() {
   setPageTitle(`Characters`);
   const session = useAtomValue(sessionState);
+  const queryClient = useQueryClient();
 
   const { data, isLoading, refetch } = useQuery({
     queryKey: [`find-character`],
@@ -124,6 +125,12 @@ export function Component() {
   const handleCreateCharacter = async () => {
     const character = await createCharacter();
     if (character) {
+      // We navigate away immediately, so the list query stays cached. With the
+      // global staleTime (main.tsx), coming back within that window would render
+      // the pre-creation list — the new character invisible for up to a minute
+      // (and the e2e cleanup, which returns here to delete it, never finds it).
+      // Mark the list stale so the next mount refetches.
+      queryClient.invalidateQueries({ queryKey: ['find-character'] });
       navigate(`/builder/${character.id}`);
     }
     setLoadingCreateCharacter(false);


### PR DESCRIPTION
## Summary
- Creating a character navigates to the builder without invalidating the `['find-character']` list query. With the global `staleTime: 60s` from PR #270, coming back to the characters page within that window shows the cached pre-creation list, and the new character is invisible for up to a minute.
- This is also the root cause of the two failing Cypress specs (characterBuilder, preparedCaster): their cleanup returns to the characters page to delete the test character and finds "No characters found". CI never caught it because e2e was already failing at the API step (missing migrations, fixed in PR #277) from minutes before PR #270 merged, so Cypress has been blind since July 17.
- Fix: mark the list stale on successful create so the next mount refetches. The copy, delete, and import paths already refetch explicitly.

## Verification
- Reproduced live against the local stack: create then return within the stale window showed only the old list (character present in DB but invisible). With the fix, the same flow (real button click, 31s elapsed) shows the new character immediately.
- tsc clean; the one eslint warning in the file predates this change.
- The same commit is cherry-picked into PR #277 so its e2e run can go fully green; whichever merges second becomes a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)