### PR TITLE
fix: react-query serving content from the wrong source scope

### DIFF
--- a/frontend/src/common/CreatureInfo.tsx
+++ b/frontend/src/common/CreatureInfo.tsx
@@ -23,7 +23,7 @@ import TraitsDisplay from './TraitsDisplay';
 import { StoreID, VariableStr } from '@schemas/variables';
 import { getAllAncestryTraitVariables, getVariable } from '@variables/variable-manager';
 import { useQuery } from '@tanstack/react-query';
-import { fetchContentAll, getDefaultSources } from '@content/content-store';
+import { fetchContentAll, getDefaultSources, getDefaultSourcesKey } from '@content/content-store';
 import { isTruthy } from '@utils/type-fixing';
 import { convertToSize } from '@upload/foundry-utils';
 
@@ -39,7 +39,7 @@ export function CreatureDetailedInfo(props: { id: StoreID; creature: Creature })
   // const conditions = props.creature?.details?.conditions ?? [];
 
   const { data } = useQuery({
-    queryKey: [`get-traits`],
+    queryKey: [`get-traits`, { sources: getDefaultSourcesKey('INFO') }],
     queryFn: async () => {
       return await fetchContentAll<Trait>('trait', getDefaultSources('INFO'));
     },

--- a/frontend/src/common/ItemSelect.tsx
+++ b/frontend/src/common/ItemSelect.tsx
@@ -1,4 +1,4 @@
-import { fetchContentAll, getDefaultSources } from '@content/content-store';
+import { fetchContentAll, getDefaultSources, getDefaultSourcesKey } from '@content/content-store';
 import { Autocomplete, TagsInput } from '@mantine/core';
 import { useQuery } from '@tanstack/react-query';
 import { Item } from '@schemas/content';
@@ -18,7 +18,7 @@ export function ItemSelect(props: {
   onChange: (item?: Item, name?: string) => void;
 }) {
   const { data, isFetching } = useQuery({
-    queryKey: [`get-items`],
+    queryKey: [`get-items`, { sources: getDefaultSourcesKey('INFO') }],
     queryFn: async () => {
       return await fetchContentAll<Item>('item', getDefaultSources('INFO'));
     },
@@ -54,7 +54,7 @@ export function ItemMultiSelect(props: {
   onChange: (items?: Item[], names?: string[]) => void;
 }) {
   const { data, isFetching } = useQuery({
-    queryKey: [`get-items`],
+    queryKey: [`get-items`, { sources: getDefaultSourcesKey('INFO') }],
     queryFn: async () => {
       return await fetchContentAll<Item>('item', getDefaultSources('INFO'));
     },

--- a/frontend/src/common/TraitsInput.tsx
+++ b/frontend/src/common/TraitsInput.tsx
@@ -1,5 +1,5 @@
 import { isTraitVisible } from '@content/content-hidden';
-import { fetchContentAll, getDefaultSources } from '@content/content-store';
+import { fetchContentAll, getDefaultSources, getDefaultSourcesKey } from '@content/content-store';
 import { TagsInput, TagsInputProps } from '@mantine/core';
 import { useQuery } from '@tanstack/react-query';
 import { Trait } from '@schemas/content';
@@ -16,7 +16,7 @@ interface TraitsInputProps extends TagsInputProps {
 
 export default function TraitsInput(props: TraitsInputProps) {
   const { data, isFetching } = useQuery({
-    queryKey: [`get-traits`],
+    queryKey: [`get-traits`, { sources: getDefaultSourcesKey('INFO') }],
     queryFn: async () => {
       return await fetchContentAll<Trait>('trait', getDefaultSources('INFO'));
     },

--- a/frontend/src/common/operations/selection/InjectSelectOptionOperation.tsx
+++ b/frontend/src/common/operations/selection/InjectSelectOptionOperation.tsx
@@ -1,4 +1,4 @@
-import { fetchContentAll, getDefaultSources } from '@content/content-store';
+import { fetchContentAll, getDefaultSources, getDefaultSourcesKey } from '@content/content-store';
 import { OperationWrapper } from '../Operations';
 import { Select, Stack } from '@mantine/core';
 import { useDidUpdate } from '@mantine/hooks';
@@ -21,7 +21,7 @@ export function InjectSelectOptionOperation(props: {
   const [option, setOption] = useState<InjectedSelectOption | null>(props.value ? JSON.parse(props.value) : null);
 
   const { data, isFetching } = useQuery({
-    queryKey: [`get-all-selection-options`],
+    queryKey: [`get-all-selection-options`, { sources: getDefaultSourcesKey('PAGE') }],
     queryFn: async () => {
       const operations: Operation[] = [];
 

--- a/frontend/src/common/select/SelectContent.tsx
+++ b/frontend/src/common/select/SelectContent.tsx
@@ -4,7 +4,7 @@ import { creatureDrawerState, drawerState } from '@atoms/navAtoms';
 import { ActionSymbol } from '@common/Actions';
 import { BuyItemButton } from '@common/BuyItemButton';
 import TraitsDisplay from '@common/TraitsDisplay';
-import { fetchContentAll, fetchContentById, getDefaultSources } from '@content/content-store';
+import { fetchContentAll, fetchContentById, getDefaultSources, getDefaultSourcesKey } from '@content/content-store';
 import { isActionCost } from '@content/content-utils';
 import { isItemArchaic } from '@items/inv-utils';
 import {
@@ -488,7 +488,10 @@ export default function SelectContentModal({
   }, [innerProps.options?.overrideOptions, innerProps.options?.abilityBlockType]);
 
   const { data: versHeritageData } = useQuery({
-    queryKey: [`select-content-vers-heritage-data`, { selectedId: innerProps.options?.selectedId }],
+    queryKey: [
+      `select-content-vers-heritage-data`,
+      { selectedId: innerProps.options?.selectedId, sources: getDefaultSourcesKey('PAGE') },
+    ],
     queryFn: async ({ queryKey }) => {
       // @ts-ignore
 
@@ -745,7 +748,14 @@ function SelectionOptions(props: {
   const sortByPrereqs = props.abilityBlockType === 'feat' && (character?.options?.auto_detect_prerequisites ?? false);
 
   const { data, isFetching } = useQuery({
-    queryKey: [`select-content-options-${props.type}`, { sourceId: props.sourceId }],
+    queryKey: [
+      `select-content-options-${props.type}`,
+      {
+        sourceId: props.sourceId,
+        // Default sources only matter when no specific source is pinned (mirrors the queryFn's fallback)
+        sources: props.sourceId === 'all' || !props.sourceId ? getDefaultSourcesKey('PAGE') : null,
+      },
+    ],
     queryFn: async ({ queryKey }) => {
       // @ts-ignore
       const [_key, { sourceId }] = queryKey;

--- a/frontend/src/drawers/types/AncestryDrawer.tsx
+++ b/frontend/src/drawers/types/AncestryDrawer.tsx
@@ -5,7 +5,7 @@ import RichText from '@common/RichText';
 import TraitsDisplay from '@common/TraitsDisplay';
 import { FeatSelectionOption, HeritageSelectionOption } from '@common/select/SelectContent';
 import { isAbilityBlockVisible } from '@content/content-hidden';
-import { fetchContentAll, fetchContentById, getDefaultSources } from '@content/content-store';
+import { fetchContentAll, fetchContentById, getDefaultSources, getDefaultSourcesKey } from '@content/content-store';
 import { getIconFromContentType } from '@content/content-utils';
 import ShowOperationsButton from '@drawers/ShowOperationsButton';
 import { getMetadataOpenedDict } from '@drawers/drawer-utils';
@@ -96,7 +96,7 @@ export function AncestryDrawerContent(props: {
   const id = props.data.id;
 
   const { data, isFetching, refetch } = useQuery({
-    queryKey: [`find-ancestry-details-${id}`, { id }],
+    queryKey: [`find-ancestry-details-${id}`, { id, sources: getDefaultSourcesKey('INFO') }],
     queryFn: async ({ queryKey }) => {
       // @ts-ignore
        

--- a/frontend/src/drawers/types/ArchetypeDrawer.tsx
+++ b/frontend/src/drawers/types/ArchetypeDrawer.tsx
@@ -3,7 +3,7 @@ import RichText from '@common/RichText';
 import TraitsDisplay from '@common/TraitsDisplay';
 import { FeatSelectionOption } from '@common/select/SelectContent';
 import { isAbilityBlockVisible } from '@content/content-hidden';
-import { fetchContentAll, fetchContentById, getDefaultSources } from '@content/content-store';
+import { fetchContentAll, fetchContentById, getDefaultSources, getDefaultSourcesKey } from '@content/content-store';
 import { getMetadataOpenedDict } from '@drawers/drawer-utils';
 import {
   Accordion,
@@ -80,7 +80,7 @@ export function ArchetypeDrawerContent(props: {
   const id = props.data.id;
 
   const { data, isFetching, refetch } = useQuery({
-    queryKey: [`find-archetype-details-${id}`, { id }],
+    queryKey: [`find-archetype-details-${id}`, { id, sources: getDefaultSourcesKey('INFO') }],
     queryFn: async ({ queryKey }) => {
       // @ts-ignore
        

--- a/frontend/src/drawers/types/ClassArchetypeDrawer.tsx
+++ b/frontend/src/drawers/types/ClassArchetypeDrawer.tsx
@@ -3,7 +3,7 @@ import RichText from '@common/RichText';
 import TraitsDisplay from '@common/TraitsDisplay';
 import { ClassFeatureSelectionOption, FeatSelectionOption } from '@common/select/SelectContent';
 import { isAbilityBlockVisible } from '@content/content-hidden';
-import { fetchContentAll, fetchContentById, getDefaultSources } from '@content/content-store';
+import { fetchContentAll, fetchContentById, getDefaultSources, getDefaultSourcesKey } from '@content/content-store';
 import ShowOperationsButton from '@drawers/ShowOperationsButton';
 import { getMetadataOpenedDict } from '@drawers/drawer-utils';
 import {
@@ -86,7 +86,7 @@ export function ClassArchetypeDrawerContent(props: {
   const id = props.data.id;
 
   const { data, isFetching, refetch } = useQuery({
-    queryKey: [`find-class-archetype-details-${id}`, { id }],
+    queryKey: [`find-class-archetype-details-${id}`, { id, sources: getDefaultSourcesKey('INFO') }],
     queryFn: async ({ queryKey }) => {
       // @ts-ignore
        

--- a/frontend/src/drawers/types/ClassDrawer.tsx
+++ b/frontend/src/drawers/types/ClassDrawer.tsx
@@ -5,7 +5,7 @@ import RichText from '@common/RichText';
 import TraitsDisplay from '@common/TraitsDisplay';
 import { FeatSelectionOption } from '@common/select/SelectContent';
 import { isAbilityBlockVisible } from '@content/content-hidden';
-import { fetchContentAll, fetchContentById, getDefaultSources } from '@content/content-store';
+import { fetchContentAll, fetchContentById, getDefaultSources, getDefaultSourcesKey } from '@content/content-store';
 import ShowOperationsButton from '@drawers/ShowOperationsButton';
 import { getMetadataOpenedDict } from '@drawers/drawer-utils';
 import {
@@ -108,7 +108,7 @@ export function ClassDrawerContent(props: {
   const id = props.data.id;
 
   const { data, isFetching, refetch } = useQuery({
-    queryKey: [`find-class-details-${id}`, { id }],
+    queryKey: [`find-class-details-${id}`, { id, sources: getDefaultSourcesKey('INFO') }],
     queryFn: async ({ queryKey }) => {
       // @ts-ignore
        

--- a/frontend/src/drawers/types/CreatureDrawer.tsx
+++ b/frontend/src/drawers/types/CreatureDrawer.tsx
@@ -4,7 +4,13 @@ import { glassStyle } from '@utils/colors';
 import { DisplayIcon } from '@common/IconDisplay';
 import StatBlockSection from '@common/StatBlockSection';
 import { applyConditions } from '@conditions/condition-handler';
-import { fetchContentById, fetchContentPackage, fetchTraits, getDefaultSources } from '@content/content-store';
+import {
+  fetchContentById,
+  fetchContentPackage,
+  fetchTraits,
+  getDefaultSources,
+  getDefaultSourcesKey,
+} from '@content/content-store';
 import { getMetadataOpenedDict } from '@drawers/drawer-utils';
 import { addExtraItems, checkBulkLimit } from '@items/inv-handlers';
 import { applyEquipmentPenalties } from '@items/inv-utils';
@@ -123,7 +129,7 @@ export function CreatureDrawerContent(props: {
   const view = props.data.readOnly ? 'BLOCK' : drawerData.view;
 
   const { data: content, isFetching, refetch } = useQuery({
-    queryKey: [`find-creature-details-${id}`, { id }],
+    queryKey: [`find-creature-details-${id}`, { id, sources: getDefaultSourcesKey('INFO') }],
     queryFn: async ({ queryKey }) => {
       // @ts-ignore
        

--- a/frontend/src/drawers/types/StatPerceptionDrawer.tsx
+++ b/frontend/src/drawers/types/StatPerceptionDrawer.tsx
@@ -1,7 +1,7 @@
 import { drawerState } from '@atoms/navAtoms';
 import RichText from '@common/RichText';
 import { collectEntitySenses } from '@content/collect-content';
-import { fetchContentAll, getDefaultSources } from '@content/content-store';
+import { fetchContentAll, getDefaultSources, getDefaultSourcesKey } from '@content/content-store';
 import { convertToHardcodedLink } from '@content/hardcoded-links';
 import {
   Title,
@@ -73,7 +73,7 @@ export function StatPerceptionDrawerContent(props: { data: { id: StoreID } }) {
 
   // Collect senses info
   const { data: abilityBlocks } = useQuery({
-    queryKey: [`find-ability-blocks`],
+    queryKey: [`find-ability-blocks`, { sources: getDefaultSourcesKey('PAGE') }],
     queryFn: async () => {
       return await fetchContentAll<AbilityBlock>('ability-block', getDefaultSources('PAGE'));
     },

--- a/frontend/src/drawers/types/StatProfDrawer.tsx
+++ b/frontend/src/drawers/types/StatProfDrawer.tsx
@@ -1,7 +1,7 @@
 import { drawerState } from '@atoms/navAtoms';
 import RichText from '@common/RichText';
 import { ActionSelectionOption } from '@common/select/SelectContent';
-import { fetchContentAll, getDefaultSources } from '@content/content-store';
+import { fetchContentAll, getDefaultSources, getDefaultSourcesKey } from '@content/content-store';
 import { convertToHardcodedLink } from '@content/hardcoded-links';
 import {
   Title,
@@ -420,7 +420,10 @@ function SkillActionsSection(props: { variableName: string }) {
   const [_drawer, openDrawer] = useAtom(drawerState);
 
   const { data: actions } = useQuery({
-    queryKey: [`find-skill-actions-${props.variableName}`, { variableName: props.variableName }],
+    queryKey: [
+      `find-skill-actions-${props.variableName}`,
+      { variableName: props.variableName, sources: getDefaultSourcesKey('PAGE') },
+    ],
     queryFn: async ({ queryKey }) => {
       // @ts-ignore
        

--- a/frontend/src/drawers/types/VersatileHeritageDrawer.tsx
+++ b/frontend/src/drawers/types/VersatileHeritageDrawer.tsx
@@ -3,7 +3,7 @@ import RichText from '@common/RichText';
 import TraitsDisplay from '@common/TraitsDisplay';
 import { FeatSelectionOption } from '@common/select/SelectContent';
 import { isAbilityBlockVisible } from '@content/content-hidden';
-import { fetchContentAll, fetchContentById, getDefaultSources } from '@content/content-store';
+import { fetchContentAll, fetchContentById, getDefaultSources, getDefaultSourcesKey } from '@content/content-store';
 import { getMetadataOpenedDict } from '@drawers/drawer-utils';
 import {
   Accordion,
@@ -82,7 +82,7 @@ export function VersatileHeritageDrawerContent(props: {
   const id = props.data.id;
 
   const { data, isFetching, refetch } = useQuery({
-    queryKey: [`find-versatileHeritage-details-${id}`, { id }],
+    queryKey: [`find-versatileHeritage-details-${id}`, { id, sources: getDefaultSourcesKey('INFO') }],
     queryFn: async ({ queryKey }) => {
       // @ts-ignore
        

--- a/frontend/src/modals/AddItemsModal.tsx
+++ b/frontend/src/modals/AddItemsModal.tsx
@@ -1,6 +1,6 @@
 import { drawerState } from '@atoms/navAtoms';
 import { ItemSelectionOption } from '@common/select/SelectContent';
-import { fetchContentAll, getDefaultSources } from '@content/content-store';
+import { fetchContentAll, getDefaultSources, getDefaultSourcesKey } from '@content/content-store';
 import {
   ActionIcon,
   Center,
@@ -42,7 +42,7 @@ export default function AddItemsModal({
   const [advancedSearchOpen, setAdvancedSearchOpen] = useState(false);
 
   const { data: rawItems, isFetching } = useQuery({
-    queryKey: [`find-items-add-items`],
+    queryKey: [`find-items-add-items`, { sources: getDefaultSourcesKey('PAGE') }],
     queryFn: async () => {
       return (await fetchContentAll<Item>('item', getDefaultSources('PAGE'))).filter((item) =>
         isItemVisible('CHARACTER', item)

--- a/frontend/src/modals/CreateCreatureModal.tsx
+++ b/frontend/src/modals/CreateCreatureModal.tsx
@@ -1,7 +1,7 @@
 import { OperationSection } from '@common/operations/Operations';
 import RichTextInput from '@common/rich_text_input/RichTextInput';
 import { DISCORD_URL } from '@constants/urls';
-import { fetchContentAll, fetchContentById, getDefaultSources } from '@content/content-store';
+import { fetchContentAll, fetchContentById, getDefaultSources, getDefaultSourcesKey } from '@content/content-store';
 import { toHTML } from '@content/content-utils';
 import {
   ActionIcon,
@@ -121,7 +121,7 @@ export function CreateCreatureModal(props: {
 
   // Get all ability blocks
   const { data: abilityBlocks } = useQuery({
-    queryKey: [`get-all-ability-blocks`],
+    queryKey: [`get-all-ability-blocks`, { sources: getDefaultSourcesKey('INFO') }],
     queryFn: async () => {
       return await fetchContentAll<AbilityBlock>('ability-block', getDefaultSources('INFO'));
     },

--- a/frontend/src/modals/ManageSpellsModal.tsx
+++ b/frontend/src/modals/ManageSpellsModal.tsx
@@ -3,7 +3,7 @@ import { SelectContentButton, SpellSelectionOption, selectContent } from '@commo
 import { EDIT_MODAL_HEIGHT, IMPRINT_BG_COLOR } from '@constants/data';
 import { collectEntitySpellcasting } from '@content/collect-content';
 import { isSpellVisible } from '@content/content-hidden';
-import { fetchContentAll, getDefaultSources } from '@content/content-store';
+import { fetchContentAll, getDefaultSources, getDefaultSourcesKey } from '@content/content-store';
 import {
   Box,
   Button,
@@ -57,7 +57,10 @@ export default function ManageSpellsModal(props: {
   const [_drawer, openDrawer] = useAtom(drawerState);
 
   const { data: allRawSpells, isFetching } = useQuery({
-    queryKey: [`find-spells-in-manage-spells-modal`, { entityId: props.entity?.id, source: props.source }],
+    queryKey: [
+      `find-spells-in-manage-spells-modal`,
+      { entityId: props.entity?.id, source: props.source, sources: getDefaultSourcesKey('PAGE') },
+    ],
     queryFn: async () => {
       return (await fetchContentAll<Spell>('spell', getDefaultSources('PAGE'))).filter((spell) =>
         isSpellVisible(props.id, spell)

--- a/frontend/src/pages/campaign/panels/EncountersPanel.tsx
+++ b/frontend/src/pages/campaign/panels/EncountersPanel.tsx
@@ -7,7 +7,7 @@ import { DisplayIcon } from '@common/IconDisplay';
 import { selectContent } from '@common/select/SelectContent';
 import { applyConditions } from '@conditions/condition-handler';
 import { GUIDE_BLUE, IMPRINT_BG_COLOR, IMPRINT_BORDER_COLOR } from '@constants/data';
-import { defineDefaultSources, fetchContentPackage, getDefaultSources } from '@content/content-store';
+import { defineDefaultSources, fetchContentPackage, getDefaultSources, getDefaultSourcesKey } from '@content/content-store';
 import { getBestArmor } from '@items/inv-utils';
 import {
   Tabs,
@@ -582,6 +582,8 @@ function EncounterView(props: {
       `computed-combatants`,
       {
         combatants: combatants,
+        // computeCombatants fetches content scoped by the default PAGE sources
+        sources: getDefaultSourcesKey('PAGE'),
       },
     ],
     queryFn: async () => {

--- a/frontend/src/pages/character_builder/CharBuilderCreation.tsx
+++ b/frontend/src/pages/character_builder/CharBuilderCreation.tsx
@@ -11,6 +11,7 @@ import {
   fetchContentPackage,
   fetchContentSources,
   getDefaultSources,
+  getDefaultSourcesKey,
   isContentPackageEmpty,
 } from '@content/content-store';
 import { getIconFromContentType } from '@content/content-utils';
@@ -75,7 +76,10 @@ export default function CharBuilderCreation(props: { characterId: number; pageHe
   const [doneLoading, setDoneLoading] = useState(false);
 
   const { data: content, isFetching, refetch } = useQuery({
-    queryKey: [`find-content-${props.characterId}-for-char-builder-creation`, { characterId: props.characterId }],
+    queryKey: [
+      `find-content-${props.characterId}-for-char-builder-creation`,
+      { characterId: props.characterId, sources: getDefaultSourcesKey('PAGE') },
+    ],
     queryFn: async () => {
       // Prefetch content sources (to avoid multiple requests)
       await fetchContentSources(getDefaultSources('PAGE'));

--- a/frontend/src/pages/character_builder/CharBuilderHome.tsx
+++ b/frontend/src/pages/character_builder/CharBuilderHome.tsx
@@ -205,9 +205,10 @@ export default function CharBuilderHome(props: { characterId: number; pageHeight
         resetContentStore();
         defineDefaultSources('PAGE', newEnabled ?? []);
         refetch();
-        queryClient.invalidateQueries({
-          queryKey: [`find-content-${character?.id}`, `get-character-init-builder-${character?.id}`],
-        });
+        // One call per query: a queryKey filter is an element-wise prefix, so combining these
+        // two root strings into a single filter array matches neither query.
+        queryClient.invalidateQueries({ queryKey: [`find-content-${character?.id}`] }); // character sheet content package
+        queryClient.invalidateQueries({ queryKey: [`get-character-init-builder-${character?.id}`] }); // builder character record
 
         // Save new enabled books to character
         return {

--- a/frontend/src/pages/character_sheet/panels/CompanionsPanel.tsx
+++ b/frontend/src/pages/character_sheet/panels/CompanionsPanel.tsx
@@ -1,6 +1,6 @@
 import { characterState } from '@atoms/characterAtoms';
 import { creatureDrawerState, drawerState } from '@atoms/navAtoms';
-import { fetchContentAll, fetchContentPackage, getDefaultSources } from '@content/content-store';
+import { fetchContentAll, fetchContentPackage, getDefaultSources, getDefaultSourcesKey } from '@content/content-store';
 import {
   Stack,
   Title,
@@ -500,7 +500,7 @@ function AddCompanionSection() {
   const isPhone = useMediaQuery(phoneQuery());
 
   const { data, isFetching } = useQuery({
-    queryKey: [`get-companions-data`],
+    queryKey: [`get-companions-data`, { sources: getDefaultSourcesKey('PAGE') }],
     queryFn: async () => {
       const traits = await fetchContentAll<Trait>('trait', getDefaultSources('PAGE'));
       const creatures = await fetchContentAll<Creature>('creature', getDefaultSources('PAGE'));

--- a/frontend/src/pages/character_sheet/panels/FeatsFeaturesPanel.tsx
+++ b/frontend/src/pages/character_sheet/panels/FeatsFeaturesPanel.tsx
@@ -6,7 +6,7 @@ import {
   HeritageSelectionOption,
   PhysicalFeatureSelectionOption,
 } from '@common/select/SelectContent';
-import { fetchContentAll, getContentFast, getDefaultSources } from '@content/content-store';
+import { fetchContentAll, getContentFast, getDefaultSources, getDefaultSourcesKey } from '@content/content-store';
 import {
   useMantineTheme,
   useMantineColorScheme,
@@ -42,7 +42,7 @@ export default function FeatsFeaturesPanel(props: { panelHeight: number; panelWi
   const [section, setSection] = useState('FEATS');
 
   const { data: rawData } = useQuery({
-    queryKey: [`find-feats-and-features`],
+    queryKey: [`find-feats-and-features`, { characterId: character?.id, sources: getDefaultSourcesKey('PAGE') }],
     queryFn: async () => {
       if (!character) return null;
 

--- a/frontend/src/pages/character_sheet/panels/SpellsPanel.tsx
+++ b/frontend/src/pages/character_sheet/panels/SpellsPanel.tsx
@@ -1,7 +1,7 @@
 import { ActionSymbol } from '@common/Actions';
 import TokenSelect from '@common/TokenSelect';
 import { collectEntitySpellcasting } from '@content/collect-content';
-import { fetchContentAll, getContentFast, getDefaultSources } from '@content/content-store';
+import { fetchContentAll, getContentFast, getDefaultSources, getDefaultSourcesKey } from '@content/content-store';
 import {
   Accordion,
   ActionIcon,
@@ -76,7 +76,7 @@ export default function SpellsPanel(props: {
   >();
 
   const { data: spells } = useQuery({
-    queryKey: [`find-spells-and-data`],
+    queryKey: [`find-spells-and-data`, { sources: getDefaultSourcesKey('PAGE') }],
     queryFn: async () => {
       if (!props.entity) return null;
 

--- a/frontend/src/process/content/content-store.ts
+++ b/frontend/src/process/content/content-store.ts
@@ -341,6 +341,25 @@ export function getDefaultSources(view: SourceKey) {
 }
 
 /**
+ * A stable, serializable fingerprint of the current default sources for a view, for use in
+ * react-query queryKeys.
+ *
+ * The default sources are module-level mutable state (see defineDefaultSources), so any
+ * queryFn that fetches content scoped by getDefaultSources(view) MUST include this value in
+ * its queryKey. A key without it pins the first-fetched corpus for the cache lifetime: after
+ * some page narrows the scope (e.g. ContentFeedbackModal scoping INFO to a single book),
+ * every other consumer of that key silently gets the narrowed corpus — pickers showing the
+ * wrong set of books depending on page-visit order.
+ *
+ * Array scopes are sorted before serializing so the same set of source ids produces the same
+ * fingerprint regardless of the order the sources were enabled in.
+ */
+export function getDefaultSourcesKey(view: SourceKey): string {
+  const sources = getDefaultSources(view);
+  return Array.isArray(sources) ? [...sources].sort((a, b) => a - b).join(',') : sources;
+}
+
+/**
  * Import content from a content package into the content store
  * @param packageData - Content package data to import
  */


### PR DESCRIPTION
## Problem

`getDefaultSources('INFO'/'PAGE')` is module-level mutable state, but 21 `useQuery` sites fetched with it under queryKeys that never included the scope. react-query served whatever corpus was fetched first in the session for any later scope, so picker and drawer contents depended on page-visit order. This is what masked (and intermittently unmasked) the property-rune bug fixed in `ContentFeedbackModal`: scoping INFO to one book emptied the rune picker in `ItemSelect` for the rest of the staleTime window.

## Fix

- New `getDefaultSourcesKey(view)` helper in `content-store.ts`: a stable fingerprint of the current scope (sorted source ids joined, or the sentinel string), with a JSDoc rule that any queryFn fetching via `getDefaultSources` must include it in its queryKey. Sorting keeps the same book set producing the same key regardless of enable order.
- Included the fingerprint in all 22 affected query sites: `ItemSelect`/`ItemMultiSelect`, `TraitsInput`, `CreatureInfo`, `InjectSelectOptionOperation`, `AddItemsModal`, `CreateCreatureModal`, `ManageSpellsModal`, `SelectContent` (both queries; the options query only keys on scope when its queryFn actually falls back to defaults), the seven content drawers, the three character-sheet panels, `CharBuilderCreation`, and `EncountersPanel`'s computed-combatants query.
- `FeatsFeaturesPanel` also gains `characterId` in its key: its queryFn builds per-character results from the character atom, the same stale-cache mechanism.
- Separate commit: the `changeBooks` flow in `CharBuilderHome` passed two unrelated key roots as one composite `invalidateQueries` filter, which prefix-matches element-wise and therefore matched nothing. Split into one call per query (sheet content package + builder init query).

Deliberately untouched: queryFns that *define* the scope themselves (admin pages, `find-encounters`), and `AdvancedSearchModal`, whose usage re-runs in an effect on every open.

## Verification

- `tsc --noEmit` clean; eslint 0 errors (26 pre-existing warnings, none on changed lines).
- Live in the app: opened the Barbarian class drawer, narrowed INFO to one book via `defineDefaultSources`, reopened the same drawer. The query cache now holds two entries: `sources: "ALL-USER-ACCESSIBLE"` with 13,700 ability blocks and a freshly fetched `sources: "3"` with 274. Pre-fix, the second open served the first corpus.
- Invalidation fix demonstrated against live cache state: the old composite filter matches 0 cached queries, the split filter matches the sheet's `find-content-<id>` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)