### PR TITLE
fix(content-updates): don't narrow item pickers to the edited book

### DIFF
--- a/frontend/src/modals/ContentFeedbackModal.tsx
+++ b/frontend/src/modals/ContentFeedbackModal.tsx
@@ -8,6 +8,7 @@ import {
   defineDefaultSources,
   fetchAbilityBlockByName,
   fetchContentById,
+  fetchContentSources,
   fetchCreatureByName,
   fetchItemByName,
   fetchSpellByName,
@@ -50,8 +51,17 @@ export default function ContentFeedbackModal(props: {
       props.onStartFeedback();
       setSubmitUpdate({ id: undefined, content: props.type });
 
-      // Add the content source to make sure we can reference it's content
-      defineDefaultSources('INFO', props.data.contentSourceId ? [props.data.contentSourceId] : 'ALL-USER-ACCESSIBLE');
+      // Make sure we can reference this source's content (it may be unpublished) WITHOUT
+      // narrowing the scope to just it — the editor's item pickers (base item, property
+      // runes, upgrades) list from these sources, and runes live in other books.
+      defineDefaultSources('INFO', 'ALL-USER-ACCESSIBLE');
+      const sourceId = props.data.contentSourceId;
+      if (sourceId) {
+        void (async () => {
+          const accessible = await fetchContentSources('ALL-USER-ACCESSIBLE');
+          defineDefaultSources('INFO', [...accessible.map((s) => s.id), sourceId]);
+        })();
+      }
     }
   }, []);
 


### PR DESCRIPTION
## Problem

Reported in Discord #content-curation (2026-07-28): property runes can't be added to weapons or armor being created via a content update.

## Cause

Since efc46409 ("Reworked content sources", Dec 27), starting a content-update **creation** runs:

```ts
defineDefaultSources('INFO', props.data.contentSourceId ? [props.data.contentSourceId] : 'ALL-USER-ACCESSIBLE');
```

The comment says "Add the content source to make sure we can reference it's content", but `defineDefaultSources` **replaces** the scope rather than adding — so the editor's lookup scope becomes just `[Common Core, edited-book]`. The item editor's pickers (base item, property runes, upgrade slots) list items from that scope. Common Core contains no runes, so creating an item in any book that doesn't itself contain rune items yields an empty property-rune picker. The DB shows the last successful property-rune submission was 2026-03-04; before that, August 2025 (pre-change). It intermittently still worked because the pickers' react-query key is static, so a session that had already loaded the broad corpus kept serving it.

## Fix

Set INFO sources to the full accessible corpus synchronously, then extend with the edited book once the accessible source list resolves. The extension still matters: unpublished in-progress books aren't part of `'ALL-USER-ACCESSIBLE'`, and referencing their content is what the original change was legitimately protecting.

## Verification

- `tsc --noEmit` clean.
- Against prod data, simulating the exact picker fetch + filter for book 839 (Bastion of Blasphemies, where the report originated): old narrowed scope → 21 items, **0** property-rune options; new union scope → 6,238 items, **189** property-rune options across 99 sources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)