### PR TITLE
fix(content): stop one bad operation from faking a content-load failure

### DIFF
--- a/frontend/src/common/operations/variables/AdjValOperation.tsx
+++ b/frontend/src/common/operations/variables/AdjValOperation.tsx
@@ -14,6 +14,7 @@ import {
 import { Box, NumberInput, SegmentedControl, TextInput, Text } from '@mantine/core';
 import { getVariable } from '@variables/variable-manager';
 import { useDidUpdate } from '@mantine/hooks';
+import { getDefaultAdjValue } from './operation-value-defaults';
 
 export function AdjValOperation(props: {
   variable: string;
@@ -42,7 +43,13 @@ export function AdjValOperation(props: {
           setVariableName(value);
           setVariableData(variable);
           props.onSelect(value);
-          setValue('');
+
+          // Reset the *saved* value too, not just local state — otherwise re-pointing an
+          // operation at a different variable leaves a value of the wrong shape in the
+          // operation, which then throws in the operations engine at runtime.
+          const resetValue = getDefaultAdjValue(variable?.type ?? 'str');
+          setValue(resetValue);
+          props.onValueChange(resetValue);
         }}
       />
       {variableData && (
@@ -71,19 +78,9 @@ export function AdjustValueInput(props: {
   };
 }) {
   useEffect(() => {
-    // Empty value
+    // Empty value — give it the shape this variable type's input expects
     if (props.value === '') {
-      if (props.variableType === 'attr') {
-        props.onChange({ value: 0 });
-      } else if (props.variableType === 'num') {
-        props.onChange(0);
-      } else if (props.variableType === 'bool') {
-        props.onChange(false);
-      } else if (props.variableType === 'str' || props.variableType === 'list-str') {
-        props.onChange('');
-      } else if (props.variableType === 'prof') {
-        props.onChange({ value: 'U', increases: 0 });
-      }
+      props.onChange(getDefaultAdjValue(props.variableType) as VariableValue);
     }
   }, []);
 

--- a/frontend/src/common/operations/variables/SetValOperation.tsx
+++ b/frontend/src/common/operations/variables/SetValOperation.tsx
@@ -13,6 +13,7 @@ import { Box, JsonInput, NumberInput, SegmentedControl, TextInput, Text } from '
 import { getVariable } from '@variables/variable-manager';
 import { useDidUpdate } from '@mantine/hooks';
 import { isNumber, isString, isBoolean } from 'lodash-es';
+import { getDefaultSetValue } from './operation-value-defaults';
 
 export function SetValOperation(props: {
   variable: string;
@@ -42,7 +43,14 @@ export function SetValOperation(props: {
           setVariableName(value);
           setVariableData(variable);
           props.onSelect(value);
-          setValue('');
+
+          // Reset the *saved* value too, not just local state. Previously only setValue('')
+          // ran here, so re-pointing an operation at a different variable left the old value
+          // in the operation — e.g. a `false` left over from a bool variable landing on a
+          // list-str one. Those type-mismatched ops throw in the operations engine at runtime.
+          const resetValue = getDefaultSetValue(variable?.type ?? 'str');
+          setValue(resetValue);
+          props.onValueChange(resetValue);
         }}
       />
       {variableData && (

--- a/frontend/src/common/operations/variables/operation-value-defaults.ts
+++ b/frontend/src/common/operations/variables/operation-value-defaults.ts
@@ -1,0 +1,49 @@
+import {
+  AttributeValue,
+  ExtendedProficiencyValue,
+  ExtendedVariableValue,
+  ProficiencyValue,
+  VariableType,
+  VariableValue,
+} from '@schemas/variables';
+
+/**
+ * Default values for the operation editors, keyed by the type of the variable an operation
+ * points at.
+ *
+ * These exist so that re-pointing an operation at a different variable can reset its value to
+ * something the new variable actually accepts. Without that reset the operation keeps the
+ * previous value — e.g. a `false` left over from a bool variable landing on a list-str one —
+ * and the operations engine then throws `Invalid value for variable: ...` at runtime, which
+ * breaks every sheet or drawer that runs it.
+ */
+
+/**
+ * The value an "Override Value" (setValue) operation should hold for a variable of this type.
+ *
+ * Each branch mirrors the shape its matching <SetValueInput /> branch reads back.
+ */
+export function getDefaultSetValue(variableType: VariableType): VariableValue {
+  if (variableType === 'attr') return { value: 0, partial: false } as AttributeValue;
+  if (variableType === 'num') return 0;
+  if (variableType === 'bool') return false;
+  if (variableType === 'prof') return { value: 'U' } as ProficiencyValue;
+  // list-str values are stored as a JSON string (the input is a <JsonInput />), so the empty
+  // default is the *string* '[]' rather than a bare array.
+  if (variableType === 'list-str') return '[]';
+  return '';
+}
+
+/**
+ * The value an "Adjust Value" (adjValue) operation should hold for a variable of this type.
+ *
+ * Note this differs from the setValue defaults: adjValue appends to a list-str rather than
+ * replacing it, so its empty default is a plain '' rather than an empty JSON array.
+ */
+export function getDefaultAdjValue(variableType: VariableType): ExtendedVariableValue {
+  if (variableType === 'attr') return { value: 0 } as AttributeValue;
+  if (variableType === 'num') return 0;
+  if (variableType === 'bool') return false;
+  if (variableType === 'prof') return { value: 'U', increases: 0 } as ExtendedProficiencyValue;
+  return '';
+}

--- a/frontend/src/drawers/types/CreatureDrawer.tsx
+++ b/frontend/src/drawers/types/CreatureDrawer.tsx
@@ -12,6 +12,7 @@ import {
   getDefaultSourcesKey,
 } from '@content/content-store';
 import { getMetadataOpenedDict } from '@drawers/drawer-utils';
+import { displayError } from '@utils/notifications';
 import { addExtraItems, checkBulkLimit } from '@items/inv-handlers';
 import { applyEquipmentPenalties } from '@items/inv-utils';
 import {
@@ -237,6 +238,19 @@ export function CreatureDrawerContent(props: {
         setLoading(false);
         refreshStatBlock();
       }, 100);
+    }).catch((error) => {
+      // A single malformed operation (e.g. a setValue whose value doesn't match its
+      // variable's type) rejects the whole execution in the operations worker. Without this
+      // catch `loading` stayed true forever while `isFetching` was false, so the drawer
+      // rendered "Couldn't load this content" — a connection error for what is really bad
+      // content data, with no way out short of editing the record in the database.
+      // Settle instead: render what the record does have and surface the real reason.
+      console.error(`Error: Failed to execute operations for creature ${creature.id}`, error);
+      displayError(`Couldn't compute "${creature.name}": ${error?.message ?? error}`);
+
+      executingOperations.current = false;
+      setLoading(false);
+      refreshStatBlock();
     });
   }, [creature, content]);
 

--- a/frontend/src/pages/character_sheet/panels/CompanionsPanel.tsx
+++ b/frontend/src/pages/character_sheet/panels/CompanionsPanel.tsx
@@ -26,7 +26,7 @@ import { confirmHealth } from '../entity-handler';
 import { DisplayIcon } from '@common/IconDisplay';
 import { sign } from '@utils/numbers';
 import { ConditionPills, selectCondition } from '../sections/ConditionSection';
-import { setterOrUpdaterToValue } from '@utils/type-fixing';
+import { isTruthy, setterOrUpdaterToValue } from '@utils/type-fixing';
 import { IconPlus, IconX } from '@tabler/icons-react';
 import { cloneDeep } from 'lodash-es';
 import { executeOperations } from '@operations/operations.main';
@@ -491,7 +491,22 @@ async function computeCompanions(companions: Creature[]) {
     };
   }
 
-  return await Promise.all(companions.map(computeCompanion));
+  // Compute each companion independently. A companion whose operations throw (bad content
+  // data, e.g. a setValue whose value doesn't match its variable's type) used to reject the
+  // whole Promise.all, which blanked the computed stats of *every* companion on the sheet.
+  // Now only that companion is dropped — consumers already treat a missing entry as "no
+  // computed stats yet" — and the reason is logged.
+  const results = await Promise.all(
+    companions.map(async (companion, index) => {
+      try {
+        return await computeCompanion(companion, index);
+      } catch (error) {
+        console.error(`Error: Failed to compute companion "${companion.name}" (${companion.id})`, error);
+        return null;
+      }
+    })
+  );
+  return results.filter(isTruthy);
 }
 
 function AddCompanionSection() {


### PR DESCRIPTION
Reported in Discord: Ooze Eidolon (content update #40470) couldn't be opened on a sheet — the drawer showed **"Couldn't load this content / Something went wrong fetching it. Check your connection and try again."** Zarienne and chucklebean both hit it, it survived reloads, and it never resolved on its own.

## Root cause

The `Ooze Eidolon` creature carried:

```json
{"type":"setValue","data":{"variable":"SENSES_PRECISE","value":false}}
```

`SENSES_PRECISE` is a `list-str`, so `false` matches no branch in `setVariable` and falls through to `throwError` (`variable-manager.ts`). That throw happens inside the operations **Web Worker**, so `execInWorker`'s promise rejects — and `CreatureDrawerContent` did `executeOperations(...).then(...)` with no `.catch`. `setLoading(false)` never ran, `loading` stayed `true` while `isFetching` was `false`, and the drawer fell through to `DrawerLoadState`'s connection-error copy.

A content-data problem presenting as a network error, with no way out short of editing the row in the database.

## Changes

- **`CreatureDrawer`** — catch the rejection, settle, and surface the real reason via `displayError` instead of the connection message.
- **`CompanionsPanel`** — `computeCompanions` now computes each companion independently. One bad companion used to reject the whole `Promise.all` and blank the computed stats of *every* companion on the sheet. Consumers already treat a missing entry as "no computed stats yet".
- **`SetValOperation` / `AdjValOperation`** — reset the **saved** value when the operation is re-pointed at a different variable. Previously only local state was cleared (`setValue('')`) while `onValueChange` was never called, so the old value stuck around against a variable of a different type. That is how the bad `false` got authored: a leftover from a bool variable landing on a list-str one. Shared defaults now live in `operation-value-defaults.ts`.

## Data fix (already applied to prod, not in this PR)

Both `Ooze Eidolon` creature rows — 12744 (Impossible Magic) and 12742 (Pre-Submission Testing) — had the operation's value changed from `false` to `"[]"`. Verified in-app: that yields precise senses `["motion sense, 60"]`, matching the stat block's "motion sense (precise) 60 feet, no vision". Deleting the operation instead would wrongly leave `NORMAL_VISION` in.

## Verification

- Ooze Eidolon now renders correctly from the fixed prod data — `precise: motion sense (60 ft.); imprecise: hearing; vague: smell`, no normal vision.
- Against still-broken data (the `content_update` snapshot, which this PR deliberately does not touch), the drawer now settles and reports `Couldn't compute "Ooze Eidolon": Invalid value for variable: SENSES_PRECISE, false` instead of hanging on the connection error.
- The reset helper was checked against the engine: the exact bug case now produces `"[]"`, which `setVariable` accepts.
- `tsc --noEmit` clean; eslint adds no new warnings.

## Known follow-ups (not in this PR)

- The `content_update.data` snapshot for #40470 still holds the bad operation, so "View Creature" on that page will show the stat block plus the explanatory error rather than a clean render. It's the record of what was submitted, so I left it alone — happy to patch it if we'd rather the page read clean.
- Creature 12744 has `abilities_added: []` while every other eidolon has `[46369, 46469]` (Eidolon Advancement + Eidolon Skills) — the gap Zarienne flagged herself. Content call, not a code bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)