### PR TITLE
fix(variables): compile inline prof variables to their full value

### DIFF
--- a/frontend/src/process/variables/variable-utils.ts
+++ b/frontend/src/process/variables/variable-utils.ts
@@ -18,7 +18,7 @@ import {
 } from '@schemas/variables';
 import { getVariables } from './variable-manager';
 import { evaluate } from 'mathjs/number';
-import { getFinalVariableValue } from './variable-helpers';
+import { getFinalProfValue, getFinalVariableValue } from './variable-helpers';
 import { toLabel } from '@utils/strings';
 import { throwError } from '@utils/error-handling';
 
@@ -301,7 +301,14 @@ export function compileExpressions(id: StoreID, text?: string, round = false) {
     for (const variable of variables) {
       if (variable.trim() === '') continue;
       if (compiledExpression.toUpperCase().includes(variable.toUpperCase())) {
-        const finalValue = getFinalVariableValue(id, variable).total;
+        // Proficiency variables need the full prof computation (rank + level + attribute +
+        // bonuses; *_DC names add the base 10) — getFinalVariableValue only totals flat
+        // bonuses for profs, which made every inline {{SPELL_DC}}-style reference compile
+        // to 0 (on companions AND characters alike).
+        const varObj = getVariables(id)[variable];
+        const finalValue = isVariableProf(varObj)
+          ? parseInt(getFinalProfValue(id, variable, variable.toUpperCase().endsWith('_DC')))
+          : getFinalVariableValue(id, variable).total;
         compiledExpression = compiledExpression.replace(new RegExp(`\\b${variable}\\b`, 'gi'), finalValue.toString());
       }
     }


### PR DESCRIPTION
## Problem

`compileExpressions` substitutes every variable via `getFinalVariableValue().total`, which for prof-type variables only totals flat bonuses — so any inline `{{SPELL_DC}}`-style reference in description text rendered **0**, on characters and companions alike.

## Fix

Prof-type variables now resolve through `getFinalProfValue` (rank + level + attribute + bonuses); names ending in `_DC` add the base 10. All other variable types keep the existing path.

## Verification

Live harness in the dev app: `{{SPELL_DC}}` renders 23 for a level-9 Expert store (was 0) and 17 on a level-3 creature store with the prof bound from the character store (was 0); `{{SPELL_ATTACK}}` renders 13 (sign-prefixed string parses); `{{SPELL_DC/2}}` evaluates and floors to 11; non-prof substitutions and plain math unchanged. `tsc` passes.