### PR TITLE
feat(items): player-selectable weapon group via override variable

### DIFF
--- a/frontend/src/drawers/types/InvItemDrawer.tsx
+++ b/frontend/src/drawers/types/InvItemDrawer.tsx
@@ -27,7 +27,7 @@ import {
   labelizeBulk,
   isItemWithHealth,
 } from '@items/inv-utils';
-import { getWeaponStats, parseOtherDamage } from '@items/weapon-handler';
+import { getWeaponGroup, getWeaponStats, parseOtherDamage } from '@items/weapon-handler';
 import {
   Accordion,
   ActionIcon,
@@ -925,10 +925,12 @@ function InvItemSections(props: {
   }
 
   let categoryAndGroupSection = null;
-  if (props.invItem.item.meta_data?.category || props.invItem.item.meta_data?.group) {
+  // Effective group can come from a player-selected override (e.g. Solar Weapon)
+  const effectiveGroup = getWeaponGroup(props.storeId, props.invItem.item);
+  if (props.invItem.item.meta_data?.category || effectiveGroup) {
     let groupDesc =
-      getWeaponSpecialization(props.invItem.item.meta_data?.group as ItemMetaGroupWeapon) ??
-      getArmorSpecialization(props.invItem.item.meta_data?.group as ItemMetaGroupArmor);
+      getWeaponSpecialization(effectiveGroup as ItemMetaGroupWeapon) ??
+      getArmorSpecialization(effectiveGroup as ItemMetaGroupArmor);
     if (groupDesc && hasAttackAndDamage) {
       if (hasAttackAndDamage) {
         groupDesc = {
@@ -957,7 +959,7 @@ function InvItemSections(props: {
               </Text>
             </Group>
           )}
-          {props.invItem.item.meta_data?.group && (
+          {effectiveGroup && (
             <Group wrap='nowrap' gap={10} style={{ flexGrow: 1 }}>
               <Text fw={600} c='gray.2' span>
                 Group
@@ -973,7 +975,7 @@ function InvItemSections(props: {
               >
                 <HoverCard.Target>
                   <Text c='gray.2' style={{ cursor: groupDesc ? 'pointer' : undefined }} span>
-                    {toLabel(props.invItem.item.meta_data?.group)}
+                    {toLabel(effectiveGroup)}
                   </Text>
                 </HoverCard.Target>
                 <HoverCard.Dropdown>

--- a/frontend/src/drawers/types/ItemDrawer.tsx
+++ b/frontend/src/drawers/types/ItemDrawer.tsx
@@ -27,7 +27,7 @@ import {
   labelizeBulk,
   isItemWithHealth,
 } from '@items/inv-utils';
-import { getWeaponStats, parseOtherDamage } from '@items/weapon-handler';
+import { getWeaponGroup, getWeaponStats, parseOtherDamage } from '@items/weapon-handler';
 import {
   Title,
   Text,
@@ -669,10 +669,12 @@ function MiscItemSections(props: { item: Item; store: StoreID; openDrawer: Sette
   }
 
   let categoryAndGroupSection = null;
-  if (props.item.meta_data?.category || props.item.meta_data?.group) {
+  // Effective group can come from a player-selected override (e.g. Solar Weapon)
+  const effectiveGroup = getWeaponGroup(props.store, props.item);
+  if (props.item.meta_data?.category || effectiveGroup) {
     let groupDesc =
-      getWeaponSpecialization(props.item.meta_data?.group as ItemMetaGroupWeapon) ??
-      getArmorSpecialization(props.item.meta_data?.group as ItemMetaGroupArmor);
+      getWeaponSpecialization(effectiveGroup as ItemMetaGroupWeapon) ??
+      getArmorSpecialization(effectiveGroup as ItemMetaGroupArmor);
     if (groupDesc) {
       if (hasAttackAndDamage) {
         groupDesc = {
@@ -701,7 +703,7 @@ function MiscItemSections(props: { item: Item; store: StoreID; openDrawer: Sette
               </Text>
             </Group>
           )}
-          {props.item.meta_data?.group && (
+          {effectiveGroup && (
             <Group wrap='nowrap' gap={10}>
               <Text fw={600} c='gray.2' span>
                 Group
@@ -717,7 +719,7 @@ function MiscItemSections(props: { item: Item; store: StoreID; openDrawer: Sette
               >
                 <HoverCard.Target>
                   <Text c='gray.2' style={{ cursor: groupDesc ? 'pointer' : undefined }} span>
-                    {toLabel(props.item.meta_data?.group)}
+                    {toLabel(effectiveGroup)}
                   </Text>
                 </HoverCard.Target>
                 <HoverCard.Dropdown>

--- a/frontend/src/process/items/weapon-handler.ts
+++ b/frontend/src/process/items/weapon-handler.ts
@@ -1,6 +1,6 @@
 import { getCachedContent } from '@content/content-store';
 import { Item, Trait } from '@schemas/content';
-import { StoreID, VariableBool, VariableListStr, VariableNum, VariableProf } from '@schemas/variables';
+import { StoreID, VariableBool, VariableListStr, VariableNum, VariableProf, VariableStr } from '@schemas/variables';
 import { hasTraitType } from '@utils/traits';
 import { getFinalProfValue, getFinalVariableValue, getProfValueParts } from '@variables/variable-helpers';
 import { getVariable } from '@variables/variable-manager';
@@ -508,6 +508,19 @@ function getProfessionalTraitSkills(item: Item): string[] {
   return skills;
 }
 
+/**
+ * The weapon's effective group. A str variable named WEAPON_GROUP_OVERRIDE_<ITEM NAME>
+ * overrides the item's stored group — for weapons whose group is player-selected
+ * (e.g. the solarian's Solar Weapon, whose form is chosen and can be re-forged).
+ */
+export function getWeaponGroup(id: StoreID, item: Item): string | undefined {
+  const override = getVariable<VariableStr>(id, `WEAPON_GROUP_OVERRIDE_${labelToVariable(item.name)}`)?.value;
+  if (override && override.trim().length > 0) {
+    return override.trim().toLowerCase();
+  }
+  return item.meta_data?.group;
+}
+
 function getProfTotal(id: StoreID, item: Item) {
   let category = item.meta_data?.category ?? 'simple';
 
@@ -517,7 +530,8 @@ function getProfTotal(id: StoreID, item: Item) {
   const matchFamiliarity = () => {
     for (const f of familiarity) {
       if (item.name.trim().toUpperCase() === f) return true;
-      if (item.meta_data?.group && item.meta_data.group.trim().toUpperCase() === f) return true;
+      const effectiveGroup = getWeaponGroup(id, item);
+      if (effectiveGroup && effectiveGroup.trim().toUpperCase() === f) return true;
       // Don't use labelToVariable here, as it will remove the numbers for IDs
       if (!isNaN(parseInt(f)) && compileTraits(item).includes(parseInt(f))) return true;
     }
@@ -544,7 +558,7 @@ function getProfTotal(id: StoreID, item: Item) {
   }
   categoryProfTotal = parseInt(getFinalProfValue(id, categoryVariable));
 
-  const group = item.meta_data?.group ?? 'brawling';
+  const group = getWeaponGroup(id, item) ?? 'brawling';
 
   const groupVariable = `WEAPON_GROUP_${group.trim().toUpperCase()}`;
   const groupProfTotal = parseInt(getFinalProfValue(id, groupVariable));


### PR DESCRIPTION
Weapons whose group is player-chosen (the solarian Solar Weapon: pick one of ten groups, changeable by re-forging) previously got no group proficiency or crit specialization — the item's stored group is empty by design, and there was no mechanism to choose one.

## Changes

- **`getWeaponGroup(id, item)`** (weapon-handler): resolves a str variable `WEAPON_GROUP_OVERRIDE_<ITEM NAME>` before falling back to `meta_data.group`.
- Used in weapon proficiency (group prof candidate), the WEAPON_FAMILIARITY group matcher, and both item drawers (crit-spec lookup, section visibility, and the displayed group — so an override-only weapon shows its chosen group).
- No new operation types or editor UI: the choice wires as an existing Custom selection whose options each `createValue` the override variable; re-forging = changing the selection.

## Verification (dev app, live engine, real content)

Character with a Custom select ("Choose Your Solar Weapon's Form") choosing Sword: override variable set on execution; `getWeaponGroup` returns `sword` for item 18261 (stored group empty); crit spec resolves to Sword; attack bonus 0 → +7 once `WEAPON_GROUP_SWORD` is Trained (level 5). `tsc` passes.