### PR TITLE
fix(content): bind ADJ_VALUE item-trait filters by ID

### DIFF
--- a/frontend/src/common/operations/selection/SelectionOperation.tsx
+++ b/frontend/src/common/operations/selection/SelectionOperation.tsx
@@ -709,8 +709,9 @@ function SelectionFilteredAdjValue(props: {
 }) {
   const [group, setGroup] = useState<string>(props.filters?.group ?? 'SKILL');
   const [value, setValue] = useState<VariableValue | ExtendedProficiencyValue>(props.filters?.value ?? { value: 'U' });
-  // Item-trait filters, only meaningful for the item-backed groups (WEAPON / ARMOR)
-  const [itemTraits, setItemTraits] = useState<string[]>(props.filters?.traits ?? []);
+  // Item-trait filters, only meaningful for the item-backed groups (WEAPON / ARMOR).
+  // Trait IDs — see the note on the ability-block filter above for the legacy-name handling.
+  const [itemTraits, setItemTraits] = useState<(string | number)[]>(props.filters?.traits ?? []);
   const [hasAncestryTrait, setHasAncestryTrait] = useState<boolean | undefined>(props.filters?.hasAncestryTrait);
 
   // Whether the current group is backed by an item list (and so supports trait filtering)
@@ -751,15 +752,14 @@ function SelectionFilteredAdjValue(props: {
       </Box>
 
       {isItemGroup && (
-        <TagsInput
+        <TraitsInput
           label='Has Any of These Traits'
           description='Only include items that have at least one of these traits'
           placeholder='Enter trait'
           size='xs'
           splitChars={[',', ';', '|']}
-          data={[]}
-          value={itemTraits}
-          onChange={setItemTraits}
+          traits={itemTraits}
+          onValuesChange={setItemTraits}
         />
       )}
 

--- a/frontend/src/process/operations/operation-utils.ts
+++ b/frontend/src/process/operations/operation-utils.ts
@@ -624,8 +624,13 @@ async function filterItemsByTraitFilters(items: Item[], filters: OperationSelect
   let filtered = items;
 
   if (filters.traits && filters.traits.length > 0) {
-    const tDatas = await Promise.all(filters.traits.map((t) => fetchTraitByName(t)));
-    const traitIds = tDatas.filter(isTruthy).map((t) => t!.id);
+    const tDatas = await Promise.all(
+      filters.traits.map((t) =>
+        // If it's a number, it's a trait id, otherwise it's a legacy trait name
+        isNumber(t) ? t : fetchTraitByName(t)
+      )
+    );
+    const traitIds = tDatas.map((t) => (isNumber(t) ? t : t?.id)).filter(isTruthy);
     filtered = filtered.filter((item) => intersection(item.traits ?? [], traitIds).length > 0);
   }
 

--- a/frontend/src/schemas/operations.ts
+++ b/frontend/src/schemas/operations.ts
@@ -309,7 +309,8 @@ export const OperationSelectFiltersAdjValueSchema = z.object({
   value: z.union([VariableValueSchema, ExtendedProficiencyValueSchema]),
   // For item-backed groups (WEAPON / ARMOR) only: restrict the list to items that have at least
   // ONE of these traits (any-match, unlike ability block filters which require all).
-  traits: z.array(z.string()).optional(),
+  // Trait IDs, or legacy trait names — matches the ability-block filter above.
+  traits: z.array(z.union([z.string(), z.number()])).optional(),
   // For the WEAPON group: restrict the list to weapons that carry an ancestry (or versatile
   // heritage) trait. Backs feats like Unconventional Weaponry / Kasatha weapon selections.
   hasAncestryTrait: z.boolean().optional(),


### PR DESCRIPTION
## Summary

PR #280's ADJ_VALUE weapon/armor trait filters stored trait **names** from a bare free-text `TagsInput` and resolved them at runtime via `fetchTraitByName` -> `results[0]` — the ambiguous-name pattern 5bc148fe eliminated from the ability-block and spell filters. When two books define a trait with the same name, the filter matched whichever trait won the lookup, which depended on the viewer's enabled sources.

This mirrors 5bc148fe for the ADJ_VALUE filter:

- **SelectionOperation.tsx** — the filter's free-text `TagsInput` is now the ID-based `TraitsInput` picker, state widened to `(string | number)[]`. New saves persist trait IDs; unresolvable entries are kept as typed.
- **schemas/operations.ts** — `OperationSelectFiltersAdjValueSchema.traits` widened to `z.array(z.union([z.string(), z.number()]))`.
- **operation-utils.ts** — `filterItemsByTraitFilters` branches on `isNumber`: numeric entries match item trait IDs directly; strings keep the legacy name fallback.

Existing name-based filters need no migration — they resolve through the string fallback until re-saved through the picker.

## Verification

- `npx tsc --noEmit` passes.
- `determineFilteredSelectionList` exercised in the running app: a trait ID and its legacy name return identical filtered lists; a mixed list with an unresolvable name still returns the ID-matched items.
