### PR TITLE
feat(variables): INCLUDES() list-membership checks in inline expressions

### DIFF
--- a/frontend/src/process/variables/variable-utils.ts
+++ b/frontend/src/process/variables/variable-utils.ts
@@ -298,6 +298,18 @@ export function compileExpressions(id: StoreID, text?: string, round = false) {
   for (const expression of expressions) {
     let compiledExpression = expression.slice(2, -2);
     compiledExpression = compiledExpression.replace(/\\/g, '');
+    // Resolve list-membership checks to 1/0 first: INCLUDES(LIST_VARIABLE, 'value').
+    // Must run before variable substitution, which would otherwise mangle the list argument.
+    // Entries and needle compare case-insensitively; a non-list or missing variable yields 0.
+    compiledExpression = compiledExpression.replace(
+      /INCLUDES\(\s*([A-Za-z_][A-Za-z0-9_]*)\s*,\s*(?:'([^']*)'|"([^"]*)")\s*\)/gi,
+      (_match, variableName, single, double) => {
+        const needle = (single ?? double ?? '').trim().toUpperCase();
+        const listVar = getVariables(id)[variableName.toUpperCase()];
+        const list = listVar && isVariableListStr(listVar) ? listVar.value : [];
+        return list.some((entry) => entry.trim().toUpperCase() === needle) ? '1' : '0';
+      }
+    );
     for (const variable of variables) {
       if (variable.trim() === '') continue;
       if (compiledExpression.toUpperCase().includes(variable.toUpperCase())) {


### PR DESCRIPTION
Inline `{{ }}` expressions are mathjs-only, so description text couldn't branch on list variables (heritages, feats, familiarity) — the only route was a conditional op plus Inject Text.

## Change

`compileExpressions` resolves `INCLUDES(LIST_VARIABLE, 'value')` to `1`/`0` as a pre-pass before variable substitution (which would otherwise mangle the list argument). Entry/needle comparison is case-insensitive; double-quoted needles support apostrophes; a missing or non-list variable yields 0.

## Verification (dev app, live engine)

- `{{INCLUDES(HERITAGE_NAMES,'nanite')}}` → 1; wrong needle, missing variable, and non-list variable → 0 (no crash).
- Composes: `{{1 + INCLUDES(...) * 2}}` → 3; `{{LEVEL + INCLUDES(...)}}` → 7; ternary `{{INCLUDES(...) ? 3 : 1}}d6` → 3d6.
- `{{INCLUDES(WEAPON_FAMILIARITY,\"Filcher's Fork\")}}` → 1.
- Plain expressions unaffected (`{{LEVEL/2}}` → 3 at level 6).
- `tsc` passes.