### PR TITLE
Retry cold-worker failures in the raw-fetch rate-limit tests

### DIFF
--- a/supabase/functions/_tests/rate-limit.test.ts
+++ b/supabase/functions/_tests/rate-limit.test.ts
@@ -8,13 +8,36 @@ import { FUNCTIONS_URL, seed, stackUnavailable } from './seed.ts';
 
 const skip = stackUnavailable();
 
+/**
+ * Raw fetch with the same cold-worker retry as callFunction in seed.ts. These
+ * tests can't use callFunction (it consumes the body and discards the Response,
+ * and the headers are the whole point here), so they need their own guard: a
+ * booting edge worker can 5xx or cut the connection before the limiter runs.
+ * Retries boot 5xxs and thrown network errors; returns the first real reply.
+ */
+async function rawFetchWithRetry(init: RequestInit): Promise<Response> {
+  const MAX_TRIES = 3;
+  let res: Response | null = null;
+  for (let attempt = 1; attempt <= MAX_TRIES; attempt++) {
+    try {
+      res = await fetch(`${FUNCTIONS_URL}/find-spell`, init);
+      if (res.status < 500 || attempt === MAX_TRIES) return res;
+      await res.body?.cancel();
+    } catch (err) {
+      if (attempt === MAX_TRIES) throw err;
+    }
+    await new Promise((r) => setTimeout(r, 1500 * attempt));
+  }
+  return res!;
+}
+
 Deno.test({
   name: 'rate-limit: every response carries X-RateLimit-* headers',
   ignore: skip,
   async fn() {
     const { apiKey } = await seed();
     // The plain fetch (not callFunction) lets us read the headers.
-    const res = await fetch(`${FUNCTIONS_URL}/find-spell`, {
+    const res = await rawFetchWithRetry({
       method: 'POST',
       headers: {
         Authorization: `Bearer ${apiKey}`,
@@ -37,7 +60,7 @@ Deno.test({
   ignore: skip,
   async fn() {
     const fakeKey = '00000000-0000-0000-0000-000000000001';
-    const res = await fetch(`${FUNCTIONS_URL}/find-spell`, {
+    const res = await rawFetchWithRetry({
       method: 'POST',
       headers: {
         Authorization: `Bearer ${fakeKey}`,


### PR DESCRIPTION
## Summary
- The two rate-limit tests use a raw `fetch` on purpose (the response headers are what they assert; `callFunction` consumes the body and discards the Response), which made them the last tests still exposed to the CI cold-worker flake: a booting edge-function worker can return a boot 5xx or cut the connection before the limiter runs.
- This bit PR #274's e2e run (500 where 200 was expected) right after the same failure mode was fixed inside `callFunction` for every other test.
- Fix: a small `rawFetchWithRetry` helper in the test file with the same bounded retry/backoff as `callFunction`, preserving direct header access. Retried 5xx bodies are cancelled to keep the Deno sanitizer happy.

## Verification
- Both tests pass locally against the compose stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)