### PR TITLE
fix(operations): strict prof conditions, speed take-higher, reliable bindValue

### DIFF
--- a/frontend/src/process/operations/operation-controller.ts
+++ b/frontend/src/process/operations/operation-controller.ts
@@ -14,7 +14,7 @@ import {
 } from '@schemas/content';
 import { getRootSelection, resetSelections, setSelections } from './selection-tree';
 import { Operation, OperationOptions, OperationResult, OperationSelect } from '@schemas/operations';
-import { runOperations } from './operation-runner';
+import { clearPendingBinds, resolvePendingBinds, runOperations } from './operation-runner';
 import {
   addVariable,
   adjVariable,
@@ -117,6 +117,7 @@ export async function _executeCharacterOperations(data: {
   const { character, content, context } = data;
 
   resetVariables('CHARACTER');
+  clearPendingBinds();
   defineSelectionTree(character);
   defineDefaultSources('INFO', content.defaultSources.INFO);
   defineDefaultSources('PAGE', content.defaultSources.PAGE);
@@ -993,6 +994,9 @@ export async function _executeCharacterOperations(data: {
     ],
   });
 
+  // Apply queued variable bindings now that every round has run
+  resolvePendingBinds();
+
   // Set calculated stats
   setCalculatedStatsInStore('CHARACTER', character);
 
@@ -1014,6 +1018,7 @@ export async function _executeCreatureOperations(data: {
   const { id, creature, content } = data;
 
   resetVariables(id);
+  clearPendingBinds();
   defineSelectionTree(creature);
   defineDefaultSources('INFO', content.defaultSources.INFO);
   defineDefaultSources('PAGE', content.defaultSources.PAGE);
@@ -1112,6 +1117,9 @@ export async function _executeCreatureOperations(data: {
   const conditionalResults = await operationsPassthrough({
     doOnlyConditionals: true,
   });
+
+  // Apply queued variable bindings now that every round has run
+  resolvePendingBinds();
 
   // Set calculated stats
   setCalculatedStatsInStore(id, creature);

--- a/frontend/src/process/operations/operation-runner.ts
+++ b/frontend/src/process/operations/operation-runner.ts
@@ -36,7 +36,12 @@ import {
   getVariables,
   setVariable,
 } from '@variables/variable-manager';
-import { compileProficiencyType, labelToVariable, maxProficiencyType } from '@variables/variable-utils';
+import {
+  compileProficiencyType,
+  getProficiencyTypeValue,
+  labelToVariable,
+  maxProficiencyType,
+} from '@variables/variable-utils';
 import {
   ObjectWithUUID,
   determineFilteredSelectionList,
@@ -495,18 +500,47 @@ async function runSetValue(
   return null;
 }
 
+/**
+ * Variable bindings queued during execution, resolved once every round has run.
+ * Bindings copy another variable's FINAL value (e.g. Quick Climb's "climb Speed equal
+ * to your land Speed"), so they can't resolve mid-execution — and the old setTimeout
+ * deferral was lost entirely under worker execution, because the store is exported
+ * back to the main thread before the timer ever fires.
+ */
+let pendingBinds: {
+  varId: StoreID;
+  variable: string;
+  value: OperationBindValue['data']['value'];
+  sourceLabel?: string;
+}[] = [];
+
+/** Drops queued bindings from a previous (possibly aborted) execution. */
+export function clearPendingBinds() {
+  pendingBinds = [];
+}
+
+/** Applies all queued bindings against the now-final variable stores. */
+export function resolvePendingBinds() {
+  for (const bind of pendingBinds) {
+    const bindValue = getVariable(bind.value.storeId, bind.value.variable);
+    if (bindValue) {
+      setVariable(bind.varId, bind.variable, bindValue.value, bind.sourceLabel);
+    }
+  }
+  pendingBinds = [];
+}
+
 async function runBindValue(
   varId: StoreID,
   operation: OperationBindValue,
   sourceLabel?: string
 ): Promise<OperationResult> {
-  // On outside process
-  setTimeout(() => {
-    const bindValue = getVariable(operation.data.value.storeId, operation.data.value.variable);
-    if (bindValue) {
-      setVariable(varId, operation.data.variable, bindValue.value, sourceLabel);
-    }
-  }, 1);
+  pendingBinds.push({
+    varId,
+    variable: operation.data.variable,
+    value: operation.data.value,
+    sourceLabel,
+  });
   return null;
 }
 
@@ -1048,22 +1082,24 @@ async function runConditional(
       }
     } else if (variable.type === 'prof') {
       const profType = compileProficiencyType(variable.value);
+      // Compare by rank order. The strict operators must actually be strict: the
+      // condition editor offers < and ≤ as distinct options, and content depends on
+      // the difference (e.g. Virtuosic Performer's "+2 if master" else-branch only
+      // fires when the rank is NOT below master). The old maxProficiencyType-based
+      // checks returned true on equality for both < and >.
+      const rankOf = (prof: ProficiencyType) => getProficiencyTypeValue(prof);
       if (check.operator === 'EQUALS') {
         return profType === check.value;
       } else if (check.operator === 'GREATER_THAN') {
-        const bestProf = maxProficiencyType(profType, check.value as ProficiencyType);
-        return bestProf === profType;
+        return rankOf(profType) > rankOf(check.value as ProficiencyType);
       } else if (check.operator === 'LESS_THAN') {
-        const bestProf = maxProficiencyType(profType, check.value as ProficiencyType);
-        return bestProf === check.value;
+        return rankOf(profType) < rankOf(check.value as ProficiencyType);
       } else if (check.operator === 'NOT_EQUALS') {
         return profType !== check.value;
       } else if (check.operator === 'GREATER_THAN_OR_EQUALS') {
-        const bestProf = maxProficiencyType(profType, check.value as ProficiencyType);
-        return bestProf === profType || profType === check.value;
+        return rankOf(profType) >= rankOf(check.value as ProficiencyType);
       } else if (check.operator === 'LESS_THAN_OR_EQUALS') {
-        const bestProf = maxProficiencyType(profType, check.value as ProficiencyType);
-        return bestProf === check.value || profType === check.value;
+        return rankOf(profType) <= rankOf(check.value as ProficiencyType);
       }
     }
     return false;

--- a/frontend/src/process/variables/variable-manager.ts
+++ b/frontend/src/process/variables/variable-manager.ts
@@ -559,7 +559,7 @@ export function setVariable(id: StoreID, name: string, value: VariableValue, sou
     // Some variables have a special rule where we take the higher value instead of overwriting
     // This is a hack for sure and hopefully won't be too confusing for homebrewers
     // It's to make things like HP for dual-class PCs work
-    const SPECIAL_TAKE_HIGHER_VARS = ['MAX_HEALTH_CLASS_PER_LEVEL', getAllSpeedVariables(id).map((v) => v.name)];
+    const SPECIAL_TAKE_HIGHER_VARS = ['MAX_HEALTH_CLASS_PER_LEVEL', ...getAllSpeedVariables(id).map((v) => v.name)];
     //
     if (SPECIAL_TAKE_HIGHER_VARS.includes(name)) {
       variable.value = Math.max(variable.value, parseInt(`${value}`));


### PR DESCRIPTION
Three operations-engine fixes from the engine audit, each verified against prod data on the same character before/after.

## 1. Strict proficiency conditions were inclusive

`LESS_THAN` / `GREATER_THAN` on prof-type conditions were evaluated via `maxProficiencyType`, which returns its **second argument on ties** — so both strict operators returned true on equality, behaving exactly like their `_OR_EQUALS` variants (which the condition editor offers as separate options). Now compared by rank value.

Most strict-`<` content has an empty else-branch and was unaffected, but ~14 official blocks misroute on equality, in two families:
- **"+1, or +2 if master"** feats (Virtuosic Performer, Specialty Crafting, Seasoned, That's Not Natural!): exactly-master characters received +1.
- **"become trained; if already trained, gain X instead"** (Akitonian Ysoki → Quick Repair, Kholo Lore, Soldier / Space Pirate / Tattooed Historian Dedications, Infernal Bulwark): exactly-trained characters silently never got the replacement.

**Verified:** character 148457 (master Performance, Virtuosic Performer) — prod skill drawer shows **+1** circumstance; this build shows **+2**. Inclusive operators, EQUALS, and empty-else cases behave identically to before.

## 2. The take-higher rule never applied to speeds

`SPECIAL_TAKE_HIGHER_VARS` was `['MAX_HEALTH_CLASS_PER_LEVEL', [...speedNames]]` — a nested array, so `.includes(name)` never matched a speed variable and the documented dual-class take-higher rule silently only worked for HP. Fixed with a spread.

**Verified:** `setValue` of 30 then 25 on `SPEED` keeps 30; non-speed variables (e.g. `LEVEL`) still overwrite.

## 3. bindValue writes were lost under worker execution

`runBindValue` deferred its write with `setTimeout(1)`. Operations normally execute in a web worker whose store is exported the moment execution resolves — the timer fires after export and the write dies with the worker; in direct mode it raced the first render. 25 official feats bind values this way (Quick Swim, Quick Climb, Raging Athlete, Implement's Flight, …).

Binds are now queued during execution and resolved after the conditional round — before calculated stats and store export — in both the character and creature pipelines, with a clear at execution start so aborted runs can't leak stale binds.

**Verified:** character 181523 (level 20, Legendary Athletics, Quick Swim) — prod shows only "Speed 30 ft." with the swim speed entirely missing; this build shows "And Others" with the speed drawer listing "Swim 20 feet — From Quick Swim" (25 base − 5 armor penalty), computed through the real worker path.

## Deploy note

Player-visible corrections on existing characters: missing bound speeds appear, master-rank "+2" feats correct themselves, and dual-source speeds now take the higher value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)