### PR TITLE
fix(content): keep horizontal dividers in cleaning + render them legibly

### DIFF
--- a/frontend/src/ai/cleaning/item-cleaning.ts
+++ b/frontend/src/ai/cleaning/item-cleaning.ts
@@ -420,7 +420,8 @@ Rewrite the description using rich inline markdown links following the rules abo
   Only add action symbols when AoN explicitly shows an action cost. Do not add them to inline references to action names (e.g. "Interact" in a sentence is just text, not an action symbol).
 - Activation lines should be formatted as:
   **Activate—Title** <abbr cost="TWO-ACTIONS" class="action-symbol">2</abbr> ([trait](link_trait_ID), ...); **Effect** ...
-- Remove * * * horizontal dividers — use a semicolon or line break instead
+- Keep * * * horizontal dividers exactly where the original text has them — they carry the
+  book's visual separation between an item's stat lines and its prose (do not add new ones)
 - Do NOT add markdown headers (#) or bullet lists unless the original had them
 
 ### 3. Fix the usage field

--- a/frontend/src/common/RichText.tsx
+++ b/frontend/src/common/RichText.tsx
@@ -249,7 +249,17 @@ export default function RichText(props: RichTextProps) {
         },
         hr(innerProps) {
           const { className } = innerProps;
-          return <Divider className={className} />;
+          // Inline border color: the glass theme overrides --divider-color globally to the
+          // faint imprint border, which the Divider `color` prop cannot beat — so content
+          // dividers were rendering as a near-invisible hairline. The dedicated token keeps
+          // them legible without touching the app's structural dividers.
+          return (
+            <Divider
+              className={className}
+              my={8}
+              style={{ borderTopColor: 'var(--content-divider-color, rgba(209, 213, 219, 0.4))' }}
+            />
+          );
         },
         blockquote(innerProps) {
           const { children, className } = innerProps;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -11,6 +11,10 @@
   --imprint-bg-color-hover: rgba(128, 128, 130, 0.05);
   --imprint-bg-color-hover-2: rgba(222, 226, 230, 0.08);
   --imprint-border-color: rgba(209, 213, 219, 0.2);
+  /* Dividers inside rendered content descriptions (RichText hr). Deliberately stronger than
+     the structural imprint border: these separate an item's stat lines from its prose and
+     have to read as a line on the glass background. */
+  --content-divider-color: rgba(209, 213, 219, 0.4);
 }
 
 @media print {


### PR DESCRIPTION
Two halves of the missing-horizontal-lines issue:

1. **Stop deleting them**: the item-cleaning prompt explicitly ordered `Remove * * * horizontal dividers` and stripped them from 1,085 official items (measured by snapshot diff; homebrew was never touched). The rule now preserves dividers where the book has them.
2. **Make survivors visible**: the glass theme globally overrides `--divider-color` to the faint imprint border (~1.35:1 on drawer glass) and the `color` prop can't beat it, so even surviving dividers looked deleted. In-description `hr`s now use a dedicated `--content-divider-color` token (0.4 alpha) applied inline with margins; structural dividers unchanged.

Verified live in the dev app on a drawer with a surviving divider: the in-description divider computes `rgba(209,213,219,0.4)` + 8px margins; the drawer's structural dividers stay at 0.2.

Not included: restoring the already-stripped dividers (pre-cleaning text exists at `a6f30463:data/data.sql` for positional re-insertion).
