### PR TITLE
fix(content): bind traits by ID so same-named traits can't collide

### DIFF
--- a/frontend/src/common/TraitsInput.tsx
+++ b/frontend/src/common/TraitsInput.tsx
@@ -1,15 +1,26 @@
 import { isTraitVisible } from '@content/content-hidden';
-import { fetchContentAll, getDefaultSources, getDefaultSourcesKey } from '@content/content-store';
+import { fetchContentAll, fetchContentSources, getDefaultSources, getDefaultSourcesKey } from '@content/content-store';
 import { TagsInput, TagsInputProps } from '@mantine/core';
 import { useQuery } from '@tanstack/react-query';
 import { Trait } from '@schemas/content';
 import { isTruthy } from '@utils/type-fixing';
-import { uniq } from 'lodash-es';
+import { isNumber } from 'lodash-es';
+import { useMemo } from 'react';
 
 interface TraitsInputProps extends TagsInputProps {
   defaultTraits?: number[];
-  traits?: number[];
+  /**
+   * Current value. Entries are trait IDs; bare strings are accepted so legacy operation
+   * filters that stored a trait *name* keep working until they're re-saved.
+   */
+  traits?: (string | number)[];
   onTraitChange?: (traits: Trait[]) => void;
+  /**
+   * Like `onTraitChange`, but emits the raw storable values: a trait ID for every resolved
+   * tag, and the original string for anything that couldn't be resolved (a free-typed tag, or
+   * an ambiguous legacy name). Lets callers persist IDs without dropping unresolved entries.
+   */
+  onValuesChange?: (values: (string | number)[]) => void;
   includeCreatureTraits?: boolean;
   zIndex?: number;
 }
@@ -18,23 +29,82 @@ export default function TraitsInput(props: TraitsInputProps) {
   const { data, isFetching } = useQuery({
     queryKey: [`get-traits`, { sources: getDefaultSourcesKey('INFO') }],
     queryFn: async () => {
-      return await fetchContentAll<Trait>('trait', getDefaultSources('INFO'));
+      // Sources are fetched alongside the traits so two books defining the same trait name can
+      // be told apart in the dropdown (see `label` below).
+      const [traits, sources] = await Promise.all([
+        fetchContentAll<Trait>('trait', getDefaultSources('INFO')),
+        fetchContentSources(getDefaultSources('INFO')),
+      ]);
+      return { traits, sources };
     },
   });
 
-  const traits =
-    (data &&
-      data
-        .filter(isTruthy)
-        .sort((a, b) => a.name.localeCompare(b.name))
-        .filter((trait) => isTraitVisible('CHARACTER', trait))) ??
-    [];
+  const { options, byLabel, byId, byName, labelById } = useMemo(() => {
+    const traits = (data?.traits ?? [])
+      .filter(isTruthy)
+      .sort((a, b) => a.name.localeCompare(b.name))
+      .filter((trait) => isTraitVisible('CHARACTER', trait));
+
+    const sourceNames = new Map((data?.sources ?? []).map((source) => [source.id, source.name]));
+
+    // More than one book can define a trait with the same name — "Rune" exists in both
+    // Impossible Magic and Impossible Playtest. These used to collapse into a single dropdown
+    // entry that resolved by name, so picking it silently bound whichever trait happened to be
+    // fetched first, and two editing sessions could bind different traits.
+    const nameCount = new Map<string, number>();
+    for (const trait of traits) {
+      const key = trait.name.toLowerCase();
+      nameCount.set(key, (nameCount.get(key) ?? 0) + 1);
+    }
+
+    const options: string[] = [];
+    const byLabel = new Map<string, Trait>();
+    const byId = new Map<number, Trait>();
+    const byName = new Map<string, Trait[]>();
+    const labelById = new Map<number, string>();
+
+    for (const trait of traits) {
+      const key = trait.name.toLowerCase();
+      // Only qualify the ambiguous ones, so every trait with a unique name keeps its plain name
+      // and nothing changes for the vast majority of content.
+      const label =
+        (nameCount.get(key) ?? 0) > 1
+          ? `${trait.name} (${sourceNames.get(trait.content_source_id) ?? `#${trait.id}`})`
+          : trait.name;
+
+      options.push(label);
+      byLabel.set(label, trait);
+      byId.set(trait.id, trait);
+      byName.set(key, [...(byName.get(key) ?? []), trait]);
+      labelById.set(trait.id, label);
+    }
+
+    return { options, byLabel, byId, byName, labelById };
+  }, [data]);
+
+  /**
+   * Resolve a stored value to its trait. Numbers are trait IDs. Strings are legacy names, which
+   * only resolve when exactly one trait claims the name — an ambiguous one is left as typed
+   * rather than guessed at, which is the bug this component used to have.
+   */
+  const resolve = (value: string | number): Trait | undefined => {
+    if (isNumber(value)) return byId.get(value);
+    const matches = byName.get(`${value}`.toLowerCase()) ?? [];
+    return matches.length === 1 ? matches[0] : undefined;
+  };
+
+  /** Display label for a stored value, falling back to the raw value when it doesn't resolve. */
+  const labelOf = (value: string | number): string => {
+    const trait = resolve(value);
+    return trait ? (labelById.get(trait.id) ?? trait.name) : `${value}`;
+  };
 
   // Remove the added props so they don't get passed to TagsInput
   const passedProps = { ...props };
   delete passedProps.defaultTraits;
   delete passedProps.traits;
   delete passedProps.onTraitChange;
+  delete passedProps.onValuesChange;
   delete passedProps.includeCreatureTraits;
 
   return (
@@ -57,23 +127,28 @@ export default function TraitsInput(props: TraitsInputProps) {
             },
           })}
           {...passedProps}
