### PR TITLE
fix(builder): dependency prompt checks only newly toggled books

### DIFF
--- a/frontend/src/pages/campaign/panels/SettingsPanel.tsx
+++ b/frontend/src/pages/campaign/panels/SettingsPanel.tsx
@@ -128,11 +128,14 @@ export default function SettingsPanel(props: {
     };
 
     if (enabled) {
-      // Handle dependency logic
-      const requiredBooks = await findRequiredContentSources(
-        uniq([...(props.campaign?.recommended_content_sources?.enabled ?? []), ...inputIds])
-      );
-      if (requiredBooks.newSources.length > 0) {
+      // Handle dependency logic. Walk requirements from ONLY the newly toggled books and
+      // treat anything already enabled as satisfied — computing over the whole enabled set
+      // meant one stale dependency anywhere re-prompted on every toggle of every book
+      // (the Revenge of the Runelords incident).
+      const alreadyEnabled = props.campaign?.recommended_content_sources?.enabled ?? [];
+      const requiredBooks = await findRequiredContentSources(inputIds);
+      const missingSources = requiredBooks.newSources.filter((source) => !alreadyEnabled.includes(source.id));
+      if (missingSources.length > 0) {
         modals.openConfirmModal({
           title: <Title order={3}>Enable Dependencies</Title>,
           children: (
@@ -142,7 +145,7 @@ export default function SettingsPanel(props: {
                 them.
               </Text>
               <List>
-                {requiredBooks.newSources.map((source, index) => (
+                {missingSources.map((source, index) => (
                   <List.Item key={index}>
                     <Anchor
                       onClick={() => {

--- a/frontend/src/pages/character_builder/CharBuilderHome.tsx
+++ b/frontend/src/pages/character_builder/CharBuilderHome.tsx
@@ -222,11 +222,14 @@ export default function CharBuilderHome(props: { characterId: number; pageHeight
     };
 
     if (enabled) {
-      // Handle dependency logic
-      const requiredBooks = await findRequiredContentSources(
-        uniq([...(character?.content_sources?.enabled ?? []), ...inputIds])
-      );
-      if (requiredBooks.newSources.length > 0) {
+      // Handle dependency logic. Walk requirements from ONLY the newly toggled books and
+      // treat anything already enabled as satisfied — computing over the whole enabled set
+      // meant one stale dependency anywhere re-prompted on every toggle of every book,
+      // homebrew included (the Revenge of the Runelords incident).
+      const alreadyEnabled = character?.content_sources?.enabled ?? [];
+      const requiredBooks = await findRequiredContentSources(inputIds);
+      const missingSources = requiredBooks.newSources.filter((source) => !alreadyEnabled.includes(source.id));
+      if (missingSources.length > 0) {
         modals.openConfirmModal({
           title: <Title order={3}>Enable Dependencies</Title>,
           children: (
@@ -236,7 +239,7 @@ export default function CharBuilderHome(props: { characterId: number; pageHeight
                 them.
               </Text>
               <List>
-                {requiredBooks.newSources.map((source, index) => (
+                {missingSources.map((source, index) => (
                   <List.Item key={index}>
                     <Anchor
                       onClick={() => {


### PR DESCRIPTION
The Enable Dependencies modal recomputed requirements over **all** enabled sources on every toggle (CharBuilderHome.tsx + the identical logic in SettingsPanel.tsx), so one stale requirement anywhere re-prompted on every toggle of every book, and "Continue without" never stuck.

Both call sites now walk requirements from **only the newly toggled books** and treat already-enabled sources as satisfied. Confirm still enables the toggled books' full transitive closure.

Also the prerequisite for the source-requirement backfill: with this change a new dependency declaration prompts once at enable-time instead of retroactively nagging existing characters.

`tsc` passes. The pre-existing campaign-defaults homebrew flow in the same file is untouched.
