### PR TITLE
feat(operations): familiarity + rarity options on filtered weapon selections

### DIFF
--- a/frontend/src/common/operations/selection/SelectionOperation.tsx
+++ b/frontend/src/common/operations/selection/SelectionOperation.tsx
@@ -727,6 +727,9 @@ function SelectionFilteredAdjValue(props: {
       // linger invisibly after switching to e.g. SKILL
       traits: isItemGroup && itemTraits.length > 0 ? itemTraits : undefined,
       hasAncestryTrait: group === 'WEAPON' && hasAncestryTrait ? true : undefined,
+      // No editor UI for these yet — pass stored values through so a resave doesn't wipe them
+      rarities: isItemGroup ? props.filters?.rarities : undefined,
+      addToFamiliarity: group === 'WEAPON' ? props.filters?.addToFamiliarity : undefined,
     });
   }, [group, value, itemTraits, hasAncestryTrait]);
 

--- a/frontend/src/process/operations/operation-runner.ts
+++ b/frontend/src/process/operations/operation-runner.ts
@@ -413,6 +413,15 @@ async function updateVariables(
     }
   } else if (operation.data.optionType === 'ADJ_VALUE') {
     adjVariable(varId, selectedOption.variable, selectedOption.value, sourceLabel);
+    // addToFamiliarity selections (Unconventional Weaponry): the chosen weapon also joins
+    // WEAPON_FAMILIARITY, so its proficiency tracks one category lower (see weapon-handler).
+    if (
+      operation.data.optionsFilters?.type === 'ADJ_VALUE' &&
+      operation.data.optionsFilters.addToFamiliarity &&
+      selectedOption.name
+    ) {
+      adjVariable(varId, 'WEAPON_FAMILIARITY', selectedOption.name, sourceLabel);
+    }
   } else if (operation.data.optionType === 'CUSTOM') {
     // Doesn't inherently do anything, just runs its operations
   }

--- a/frontend/src/process/operations/operation-utils.ts
+++ b/frontend/src/process/operations/operation-utils.ts
@@ -644,11 +644,19 @@ async function filterItemsByTraitFilters(items: Item[], filters: OperationSelect
     filtered = filtered.filter((item) => (item.traits ?? []).some((traitId) => ancestryTraitIds.has(traitId)));
   }
 
+  if (filters.rarities && filters.rarities.length > 0) {
+    filtered = filtered.filter((item) => filters.rarities!.includes(item.rarity));
+  }
+
   return filtered;
 }
 
 async function getAdjValueList(id: StoreID, operationUUID: string, filters: OperationSelectFiltersAdjValue) {
   let variables: Variable[] = [];
+  // Real item names for item-backed groups. The variable-name round trip strips punctuation
+  // ("Filcher's Fork" -> "Filchers Fork"), which both mislabels the option and breaks the
+  // exact-name match WEAPON_FAMILIARITY does for addToFamiliarity selections.
+  const itemNames = new Map<string, string>();
 
   if (filters.group === 'SKILL') {
     variables = getAllSkillVariables(id);
@@ -672,8 +680,10 @@ async function getAdjValueList(id: StoreID, operationUUID: string, filters: Oper
       filters
     );
     variables = weapons.map((w) => {
+      const name = `WEAPON_${labelToVariable(w.name)}`;
+      itemNames.set(name, w.name);
       return {
-        name: `WEAPON_${labelToVariable(w.name)}`,
+        name,
         type: 'prof',
         value: { value: 'U', increases: 0 },
       } satisfies VariableProf;
@@ -686,8 +696,10 @@ async function getAdjValueList(id: StoreID, operationUUID: string, filters: Oper
       filters
     );
     variables = armor.map((a) => {
+      const name = `ARMOR_${labelToVariable(a.name)}`;
+      itemNames.set(name, a.name);
       return {
-        name: `ARMOR_${labelToVariable(a.name)}`,
+        name,
         type: 'prof',
         value: { value: 'U', increases: 0 },
       } satisfies VariableProf;
@@ -699,7 +711,7 @@ async function getAdjValueList(id: StoreID, operationUUID: string, filters: Oper
       _select_uuid: `${variable.name}`,
       _content_type: 'ability-block' as ContentType,
       id: `${variable.name}`,
-      name: variable ? variableToLabel(variable) : 'Unknown Value',
+      name: itemNames.get(variable.name) ?? (variable ? variableToLabel(variable) : 'Unknown Value'),
       value: filters.value,
       variable: variable.name,
     };

--- a/frontend/src/schemas/operations.ts
+++ b/frontend/src/schemas/operations.ts
@@ -314,6 +314,13 @@ export const OperationSelectFiltersAdjValueSchema = z.object({
   // For the WEAPON group: restrict the list to weapons that carry an ancestry (or versatile
   // heritage) trait. Backs feats like Unconventional Weaponry / Kasatha weapon selections.
   hasAncestryTrait: z.boolean().optional(),
+  // For item-backed groups (WEAPON / ARMOR) only: restrict the list to items of these rarities.
+  rarities: z.array(RaritySchema).optional(),
+  // For the WEAPON group: the chosen weapon's name is also appended to WEAPON_FAMILIARITY,
+  // treating it as one proficiency category lower (martial->simple, advanced->martial) so it
+  // tracks the character's category scaling. Backs "treat the chosen weapon as a simple weapon
+  // for proficiency" feats (Unconventional Weaponry).
+  addToFamiliarity: z.boolean().optional(),
 });
 export type OperationSelectFiltersAdjValue = z.infer<typeof OperationSelectFiltersAdjValueSchema>;
 


### PR DESCRIPTION
Backs "treat the chosen weapon as a simple weapon for proficiency" feats. No new editor UI.

## Changes

- **Schema**: `OperationSelectFiltersAdjValue` gains optional `rarities` (allowlist for item-backed groups) and `addToFamiliarity` (WEAPON group only).
- **Option lists**: the item filter honors `rarities`; WEAPON/ARMOR options now display the item's real name instead of the punctuation-stripped variable label ("Filcher's Fork", not "Filchers Fork") — also required for the exact-name match `WEAPON_FAMILIARITY` performs.
- **Apply**: after the normal rank grant, a select with `addToFamiliarity` appends the chosen weapon's name to `WEAPON_FAMILIARITY`, which already treats listed weapons as one proficiency category lower (martial→simple, advanced→martial) with full category scaling.
- **Editor**: the AdjValue filter reconstruction passes both new fields through so a resave doesn't wipe them. Nothing rendered.

## Verification (dev app, live engine)

- Rarity filter: 63 uncommon ancestry-trait weapons vs 118 unfiltered for the same select.
- Full path: a character whose stored selection picks Dwarven Waraxe ends execution with `WEAPON_FAMILIARITY = ["Dwarven Waraxe"]`.
- Attack math: familiar martial weapon tracks SIMPLE_WEAPONS (+7 at Trained → +9 at Expert, level 5) while an unfamiliar martial weapon stays 0; familiar advanced weapon tracks MARTIAL_WEAPONS; unfamiliar advanced stays 0.
- `tsc` passes.