-          defaultValue={traits.filter((trait) => props.defaultTraits?.includes(trait.id)).map((trait) => trait.name)}
-          value={
-            props.traits
-              ? traits.filter((trait) => props.traits?.includes(trait.id)).map((trait) => trait.name)
-              : props.value
-          }
-          data={uniq(traits.map((trait) => trait.name))}
+          defaultValue={(props.defaultTraits ?? []).map(labelOf)}
+          value={props.traits ? props.traits.map(labelOf) : props.value}
+          data={options}
           limit={1000}
           onChange={(value) => {
-            if (props.onTraitChange) {
-              props.onTraitChange(
-                value
-                  .filter(isTruthy)
-                  .map((trait) => traits.find((t) => t.name === trait)!)
-                  .filter(isTruthy)
-              );
+            const traits: Trait[] = [];
+            const values: (string | number)[] = [];
+
+            for (const label of value.filter(isTruthy)) {
+              // Match the qualified label first, then fall back to a plain name so a tag typed
+              // by hand (or carried over from older content) still binds to its trait.
+              const trait = byLabel.get(label) ?? resolve(label);
+              if (trait) {
+                traits.push(trait);
+                values.push(trait.id);
+              } else {
+                values.push(label);
+              }
             }
+
+            props.onTraitChange?.(traits);
+            props.onValuesChange?.(values);
           }}
         />
       )}

--- a/frontend/src/common/operations/selection/SelectionOperation.tsx
+++ b/frontend/src/common/operations/selection/SelectionOperation.tsx
@@ -1,3 +1,4 @@
+import TraitsInput from '@common/TraitsInput';
 import VariableSelect from '@common/VariableSelect';
 import RichTextInput from '@common/rich_text_input/RichTextInput';
 import { SelectContentButton } from '@common/select/SelectContent';
