### PR TITLE
fix(operations): level-capped rank reads in conditionals, absent-variable semantics

### DIFF
--- a/frontend/src/process/operations/operation-runner.ts
+++ b/frontend/src/process/operations/operation-runner.ts
@@ -32,6 +32,7 @@ import {
   addVariable,
   addVariableBonus,
   adjVariable,
+  getLevelCappedProficiencyType,
   getVariable,
   getVariables,
   setVariable,
@@ -1006,7 +1007,11 @@ async function runConditional(
       // if (!variable) {
       //   return false;
       // }
-      return false;
+
+      // An absent variable can't equal or include anything, so negated checks pass
+      // (e.g. a muse feature's MAIN_BARD_MUSE ≠ 'enigma' should hold when the store
+      // never created MAIN_BARD_MUSE at all). Every other operator stays false.
+      return check.operator === 'NOT_EQUALS' || check.operator === 'NOT_INCLUDES';
     }
 
     if (variable.type === 'attr') {
@@ -1081,7 +1086,12 @@ async function runConditional(
         return !varValue.map((v) => labelToVariable(v)).includes(labelToVariable(`${check.value}`));
       }
     } else if (variable.type === 'prof') {
-      const profType = compileProficiencyType(variable.value);
+      // Level-capped compile: conditionals execute before normalizeProficiencies
+      // runs, so a plain compile here could read a rank the normalization will clamp
+      // away (rank grant + spent increases) and misfire high-rank checks like Ward
+      // Medic's "legendary in Medicine". The cap keeps in-execution checks
+      // consistent with the final displayed rank.
+      const profType = getLevelCappedProficiencyType(varId, variable);
       // Compare by rank order. The strict operators must actually be strict: the
       // condition editor offers < and ≤ as distinct options, and content depends on
       // the difference (e.g. Virtuosic Performer's "+2 if master" else-branch only

--- a/frontend/src/process/variables/variable-manager.ts
+++ b/frontend/src/process/variables/variable-manager.ts
@@ -26,6 +26,7 @@ import {
   isProficiencyValue,
   isExtendedProficiencyValue,
   compileExpressions,
+  compileProficiencyType,
   isProficiencyTypeGreaterOrEqual,
   nextProficiencyType,
 } from './variable-utils';
@@ -598,6 +599,37 @@ export function setVariable(id: StoreID, name: string, value: VariableValue, sou
  * @param name - name of the variable to adjust
  * @param amount - new value to adjust by
  */
+/** The highest rank a skill increase itself may target at the given level. */
+export function getSkillIncreaseCap(level: number): ProficiencyType {
+  return level >= 15 ? 'L' : level >= 7 ? 'M' : 'E';
+}
+
+/**
+ * Compiles a proficiency the way the post-execution normalization will present it:
+ * for SKILL_* variables, positive increases can't push the compiled rank past the
+ * level's skill-increase cap, while rank grants (the base letter) always pass
+ * through. Non-skill variables and penalties compile normally.
+ *
+ * Use this wherever a rank is read DURING operation execution (conditional checks) —
+ * normalizeProficiencies only runs after execution, so a plain compile mid-round can
+ * see ranks the normalization will clamp away (e.g. a level-8 character with a
+ * master-rank grant plus spent increases would read as legendary to an in-execution
+ * condition while their sheet correctly shows master). Capping at read time keeps
+ * in-execution checks consistent with the final displayed rank, regardless of
+ * whether the check runs before or after the rank grant in operation order.
+ * @param id - Variable store ID (for LEVEL)
+ * @param variable - The proficiency variable to compile
+ * @returns - The level-capped compiled proficiency type
+ */
+export function getLevelCappedProficiencyType(id: StoreID, variable: VariableProf): ProficiencyType {
+  const compiled = compileProficiencyType(variable.value);
+  if (!variable.name.startsWith('SKILL_')) return compiled;
+  if ((variable.value.increases ?? 0) <= 0) return compiled;
+  const cap = getSkillIncreaseCap(getVariable<VariableNum>(id, 'LEVEL')?.value ?? 0);
+  const cappedStack = isProficiencyTypeGreaterOrEqual(compiled, cap) ? cap : compiled;
+  return maxProficiencyType(variable.value.value, cappedStack);
+}
+
 /**
  * Clamps every SKILL_* proficiency's spent increases to what's legal for the entity's
  * level, so rank grants and skill increases compose per RAW instead of stacking past
@@ -617,9 +649,7 @@ export function setVariable(id: StoreID, name: string, value: VariableValue, sou
  * @param id - Variable store ID to normalize
  */
 export function normalizeProficiencies(id: StoreID) {
-  const level = getVariable<VariableNum>(id, 'LEVEL')?.value ?? 0;
-  // The highest rank a skill increase itself may target at this level
-  const increaseCap: ProficiencyType = level >= 15 ? 'L' : level >= 7 ? 'M' : 'E';
+  const increaseCap = getSkillIncreaseCap(getVariable<VariableNum>(id, 'LEVEL')?.value ?? 0);
 
   for (const variable of Object.values(getVariables(id))) {
     if (!isVariableProf(variable) || !variable.name.startsWith('SKILL_')) continue;


### PR DESCRIPTION
Fixes the two remaining validated engine residuals from the audit (R1 confirmed via runtime probe, R4 downgraded-but-requested).

## 1. In-execution conditionals read pre-normalization ranks (R1)

`normalizeProficiencies` (PR #286) runs after operation execution, so a condition evaluated *during* execution compiled ranks with unclamped increases. Runtime-proven scenario: a level-8 character with a master rank grant plus two spent increases satisfied `Acrobatics ≥ legendary` mid-execution while their sheet correctly displays master — and the outcome flipped depending on whether the check ran before or after the grant in operation order. ~50 official blocks condition on skill M/L ranks (Ward Medic, Unusual Treatment, Trap Finder, Deific Obedience, …); the realistic collision is an auto-scaling dedication + increases + a high-rank-conditioned feat on the same skill.

Fix: proficiency conditions compile through a new `getLevelCappedProficiencyType` — the same level-gate math the normalization applies, computed at read time. In-execution checks now match the final displayed rank and are order-independent. Rank grants above the cap still pass through (early-legendary mythic feats), and non-skill proficiencies/penalties compile unchanged.

## 2. Absent condition variables fail every operator (R4)

`makeCheck` returned false for any condition whose variable doesn't exist in the store — including `NOT_EQUALS`/`NOT_INCLUDES`, where absence logically satisfies the check (e.g. a muse feature's `MAIN_BARD_MUSE ≠ 'enigma'` should hold when the store never created `MAIN_BARD_MUSE`). Negated operators now return true for absent variables; everything else still returns false. Official exposure is limited to orphaned build states — all 14 official NOT_EQUALS conditions target created variables that the value-creation round normally provides — but the semantics are now consistent with the empty-value case.

## Verification (single-graph engine harness + live sheet)

- Level-8 master-floor + two-increase scenario: `≥ L` no longer fires in either operation order; `≥ M` still fires; displayed rank M.
- Legitimate legendary via increases at level 15 still detected; an early legendary rank grant bypasses the cap even with a stray increase present.
- Strict `<`/`>` comparisons from #287 unregressed (exactly-M is not `< M`).
- Absent-variable checks: NOT_EQUALS/NOT_INCLUDES fire, EQUALS/INCLUDES don't.
- A live character sheet (the #286 verification character) renders identically.

## Not in this PR

The two residuals that share a deeper root — the 15+ increase-ambiguity and the increase-trained redirect blind spot — need per-level attribution of increases and rank grants (the reason the dcf7bc50 heuristic exists). That's a self-contained refactor of how the engine orders leveled effects, best done as its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)