### PR TITLE
fix(functions): strip generated search_tsv from insert/update payloads

### DIFF
--- a/supabase/functions/_shared/helpers.ts
+++ b/supabase/functions/_shared/helpers.ts
@@ -765,6 +765,9 @@ export async function insertData<T = Record<string, any>>(
   delete data.created_at;
   delete data.version;
   delete data.updated_at;
+  // GENERATED column — see the matching strip in updateData. INSERTs that echo a fetched
+  // row's search_tsv would be rejected the same way UPDATEs are.
+  delete data.search_tsv;
 
   const { data: insertedData, error } = await client.from(tableName).insert(data).select();
   if (error) {
@@ -880,6 +883,13 @@ export async function updateData(
   delete data.content_source_id;
   delete data.user_id;
   delete data.updated_at;
+  // GENERATED columns can only be written as DEFAULT; Postgres rejects any UPDATE that
+  // sets them. Full-row payloads (the content-update bot replays the editor's snapshot,
+  // which includes search_tsv since the search work added it to every content table)
+  // were failing whole creature approvals with "column can only be updated to DEFAULT".
+  // If another generated column is ever added to a content table, strip it here too
+  // (mirrors the exclusion list in migration 20260729000000).
+  delete data.search_tsv;
 
   let error: any = null;
   let dataResult: any = null;


### PR DESCRIPTION
## Problem

Creature update approvals failed with Postgres `column "search_tsv" can only be updated to DEFAULT`. Every content table gained a GENERATED `search_tsv` column in the July search work; the creature editor submits full-row snapshots including it, and PostgREST puts every payload key into the statement. The `noop_guard_generated_columns` migration fixed the *triggers* to ignore the column but never the write path. The claim/revert design worked as intended — the affected updates stayed safely PENDING and just need re-approval once this deploys.

## Fix

`updateData` and `insertData` strip `search_tsv` alongside the other server-owned keys (`id`, `created_at`, `updated_at`, …) — one chokepoint for every table and caller, matching the exclusion list in migration `20260729000000`.

## Deploy note

`helpers.ts` ships with the next edge-function deploy from clean `origin/main` (verify_jwt flags preserved via config.toml). The pending creature updates can be re-approved after deploy.