@@ -259,7 +260,9 @@ function SelectionFilteredAbilityBlock(props: {
   const [type, setType] = useState<AbilityBlockType | undefined>(props.filters?.abilityBlockType);
   const [minLevel, setMinLevel] = useState<number | undefined>(props.filters?.level.min ?? undefined);
   const [maxLevel, setMaxLevel] = useState<number | undefined>(props.filters?.level.max ?? undefined);
-  const [traits, setTraits] = useState<string[]>((props.filters?.traits as string[]) ?? []);
+  // Trait IDs. Legacy filters stored trait *names*, which are ambiguous when two books define
+  // the same name, so those are kept verbatim until the filter is re-saved through the picker.
+  const [traits, setTraits] = useState<(string | number)[]>(props.filters?.traits ?? []);
   const [isFromClass, setIsFromClass] = useState<boolean | undefined>(props.filters?.isFromClass);
   const [isFromAncestry, setIsFromAncestry] = useState<boolean | undefined>(props.filters?.isFromAncestry);
   const [isFromArchetype, setIsFromArchetype] = useState<boolean | undefined>(props.filters?.isFromArchetype);
@@ -322,14 +325,13 @@ function SelectionFilteredAbilityBlock(props: {
         </Group>
       </Box>
 
-      <TagsInput
+      <TraitsInput
         label='Has Traits'
         placeholder='Enter trait'
         size='xs'
         splitChars={[',', ';', '|']}
-        data={[]}
-        value={traits}
-        onChange={setTraits}
+        traits={traits}
+        onValuesChange={setTraits}
       />
 
       <Switch
@@ -363,7 +365,8 @@ function SelectionFilteredSpell(props: {
 }) {
   const [minLevel, setMinLevel] = useState<number | undefined>(props.filters?.level.min ?? undefined);
   const [maxLevel, setMaxLevel] = useState<number | undefined>(props.filters?.level.max ?? undefined);
-  const [traits, setTraits] = useState<string[]>(props.filters?.traits ?? []);
+  // Trait IDs — see the note on the ability-block filter above for the legacy-name handling.
+  const [traits, setTraits] = useState<(string | number)[]>(props.filters?.traits ?? []);
   const [traditions, setTraditions] = useState<string[]>(props.filters?.traditions ?? []);
 
   // Spell Data
@@ -515,14 +518,13 @@ function SelectionFilteredSpell(props: {
       </Box>
 
       <Group>
-        <TagsInput
+        <TraitsInput
           label='Has Traits'
           placeholder='Enter trait'
           size='xs'
           splitChars={[',', ';', '|']}
-          data={[]}
-          value={traits}
-          onChange={setTraits}
+          traits={traits}
+          onValuesChange={setTraits}
         />
 
         <TagsInput

--- a/frontend/src/modals/CreateAbilityBlockModal.tsx
+++ b/frontend/src/modals/CreateAbilityBlockModal.tsx
@@ -255,7 +255,7 @@ export function CreateAbilityBlockModal(props: {
               />
               <TraitsInput
                 label='Other Traits'
-                value={traits.map((trait) => trait.name)}
+                traits={traits.map((trait) => trait.id)}
                 onTraitChange={(traits) => setTraits(traits)}
                 style={{ flex: 1 }}
               />

--- a/frontend/src/modals/CreateItemModal.tsx
+++ b/frontend/src/modals/CreateItemModal.tsx
@@ -391,7 +391,7 @@ export function CreateItemModal(props: {
               />
               <TraitsInput
                 label='Traits'
-                value={traits.map((trait) => trait.name)}
+                traits={traits.map((trait) => trait.id)}
                 onTraitChange={(traits) => setTraits(traits)}
                 style={{ flex: 1 }}
               />

--- a/frontend/src/modals/CreateSpellModal.tsx
+++ b/frontend/src/modals/CreateSpellModal.tsx
@@ -289,7 +289,7 @@ export function CreateSpellModal(props: {
               />
               <TraitsInput
                 label='Traits'
-                value={traits.map((trait) => trait.name)}
+                traits={traits.map((trait) => trait.id)}
                 onTraitChange={(traits) => setTraits(traits)}
                 style={{ flex: 1 }}
               />

--- a/frontend/src/process/operations/operation-utils.ts
+++ b/frontend/src/process/operations/operation-utils.ts
@@ -472,8 +472,13 @@ async function getSpellList(operationUUID: string, filters: OperationSelectFilte
     spells = spells.filter((spell) => spell.rank <= filters.level.max!);
   }
   if (filters.traits !== undefined) {
-    const traits = await Promise.all(filters.traits.map((trait) => fetchTraitByName(trait)));
-    const traitIds = traits.filter(isTruthy).map((trait) => trait!.id);
+    const tDatas = await Promise.all(
+      filters.traits.map((t) =>
+        // If it's a number, it's a trait id, otherwise it's a legacy trait name
+        isNumber(t) ? t : fetchTraitByName(t)
+      )
+    );
+    const traitIds = tDatas.map((t) => (isNumber(t) ? t : t?.id)).filter(isTruthy);
 
     // Filter out spells that don't have all the traits
     spells = spells.filter((spell) => {

--- a/frontend/src/schemas/operations.ts
+++ b/frontend/src/schemas/operations.ts
@@ -268,7 +268,8 @@ export const OperationSelectFiltersSpellSchema = z.object({
   id: z.string(),
   type: z.literal('SPELL'),
   level: z.object({ min: z.number().nullable().optional(), max: z.number().nullable().optional() }),
-  traits: z.array(z.string()).optional(),
+  // Trait IDs, or legacy trait names — matches the ability-block filter above.
+  traits: z.array(z.union([z.string(), z.number()])).optional(),
   traditions: z.array(z.string()).optional(),
   spellData: SpellMetadataSchema.optional(),
 });


### PR DESCRIPTION
## Background

Reported in Discord (`content-curation-q-and-a` → Impossible Magic Metathread): the Runesmith "Select a Rune" pickers showed no rune alphabetically after *Ranshu, Rune of Thunder*, and a Rune-trait filter with a minimum level of 5 returned nothing at all.

The cause was that **two books define a trait named `Rune`** — Impossible Magic (5137) and Impossible Playtest (4150) — and Impossible Magic's 44 runes had ended up split across both. The data has since been corrected, but the code paths that let it happen are unchanged, so the same class of bug can recur on the next book with a name collision. The same table also has duplicate `Diacritic`, `Invocation`, and `Thrall` pairs.

## The two name-keyed paths

**Content entry.** `TraitsInput` deduped its dropdown by name (`uniq(traits.map(t => t.name))`) and resolved the picked label back with `find(t => t.name === label)`. Two same-named traits collapsed into one indistinguishable option, and picking it bound whichever trait was fetched first. Since `fetchData` has no `ORDER BY`, that could differ between editing sessions — which is how one book's runes ended up on two different traits mid-alphabet.

**Select filters.** `optionsFilters.traits` stored the trait *name*, resolved at runtime by `fetchTraitByName` → `results[0]`, which filters candidates by the viewer's enabled sources. So the same filter matched different traits for different users.

## Changes

- **`TraitsInput`** keys on trait IDs, and qualifies ambiguous entries with their source — `Rune (Impossible Magic)` vs `Rune (Impossible Playtest)`. Traits with unique names keep their plain name, so nothing changes for the vast majority of content.
- **`CreateAbilityBlockModal` / `CreateItemModal` / `CreateSpellModal`** pass trait IDs instead of names, so tags round-trip by ID rather than being re-resolved from their label.
- **Both select-filter trait fields** in `SelectionOperation` use the picker instead of a bare free-text `TagsInput` (`data={[]}`), and persist IDs. Content creators get an autocomplete where they previously had an unvalidated text box — they never type an ID.
- **Spell filters accept trait IDs** (schema + `getSpellList`), which the ability-block filter already did.

## Compatibility

No migration needed. `isNumber(t) ? t : fetchTraitByName(t)` still resolves legacy name entries, and an ambiguous legacy name is left verbatim rather than guessed at, so an existing filter is never silently re-pointed at a different trait.

## Verification

`tsc --noEmit` and `eslint` clean (one pre-existing `react-hooks/exhaustive-deps` warning in the language filter, untouched here).

Rendered the picker against live content with `traits={[5137, 4150, 'Concentrate', 'NotARealTrait']}`:

| input | renders as |
|---|---|
| `5137` | `Rune (Impossible Magic)` |
| `4150` | `Rune (Impossible Playtest)` |
| `'Concentrate'` (legacy, unique) | `Concentrate` |
| `'NotARealTrait'` (unresolvable) | `NotARealTrait` |

Removing a tag emitted `[5137, 4150, "NotARealTrait"]` — numbers for resolved traits, the raw string preserved for the unresolvable one — and `onTraitChange` gave `[5137, 4150]`. The two same-named traits stayed distinct through a full round-trip.

## Note for review

`feat/sf2e-pdf-extra-skills` has an unmerged commit touching the same `useQuery` block in `TraitsInput` (switching the fetch to `ALL-USER-ACCESSIBLE`). This PR is based on `main` and preserves `getDefaultSources('INFO')`, which currently resolves to the same value — expect a small conflict when that branch merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)