### PR TITLE
fix(functions): stable keyset pagination in fetchData + retire partial cache blobs

### DIFF
--- a/frontend/src/process/content/content-store.ts
+++ b/frontend/src/process/content/content-store.ts
@@ -146,7 +146,10 @@ const CONTENT_CACHE_KEY = 'content-store';
 // Bump to invalidate every client's persisted cache (e.g. when the content shape changes).
 // v2: source rows carry the updated_at change token; v1 blobs predate it and would fail
 // every freshness check, so retire them once via the version gate instead.
-const CONTENT_CACHE_VERSION = 2;
+// v3: fetchData previously paginated without an ORDER BY, so any multi-chunk fetch (items,
+// ability blocks) could persist a silently partial corpus that the change-token check then
+// verified as fresh forever. Retire every possibly-partial blob now that pagination is stable.
+const CONTENT_CACHE_VERSION = 3;
 // Backstop only: staleness is normally caught by the per-source change-token check against
 // get-content-versions on load (see verifyPersistedContentVersions). The TTL exists for the
 // cases where that check cannot run (offline, endpoint unreachable, >500 sources).
@@ -271,11 +274,15 @@ async function persistContentCache(): Promise<void> {
   if (!cacheDirty) return;
   cacheDirty = false;
   try {
+    // Never persist an empty list result: a full-corpus fetch that returned [] is a failure
+    // artifact (network error, interrupted load), and once persisted it would be served as
+    // the real corpus until the version/TTL gates retire it.
+    const filteredContentStore = new Map([...contentStore].filter(([, v]) => !(Array.isArray(v) && v.length === 0)));
     await idbSet(CONTENT_CACHE_KEY, {
       version: CONTENT_CACHE_VERSION,
       savedAt: Date.now(),
       idStore,
-      contentStore,
+      contentStore: filteredContentStore,
     } satisfies PersistedContentCache);
   } catch (e) {
     cacheDirty = true; // retry on the next schedule

--- a/supabase/functions/_shared/helpers.ts
+++ b/supabase/functions/_shared/helpers.ts
@@ -624,9 +624,13 @@ export async function fetchData<T = Record<string, any>>(
     return false;
   })(filters);
 
-  // Paginate through fetching rows, as there's a limit of rows per query
+  // Paginate through fetching rows, as there's a limit of rows per query.
+  // Keyset pagination (ORDER BY id + id > cursor) instead of OFFSET: without an ORDER BY,
+  // Postgres guarantees no row order across the separate chunk queries, so a plan flip
+  // mid-pagination silently drops or duplicates rows — an HTTP 200 with a partial corpus
+  // that clients then persist as complete. Every fetchData table has an `id` bigint PK.
   const CHUNK_SIZE = 5000;
-  let offset = 0;
+  let lastId: number | null = null;
   let allRows: T[] = [];
   let hasMore = true;
 
@@ -683,12 +687,15 @@ export async function fetchData<T = Record<string, any>>(
       query = query.gte('created_at', from).lte('created_at', to);
     }
 
-    const { data, error } = await query.range(offset, offset + CHUNK_SIZE - 1);
+    if (lastId !== null) {
+      query = query.gt('id', lastId);
+    }
+    const { data, error } = await query.order('id', { ascending: true }).limit(CHUNK_SIZE);
     if (error) throw error;
 
     if (data && data.length > 0) {
       allRows = allRows.concat(data);
-      offset += CHUNK_SIZE;
+      lastId = data[data.length - 1].id;
     }
 
     // Check if we've fetched all rows


### PR DESCRIPTION
## Problem

`fetchData` (helpers.ts) paginated >5,000-row tables with `.range()` offsets and **no ORDER BY**. Postgres guarantees no row order across separate chunk queries, so a plan flip mid-pagination (auto-ANALYZE, parallel seq scans) silently drops or duplicates rows — an HTTP 200 with a partial corpus. Items (2 chunks) and ability blocks (3 chunks) are exposed. The frontend persists the partial result to IndexedDB, where the per-source change-token check then verifies it as fresh indefinitely (logout doesn't clear IndexedDB).

## Fix

- **Keyset pagination**: `ORDER BY id ASC` + `id > lastId` cursor + `LIMIT` per chunk. No row can be skipped or duplicated regardless of planner behavior. Side benefit: every `results[0]` single-row lookup is now deterministic.
- **`CONTENT_CACHE_VERSION` 2 → 3**: retires every client's possibly-partial persisted blob on next load.
- **`persistContentCache` filters empty-array entries**: a failed full-corpus fetch (`[]`) can never be persisted as real again.

## Verification

- Query pattern validated live against PostgREST: 8,747 items across 2 keyset chunks — complete vs the server's exact count, zero duplicates, strictly ascending.
- `tsc` passes for the frontend changes.
- CI's deno API tests and the characterBuilder e2e exercise the patched function against the seeded 3-chunk `ability_block` table.

## Deploy note

`helpers.ts` is shared by every `find-*` function — after merge, the edge functions need a redeploy from clean `origin/main` (preserving each function's `verify_jwt`).
