### PR TITLE
fix(functions): raise worker CPU limits for self-hosted edge runtime

### DIFF
--- a/supabase/functions/main/index.ts
+++ b/supabase/functions/main/index.ts
@@ -25,6 +25,15 @@ serve(async (req: Request) => {
       servicePath,
       memoryLimitMb: 256,
       workerTimeoutMs: 5 * 60 * 1000,
+      // Without explicit CPU limits the edge-runtime defaults apply, and they are
+      // low enough that a full-corpus request (find-spell with no filters walks
+      // every spell) exceeds the hard limit on slow hardware — the supervisor then
+      // cancels the request mid-response, surfacing as a 500 or a cut-off body.
+      // Fast machines finish inside the default budget, which made this a
+      // CI-only failure. Only self-hosted/local stacks run this file; supabase
+      // cloud manages its own worker limits.
+      cpuTimeSoftLimitMs: 30 * 1000,
+      cpuTimeHardLimitMs: 60 * 1000,
       noModuleCache: false,
       importMapPath: '/home/deno/functions/import_map.json',
       envVars,


### PR DESCRIPTION
Final layer of the E2E repair (follows #289, which fixed the seed and the no-op guard): the three remaining failures — find-spell / connect returning consistent 500s or cut-off bodies — were the edge-runtime supervisor killing workers on its **default CPU-time limits**. The main service sets memory and wall-clock limits but never CPU limits, and the full-corpus find-spell request exceeds the default hard budget on a loaded CI runner while fast local machines finish inside it.

**Root-caused by reproduction**: throttling the local functions container to 0.12 CPU produced the exact CI failure, with the worker log showing `CPU time soft limit reached → CPU time hard limit reached → request has been cancelled by supervisor` (and the `IncompleteBody` connection error matching the third test's cut-off read). With explicit 30s/60s soft/hard limits, the same throttled request completes in 2s.

Only self-hosted/local stacks execute `main/index.ts` — Supabase cloud manages its own worker limits, so prod is unaffected.

**Verification**: full API suite against the seeded CI-image stack passes 40/0 locally (plus the throttled reproduction above). This PR's E2E run should be the first fully green one since July 20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)