### PR TITLE
docs(skills): wg-content linking gaps found during spell authoring

### DIFF
--- a/.claude/skills/wg-content/SKILL.md
+++ b/.claude/skills/wg-content/SKILL.md
@@ -81,8 +81,8 @@ Do **not** manually wrap "frightened", "concealed", "stupefied", "persistent fir
 
 | Type | Examples |
 |---|---|
-| **trait** | damage types (*fire*, *cold*, *electricity*, *slashing*), categories (*physical*, *spell*), materials (*cold iron*), descriptors (*death*, *poison*, *disease*) |
-| **action** | basic actions (*Strike*, *Escape*, *Seek*), named activities (*Treat Wounds*, *Recall Knowledge*, *Subsist*) |
+| **trait** | ENERGY damage types (*fire*, *cold*, *electricity*, *acid*, *sonic*, *vitality*, *void*), categories (*physical*, *spell*), materials (*cold iron*), descriptors (*death*, *poison*, *disease*), effect kinds in "X effect" phrases, and the trait lists in ability parentheticals (e.g. `**High Winds** ([air](link_trait_1524), [aura](link_trait_1492)) 30 feet`) |
+| **action** | basic actions (*Strike*, *Escape*, *Seek*, *Dismiss*), named activities (*Treat Wounds*, *Recall Knowledge*, *Subsist*), and *Cast a Spell* — including inflected prose like "as part of Casting this Spell", which links to the Cast a Spell action with the natural wording as display text |
 | **feat** | named feats referenced in prose (*Continual Recovery*, *Ward Medic*) |
 | **spell** | specific spells mentioned by name (*Fireball*, *Charm*, *Confusion*) |
 | **item** | named items |
@@ -94,6 +94,8 @@ Do **not** manually wrap "frightened", "concealed", "stupefied", "persistent fir
 - **Skill names used abstractly** — *Acrobatics*, *Athletics*, etc. when referenced as concepts (not drawer-linkable as content).
 - **Attribute names** — *Strength*, *Dexterity*, etc. (not drawer-linkable).
 - **Generic terms** — *spell*, *attack*, *creature* used as common nouns.
+- **PHYSICAL damage types** — *bludgeoning*, *piercing*, *slashing* have **no trait records** in the database, so there is nothing to link them to. Only energy/alignment-style damage types are traits. (Likewise there is currently no *Affliction* trait — "affliction" stays plain text unless one is added.)
+- **Foundry import artifacts** — legacy rows sometimes contain `\[\[Spell Effect: ...\]\]{Label}` or `@UUID[...]` tokens leaked from Foundry VTT imports. These are NOT WG syntax and render as literal junk. When porting or cleaning content, delete them (keep only the human label, e.g. `**Air Elemental**`).
 
 ## Disambiguation
 


### PR DESCRIPTION
Amends the `wg-content` skill with linking rules that surfaced during content review:

- Foundry `[[Spell Effect: …]]` / `@UUID` tokens are import junk, not WG syntax — delete on sight when porting legacy content.
- "Casting this Spell" links to the Cast a Spell action (inflected display text); Dismiss added to the basic-action examples.
- Physical damage types (bludgeoning/piercing/slashing) are not linkable — no trait records exist; the old example wrongly listed slashing. Energy types are the linkable ones. Also noted: no Affliction trait exists today.
- Trait lists in ability parentheticals (aura lines etc.) get linked.

The already-documented rules (link every occurrence, conditions auto-link) were correct — this fills the holes review found.
