### PR TITLE
fix(items): operation-granted and container items enter play at full HP

### DIFF
--- a/frontend/src/process/items/inv-handlers.tsx
+++ b/frontend/src/process/items/inv-handlers.tsx
@@ -331,6 +331,10 @@ export function addExtraItems(
             meta_data: item.meta_data
               ? {
                   ...item.meta_data,
+                  // Fresh copies enter play at full HP, same as handleAddItem. Many records
+                  // ship hp: 0 alongside a broken threshold, and isItemBroken reads
+                  // hp <= bt — without this, operation-granted gear arrives already "Broken".
+                  hp: item.meta_data.hp_max,
                   base_item_content: baseItem,
                 }
               : null,

--- a/frontend/src/process/items/inv-utils.tsx
+++ b/frontend/src/process/items/inv-utils.tsx
@@ -91,6 +91,9 @@ export async function getDefaultContainerContents(item: Item, allItems?: Item[],
     if (!containerItem) continue;
     if (containerItem.meta_data) {
       containerItem.meta_data.quantity = record.quantity;
+      // Fresh copies enter play at full HP (same as handleAddItem) — pack/kit contents
+      // whose records ship hp: 0 with a broken threshold otherwise arrive as "Broken".
+      containerItem.meta_data.hp = containerItem.meta_data.hp_max;
     }
     invItems.push({
       id: crypto.randomUUID(),


### PR DESCRIPTION
## Problem

"Broken" is computed: `isItemBroken` = `bt > 0 && hp <= bt` from the item's own meta_data. 187 item records (124 official) ship `hp: 0` alongside a real broken threshold, and while the manual add path has normalized `hp = hp_max` since December, two creation paths copy the record verbatim:

- operation-granted extra items (inv-handlers.tsx extra-items materialization)
- container default contents (inv-utils.tsx `getDefaultContainerContents`) — pack/kit contents

So granted gear and kit contents arrived pre-tagged **Broken**, with no UI anywhere to repair them.

## Fix

Both paths now normalize `hp = hp_max` exactly like `handleAddItem`. A companion data fix sets the 124 official records' stored `hp` to `hp_max` so compendium drawers stop showing the bogus badge too.

Not included: a current-HP/repair control on inventory items — separate feature decision.
