### PR TITLE
fix(variables): stop skill rank grants from stacking past level gates

### DIFF
--- a/frontend/src/process/operations/operations.main.ts
+++ b/frontend/src/process/operations/operations.main.ts
@@ -5,7 +5,7 @@ import {
   OperationResultData,
 } from '@schemas/content';
 import { VariableStore } from '@schemas/variables';
-import { exportVariableStore, importVariableStore } from '@variables/variable-manager';
+import { exportVariableStore, importVariableStore, normalizeProficiencies } from '@variables/variable-manager';
 import { _executeCharacterOperations, _executeCreatureOperations } from './operation-controller';
 
 // // Create a worker pool
@@ -174,6 +174,8 @@ export async function executeOperations<T = OperationCharacterResultPackage | Op
     }
 
     importVariableStore('CHARACTER', results!.store);
+    // Reconcile rank grants with spent skill increases (see normalizeProficiencies)
+    normalizeProficiencies('CHARACTER');
     return results!.ors as T;
   }
 
@@ -190,6 +192,8 @@ export async function executeOperations<T = OperationCharacterResultPackage | Op
     }
 
     importVariableStore(execution.data.id, results!.store);
+    // Reconcile rank grants with spent skill increases (see normalizeProficiencies)
+    normalizeProficiencies(execution.data.id);
     return results!.ors as T;
   }
 

--- a/frontend/src/process/variables/variable-manager.ts
+++ b/frontend/src/process/variables/variable-manager.ts
@@ -8,6 +8,7 @@ import {
   VariableValue,
   VariableNum,
   ExtendedVariableValue,
+  ProficiencyType,
 } from '@schemas/variables';
 import {
   isAttributeValue,
@@ -25,6 +26,8 @@ import {
   isProficiencyValue,
   isExtendedProficiencyValue,
   compileExpressions,
+  isProficiencyTypeGreaterOrEqual,
+  nextProficiencyType,
 } from './variable-utils';
 import { cloneDeep, isBoolean, isEqual, isNumber, isString, uniq } from 'lodash-es';
 import { throwError } from '@utils/error-handling';
@@ -595,6 +598,47 @@ export function setVariable(id: StoreID, name: string, value: VariableValue, sou
  * @param name - name of the variable to adjust
  * @param amount - new value to adjust by
  */
+/**
+ * Clamps every SKILL_* proficiency's spent increases to what's legal for the entity's
+ * level, so rank grants and skill increases compose per RAW instead of stacking past
+ * the level gates.
+ *
+ * Skill increases may only raise a skill to expert (any level), master (7th+), or
+ * legendary (15th+). Auto-scaling rank grants (e.g. Acrobat Dedication's master-at-7th)
+ * execute in the conditional round, after every numeric increase, so an increase spent
+ * before such a grant activates would otherwise re-apply on top of the granted rank and
+ * over-compile (trained + 1 increase + master grant = legendary). Clamping increases to
+ * the level cap absorbs exactly the redundant ones while:
+ *  - increases stacked on grants below the cap keep working (e.g. a swashbuckler
+ *    style's training + a later skill increase still compiles to expert),
+ *  - rank grants above the cap are untouched (mythic/apostle feats may exceed gates),
+ *  - negative increases (penalties) are never modified.
+ * Runs after operation execution for each store (see operations.main.ts).
+ * @param id - Variable store ID to normalize
+ */
+export function normalizeProficiencies(id: StoreID) {
+  const level = getVariable<VariableNum>(id, 'LEVEL')?.value ?? 0;
+  // The highest rank a skill increase itself may target at this level
+  const increaseCap: ProficiencyType = level >= 15 ? 'L' : level >= 7 ? 'M' : 'E';
+
+  for (const variable of Object.values(getVariables(id))) {
+    if (!isVariableProf(variable) || !variable.name.startsWith('SKILL_')) continue;
+    const increases = variable.value.increases ?? 0;
+    if (increases <= 0) continue;
+
+    // Steps from the granted rank up to the cap (0 if the grants already reach it)
+    let maxUsableIncreases = 0;
+    if (!isProficiencyTypeGreaterOrEqual(variable.value.value, increaseCap)) {
+      for (let prof = variable.value.value; prof !== increaseCap; maxUsableIncreases++) {
+        const next = nextProficiencyType(prof);
+        if (!next) break;
+        prof = next;
+      }
+    }
+    variable.value.increases = Math.min(increases, maxUsableIncreases);
+  }
+}
+
 export function adjVariable(id: StoreID, name: string, amount: VariableValue | ExtendedVariableValue, source?: string) {
   let variable = getVariables(id)[name];
   if (!variable) {


### PR DESCRIPTION
## Problem

Reported in Discord ([Acrobat dedication jumped to Legendary](https://discord.com/channels/735260060682289254/1527795036601843812)): a level-8 rogue with free-archetype Acrobat Dedication had Acrobatics compile to **Legendary** instead of Master.

## Cause

Rank grants floor a proficiency's base letter (`adjVariable`: `value = max(current, granted)`), while spent skill increases accumulate in a separate counter that `compileProficiencyType` re-applies on top. Auto-scaling grants (Acrobat Dedication's master-at-7th/legendary-at-15th) live inside LEVEL conditionals, which execute in the conditional round *after* every numeric increase — so an increase spent before the grant activates inflates the result: trained + 1 increase + master grant = legendary.

Confirmed live on a public level-8 character showing Acrobatics L. Not an Acrobat-specific data problem: 30+ official feats use the same LEVEL-conditional skill-grant pattern (Aldori Duelist / Eagle Knight / Lion Blade / Fan Dancer / Blackjacket / Avenging Runelord / Starfinder Field Agent Dedications, the War of Immortals apostle feats, Dongun Education, Brilliant Crafter, …), so this is fixed in the engine, not in data.

## Fix

`normalizeProficiencies(storeId)` runs after operation execution (both character and creature paths in `operations.main.ts`) and clamps each `SKILL_*` variable's **positive** increases to the level-legal target for skill increases (expert any level, master at 7th+, legendary at 15th+):

- increases made redundant by a rank grant are absorbed → trained + 1 increase + master grant compiles to **master**;
- increases stacked on grants below the cap keep working → swashbuckler style training + a later increase still compiles to expert (the case dcf7bc50 deliberately preserved);
- rank grants above the cap pass through untouched → mythic/apostle early-legendary feats keep working;
- negative increases (penalties) are never modified.

## Verification

- Seven direct engine scenarios via the live module (reported bug, style stacking, E-floor + increase, level-15 late increase, early legendary grant, plain progression, penalty) — all compile correctly.
- Live sheets against prod data: the affected level-8 character now shows Acrobatics **M** with style-trained Thievery still **E**; a summoner + eidolon (creature path) renders unchanged; no console errors.
- `tsc --noEmit` clean.

## Known residual

At level 15+ the cap is legendary, so a character who spent increases early (later made redundant by a floor) can still over-compile — distinguishing that from a legitimate 15th-level increase needs per-level increase tracking. Rare, and behavior there is identical to before this PR; below 15 the inflation is fully fixed. Affected characters' displayed ranks will drop to their correct values on next load, which may be worth a Discord heads-up on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)