### PR TITLE
fix(spells): count rank-less focus spell grants toward the focus pool

### DIFF
--- a/frontend/src/process/content/collect-content.ts
+++ b/frontend/src/process/content/collect-content.ts
@@ -196,7 +196,12 @@ export function collectEntitySpellcasting(id: StoreID, entity: LivingEntity) {
       focus.push({
         spell_id: spellData.spellId,
         source: spellData.castingSource ?? '',
-        rank: spellData.rank ?? 0,
+        // Keep an unset rank unset. Content marks focus CANTRIPS with an explicit `rank: 0`
+        // (e.g. bard compositions); most focus spells are granted without a rank because they
+        // auto-heighten. Collapsing unset to 0 made every rank-less grant read as a cantrip,
+        // and getFocusPoints excludes cantrips — so those spells stopped counting toward the
+        // focus pool (sheet, rest reset, and PDF export all undercounted).
+        rank: spellData.rank ?? undefined,
       });
     } else if (spellData.type === 'INNATE') {
       innate.push({


### PR DESCRIPTION
## Root cause

`getFocusPoints` (collect-content.ts) excludes focus **cantrips** via `rank !== 0`. Two changes combined to break its input:

- **74e873cc** made the FOCUS collection branch do `rank: spellData.rank ?? 0` — collapsing *unset* into the explicit-cantrip marker.
- **8674773d** (#254) switched `FocusSpellsList` to count the raw collected entries instead of resolved `Spell` records, making that op-metadata rank authoritative on the sheet.

Most content grants focus spells **without** a rank (they auto-heighten), so those grants silently stopped counting toward the pool. Real focus cantrips carry an explicit `rank: 0`, so the convention is preserved by keeping unset ranks unset.

Affected the sheet count, the rest/daily-prep reset (`entity-handler.ts` overwrites the stored current with the buggy max), and both PDF exports.

## Fix

One line: `rank: spellData.rank ?? 0` → `rank: spellData.rank ?? undefined` in the FOCUS branch (the entry type already declares `rank: number | undefined`). `undefined !== 0` counts; explicit `0` still excluded.

## Verification

- Synthetic differential in the dev app: 3 rank-less FOCUS grants + 1 explicit `rank: 0` cantrip + 1 `rank: 2` → counted = 4, `getFocusPoints` → max **3** (was **1** before the fix; an all-rank-less input computed **0**).
- `tsc` passes.

Characters using a `FOCUS_POINT_BONUS +1` custom-operation workaround stay clamped at 3, so nobody over-counts; the workaround can be removed at leisure.
