### PR TITLE
feat(variants): Stamina variant (GMG)

### DIFF
--- a/frontend/src/constants/data.ts
+++ b/frontend/src/constants/data.ts
@@ -28,6 +28,9 @@ export const IMPRINT_BORDER_COLOR = 'var(--imprint-border-color)';
 export const COMMON_CORE_ID = 3;
 export const PATHFINDER_CORE_ID = 1;
 export const STARFINDER_CORE_ID = 579;
+// The Gamemastery Guide source — holds the stamina variant's supporting content
+// (Take a Breather, Steel Your Resolve, Encouraging Words), auto-enabled with the variant.
+export const GAMEMASTERY_GUIDE_ID = 203;
 
 export const CHARACTER_SLOT_CAP = 6;
 export const CAMPAIGN_SLOT_CAP = 1;

--- a/frontend/src/drawers/types/StatHealthDrawer.tsx
+++ b/frontend/src/drawers/types/StatHealthDrawer.tsx
@@ -3,7 +3,15 @@ import { IconMathSymbols } from '@tabler/icons-react';
 import { StoreID } from '@schemas/variables';
 import { sign } from '@utils/numbers';
 import { displayFinalHealthValue } from '@variables/variable-display';
-import { getHealthValueParts } from '@variables/variable-helpers';
+import {
+  getFinalResolveValue,
+  getFinalStaminaValue,
+  getHealthValueParts,
+  getResolveAttribute,
+  isStaminaVariant,
+} from '@variables/variable-helpers';
+import { variableToLabel } from '@variables/variable-utils';
+import { getVariable } from '@variables/variable-manager';
 
 export function StatHealthDrawerTitle(props: { data: { id: StoreID } }) {
   return (
@@ -23,6 +31,10 @@ export function StatHealthDrawerTitle(props: { data: { id: StoreID } }) {
 export function StatHealthDrawerContent(props: { data: { id: StoreID } }) {
   const parts = getHealthValueParts(props.data.id);
 
+  // Stamina variant: half class HP (and no Con) goes to HP; the rest becomes stamina.
+  const staminaVariant = isStaminaVariant(props.data.id);
+  const halfClassHp = Math.floor(parts.classHp / 2);
+
   return (
     <Box>
       <Accordion variant='separated' defaultValue='breakdown'>
@@ -33,25 +45,31 @@ export function StatHealthDrawerContent(props: { data: { id: StoreID } }) {
               {displayFinalHealthValue(props.data.id)} ={' ('}
               <HoverCard shadow='md' openDelay={250} width={230} position='bottom' zIndex={10000} withArrow>
                 <HoverCard.Target>
-                  <Kbd style={{ cursor: 'pointer' }}>{parts.classHp}</Kbd>
+                  <Kbd style={{ cursor: 'pointer' }}>{staminaVariant ? halfClassHp : parts.classHp}</Kbd>
                 </HoverCard.Target>
                 <HoverCard.Dropdown py={5} px={10}>
                   <Text c='gray.0' size='xs'>
-                    This is the base hit points from your class. You gain this amount every level.
+                    {staminaVariant
+                      ? `This is the base hit points from your class, halved for the stamina variant. You gain this amount every level (the other half becomes stamina points).`
+                      : `This is the base hit points from your class. You gain this amount every level.`}
                   </Text>
                 </HoverCard.Dropdown>
               </HoverCard>
-              +
-              <HoverCard shadow='md' openDelay={250} width={230} position='bottom' zIndex={10000} withArrow>
-                <HoverCard.Target>
-                  <Kbd style={{ cursor: 'pointer' }}>{parts.conMod}</Kbd>
-                </HoverCard.Target>
-                <HoverCard.Dropdown py={5} px={10}>
-                  <Text c='gray.0' size='xs'>
-                    You add your Constitution modifier to the hit points you gain every level.
-                  </Text>
-                </HoverCard.Dropdown>
-              </HoverCard>
+              {!staminaVariant && (
+                <>
+                  +
+                  <HoverCard shadow='md' openDelay={250} width={230} position='bottom' zIndex={10000} withArrow>
+                    <HoverCard.Target>
+                      <Kbd style={{ cursor: 'pointer' }}>{parts.conMod}</Kbd>
+                    </HoverCard.Target>
+                    <HoverCard.Dropdown py={5} px={10}>
+                      <Text c='gray.0' size='xs'>
+                        You add your Constitution modifier to the hit points you gain every level.
+                      </Text>
+                    </HoverCard.Dropdown>
+                  </HoverCard>
+                </>
+              )}
               {') × '}
               <HoverCard shadow='md' openDelay={250} width={230} position='bottom' zIndex={10000} withArrow>
                 <HoverCard.Target>
@@ -151,6 +169,78 @@ export function StatHealthDrawerContent(props: { data: { id: StoreID } }) {
             </Group>
           </Accordion.Panel>
         </Accordion.Item>
+        {/* Stamina variant pools — shown only when the variant is enabled */}
+        {staminaVariant && (
+          <Accordion.Item value='stamina'>
+            <Accordion.Control icon={<IconMathSymbols size='1rem' />}>Stamina Breakdown</Accordion.Control>
+            <Accordion.Panel>
+              <Group gap={8} wrap='nowrap' align='center'>
+                <Text span>{getFinalStaminaValue(props.data.id)}</Text> ={' ('}
+                <HoverCard shadow='md' openDelay={250} width={230} position='bottom' zIndex={10000} withArrow>
+                  <HoverCard.Target>
+                    <Kbd style={{ cursor: 'pointer' }}>{halfClassHp}</Kbd>
+                  </HoverCard.Target>
+                  <HoverCard.Dropdown py={5} px={10}>
+                    <Text c='gray.0' size='xs'>
+                      This is half the base hit points from your class. You gain this amount of stamina points every
+                      level.
+                    </Text>
+                  </HoverCard.Dropdown>
+                </HoverCard>
+                +
+                <HoverCard shadow='md' openDelay={250} width={230} position='bottom' zIndex={10000} withArrow>
+                  <HoverCard.Target>
+                    <Kbd style={{ cursor: 'pointer' }}>{parts.conMod}</Kbd>
+                  </HoverCard.Target>
+                  <HoverCard.Dropdown py={5} px={10}>
+                    <Text c='gray.0' size='xs'>
+                      You add your Constitution modifier to the stamina points you gain every level.
+                    </Text>
+                  </HoverCard.Dropdown>
+                </HoverCard>
+                {') × '}
+                <HoverCard shadow='md' openDelay={250} width={230} position='bottom' zIndex={10000} withArrow>
+                  <HoverCard.Target>
+                    <Kbd style={{ cursor: 'pointer' }}>{parts.level}</Kbd>
+                  </HoverCard.Target>
+                  <HoverCard.Dropdown py={5} px={10}>
+                    <Text c='gray.0' size='xs'>
+                      This is your current level.
+                    </Text>
+                  </HoverCard.Dropdown>
+                </HoverCard>
+              </Group>
+            </Accordion.Panel>
+          </Accordion.Item>
+        )}
+        {staminaVariant && (
+          <Accordion.Item value='resolve'>
+            <Accordion.Control icon={<IconMathSymbols size='1rem' />}>Resolve Breakdown</Accordion.Control>
+            <Accordion.Panel>
+              <Group gap={8} wrap='nowrap' align='center'>
+                <Text span>{getFinalResolveValue(props.data.id)}</Text> =
+                <HoverCard shadow='md' openDelay={250} width={230} position='bottom' zIndex={10000} withArrow>
+                  <HoverCard.Target>
+                    <Kbd style={{ cursor: 'pointer' }}>
+                      {(() => {
+                        // Label the key attribute the resolve pool is based on (e.g. "Strength")
+                        const attributeName = getResolveAttribute(props.data.id);
+                        const attribute = attributeName ? getVariable(props.data.id, attributeName) : null;
+                        return attribute ? variableToLabel(attribute) : 'Key Attribute';
+                      })()}
+                    </Kbd>
+                  </HoverCard.Target>
+                  <HoverCard.Dropdown py={5} px={10}>
+                    <Text c='gray.0' size='xs'>
+                      Your maximum resolve points equal your class's key attribute modifier. Spend 1 resolve point to
+                      Take a Breather (10 minutes) and restore all your stamina points.
+                    </Text>
+                  </HoverCard.Dropdown>
+                </HoverCard>
+              </Group>
+            </Accordion.Panel>
+          </Accordion.Item>
+        )}
       </Accordion>
     </Box>
   );

--- a/frontend/src/pages/campaign/panels/SettingsPanel.tsx
+++ b/frontend/src/pages/campaign/panels/SettingsPanel.tsx
@@ -497,24 +497,21 @@ export default function SettingsPanel(props: {
                     });
                   }}
                 />
-                {/* <LinkSwitch
+                <LinkSwitch
                   label='Stamina'
                   info={`In some fantasy stories, the heroes are able to avoid any serious injury until the situation gets dire, getting by with a graze or a flesh wound and needing nothing more than a quick rest to get back on their feet. If your group wants to tell tales like those, you can use the stamina variant to help make that happen.`}
                   url='https://2e.aonprd.com/Rules.aspx?ID=1378'
                   enabled={props.campaign?.recommended_variants?.stamina}
                   onLinkChange={(enabled) => {
-                    setCharacter((prev) => {
-                      if (!prev) return prev;
-                      return {
-                        ...prev,
-                        variants: {
-                          ...prev.variants,
-                          stamina: enabled,
-                        },
-                      };
+                    props.setCampaign({
+                      ...props.campaign,
+                      recommended_variants: {
+                        ...props.campaign.recommended_variants,
+                        stamina: enabled,
+                      },
                     });
                   }}
-                /> */}
+                />
               </Stack>
             </Tabs.Panel>
 

--- a/frontend/src/pages/character_builder/CharBuilderHome.tsx
+++ b/frontend/src/pages/character_builder/CharBuilderHome.tsx
@@ -1,6 +1,12 @@
 import { generateNames } from '@ai/fantasygen-dev/name-controller';
 import { GroupLinkSwitch, LinkSwitch, LinksGroup } from '@common/LinksGroup';
-import { GUIDE_BLUE, IMPRINT_BG_COLOR, IMPRINT_BG_COLOR_HOVER, IMPRINT_BORDER_COLOR } from '@constants/data';
+import {
+  GAMEMASTERY_GUIDE_ID,
+  GUIDE_BLUE,
+  IMPRINT_BG_COLOR,
+  IMPRINT_BG_COLOR_HOVER,
+  IMPRINT_BORDER_COLOR,
+} from '@constants/data';
 import {
   Stack,
   Group,
@@ -610,7 +616,7 @@ export default function CharBuilderHome(props: { characterId: number; pageHeight
                     });
                   }}
                 />
-                {/* <LinkSwitch
+                <LinkSwitch
                   label='Stamina'
                   info={`In some fantasy stories, the heroes are able to avoid any serious injury until the situation gets dire, getting by with a graze or a flesh wound and needing nothing more than a quick rest to get back on their feet. If your group wants to tell tales like those, you can use the stamina variant to help make that happen.`}
                   url='https://2e.aonprd.com/Rules.aspx?ID=1378'
@@ -620,6 +626,21 @@ export default function CharBuilderHome(props: { characterId: number; pageHeight
                       if (!prev) return prev;
                       return {
                         ...prev,
+                        // Start the pools at -1 when enabling — the "full" sentinel (the sheet
+                        // renders negative pool values as their max).
+                        ...(enabled ? { stamina_current: -1, resolve_current: -1 } : {}),
+                        // Auto-enable the Gamemastery Guide book so the variant's supporting
+                        // content (Take a Breather, stamina feats) is available. Left enabled
+                        // when the variant is turned off — the player may be using other GMG
+                        // content and can disable the book themselves.
+                        ...(enabled
+                          ? {
+                              content_sources: {
+                                ...prev.content_sources,
+                                enabled: uniq([...(prev.content_sources?.enabled ?? []), GAMEMASTERY_GUIDE_ID]),
+                              },
+                            }
+                          : {}),
                         variants: {
                           ...prev.variants,
                           stamina: enabled,
@@ -627,7 +648,7 @@ export default function CharBuilderHome(props: { characterId: number; pageHeight
                       };
                     });
                   }}
-                /> */}
+                />
               </Stack>
             </Tabs.Panel>
 
@@ -1164,12 +1185,16 @@ export default function CharBuilderHome(props: { characterId: number; pageHeight
             const applySettings = async () => {
               setCharacter((prev) => {
                 if (!prev) return prev;
+                // If the campaign settings newly enable the stamina variant, start the pools at
+                // -1 — the "full" sentinel (the sheet renders negative pool values as their max).
+                const enablingStamina = campaign?.recommended_variants?.stamina && !prev.variants?.stamina;
                 return {
                   ...prev,
                   content_sources: campaign?.recommended_content_sources,
                   variants: campaign?.recommended_variants,
                   options: campaign?.recommended_options,
                   custom_operations: campaign?.custom_operations,
+                  ...(enablingStamina ? { stamina_current: -1, resolve_current: -1 } : {}),
                 };
               });
             };

--- a/frontend/src/pages/character_sheet/entity-handler.ts
+++ b/frontend/src/pages/character_sheet/entity-handler.ts
@@ -2,8 +2,13 @@ import { getConditionByName } from '@conditions/condition-handler';
 import { collectEntitySpellcasting, getFocusPoints } from '@content/collect-content';
 import { filterByTraitType } from '@items/inv-utils';
 import { LivingEntity } from '@schemas/content';
-import { StoreID, VariableAttr, VariableNum, VariableProf } from '@schemas/variables';
-import { getFinalHealthValue } from '@variables/variable-helpers';
+import { StoreID, VariableAttr, VariableNum } from '@schemas/variables';
+import {
+  getFinalHealthValue,
+  getFinalResolveValue,
+  getFinalStaminaValue,
+  isStaminaVariant,
+} from '@variables/variable-helpers';
 import { getVariable } from '@variables/variable-manager';
 import { cloneDeep } from 'lodash-es';
 import { evaluate } from 'mathjs';
@@ -75,6 +80,58 @@ export function confirmHealth(
   };
 }
 
+/**
+ * Parse + clamp an edited pool value (stamina or resolve points) to [0, max] and save it.
+ * Accepts math expressions the same way HP edits do (e.g. "12-4").
+ */
+export function confirmPool(
+  key: 'stamina_current' | 'resolve_current',
+  value: string,
+  max: number,
+  setEntity?: SetterOrUpdater<LivingEntity | null>
+) {
+  let result = -1;
+  try {
+    result = evaluate(value);
+  } catch (e) {
+    result = parseInt(value);
+  }
+  if (isNaN(result)) result = 0;
+  result = Math.floor(result);
+  if (result < 0) result = 0;
+  if (result > max) result = max;
+
+  setEntity?.((c) => {
+    if (!c) return c;
+    return {
+      ...c,
+      [key]: result,
+    };
+  });
+  return result;
+}
+
+/**
+ * Take a Breather (stamina variant, 10-min activity): spend 1 resolve point to restore
+ * all stamina points. No-op if the entity has no resolve left.
+ */
+export function handleTakeBreather(id: StoreID, entity: LivingEntity, setEntity?: SetterOrUpdater<LivingEntity | null>) {
+  const maxResolve = getFinalResolveValue(id);
+  // Negative pool values are the "uninitialized / full" sentinel
+  const currentResolve = entity.resolve_current < 0 ? maxResolve : entity.resolve_current;
+  if (currentResolve <= 0) return false;
+
+  setEntity?.((c) => {
+    if (!c) return c;
+    return {
+      ...c,
+      stamina_current: getFinalStaminaValue(id),
+      resolve_current: currentResolve - 1,
+    };
+  });
+  return true;
+}
+
 export function confirmExperience(exp: string, entity: LivingEntity, setEntity?: SetterOrUpdater<LivingEntity | null>) {
   let result = -1;
   try {
@@ -122,20 +179,10 @@ export function handleRest(id: StoreID, entity: LivingEntity, setEntity?: Setter
   }
   newEntity.hp_current = currentHealth + regenAmount;
 
-  // Regen Stamina and Resolve
-  if (true) {
-    const classHP = getVariable<VariableNum>(id, 'MAX_HEALTH_CLASS_PER_LEVEL')!.value;
-    const newStamina = (Math.floor(classHP / 2) + conMod) * level;
-
-    let keyMod = 0;
-    const classDC = getVariable<VariableProf>(id, 'CLASS_DC')!;
-    if (classDC.value.attribute) {
-      keyMod = getVariable<VariableAttr>(id, classDC.value.attribute)?.value.value ?? 0;
-    }
-    const newResolve = keyMod;
-
-    newEntity.stamina_current = newStamina;
-    newEntity.resolve_current = newResolve;
+  // Regen Stamina and Resolve — a full rest restores both pools to max (stamina variant only)
+  if (isStaminaVariant(id)) {
+    newEntity.stamina_current = getFinalStaminaValue(id);
+    newEntity.resolve_current = getFinalResolveValue(id);
   }
 
   // Set spells to default

--- a/frontend/src/pages/character_sheet/sections/HealthSection.tsx
+++ b/frontend/src/pages/character_sheet/sections/HealthSection.tsx
@@ -4,12 +4,17 @@ import BlurBox from '@common/BlurBox';
 import ClickEditText from '@common/ClickEditText';
 import { useMantineTheme, Group, Anchor, Button, Box, Text } from '@mantine/core';
 import { interpolateHealth } from '@utils/colors';
-import { getFinalHealthValue } from '@variables/variable-helpers';
+import {
+  getFinalHealthValue,
+  getFinalResolveValue,
+  getFinalStaminaValue,
+  isStaminaVariant,
+} from '@variables/variable-helpers';
 import { evaluate } from 'mathjs';
 import { useNavigate } from 'react-router-dom';
 import { useAtom } from 'jotai';
 import { SetterOrUpdater } from '@utils/type-fixing';
-import { confirmHealth } from '../entity-handler';
+import { confirmHealth, confirmPool, handleTakeBreather } from '../entity-handler';
 import { StoreID } from '@schemas/variables';
 import { LivingEntity } from '@schemas/content';
 
@@ -31,6 +36,20 @@ export default function HealthSection(props: {
   let tempHealth = props.entity?.hp_temp;
   if (tempHealth === undefined || tempHealth < 0) {
     tempHealth = 0;
+  }
+
+  // Stamina variant (GM Core): the sheet gains stamina & resolve pools.
+  // Negative pool values are the "uninitialized / full" sentinel (same convention as HP).
+  const staminaVariant = isStaminaVariant(props.id);
+  const maxStamina = getFinalStaminaValue(props.id);
+  const maxResolve = getFinalResolveValue(props.id);
+  let currentStamina = props.entity?.stamina_current;
+  if (currentStamina === undefined || currentStamina < 0 || currentStamina > maxStamina) {
+    currentStamina = maxStamina;
+  }
+  let currentResolve = props.entity?.resolve_current;
+  if (currentResolve === undefined || currentResolve < 0 || currentResolve > maxResolve) {
+    currentResolve = maxResolve;
   }
 
   return (
@@ -123,21 +142,127 @@ export default function HealthSection(props: {
               />
             </Box>
           </Group>
-          <Button
-            variant='subtle'
-            color='gray.5'
-            size='compact-xs'
-            fw={400}
-            onClick={() => {
-              openDrawer({
-                type: 'stat-resist-weak',
-                data: { id: props.id },
-                extra: { addToHistory: true },
-              });
-            }}
-          >
-            Resistances & Weaknesses
-          </Button>
+          {/* Stamina variant row — only rendered when the variant is enabled */}
+          {staminaVariant && (
+            <Group wrap='nowrap' justify='space-between' align='flex-start' w='100%' gap={0} grow>
+              <Box>
+                <Text ta='center' fz='sm' fw={500} c='gray.0'>
+                  Stamina
+                </Text>
+                <Group wrap='nowrap' justify='center' align='center' gap={10}>
+                  <ClickEditText
+                    color={interpolateHealth(maxStamina > 0 ? currentStamina / maxStamina : 0)}
+                    size='lg'
+                    value={`${currentStamina}`}
+                    height={40}
+                    miw={20}
+                    placeholder='SP'
+                    onChange={(value) => {
+                      if (!props.entity) return;
+                      confirmPool('stamina_current', value, getFinalStaminaValue(props.id), props.setEntity);
+                    }}
+                  />
+                  <Box>
+                    <Text size='md' c='gray.4' style={{ cursor: 'default' }}>
+                      /
+                    </Text>
+                  </Box>
+                  <Box>
+                    <Anchor
+                      size='md'
+                      c='gray.2'
+                      style={{ cursor: 'pointer' }}
+                      onClick={() => {
+                        openDrawer({
+                          type: 'stat-hp',
+                          data: { id: props.id },
+                          extra: { addToHistory: true },
+                        });
+                      }}
+                      underline='hover'
+                    >
+                      {maxStamina}
+                    </Anchor>
+                  </Box>
+                </Group>
+              </Box>
+
+              <Box>
+                <Text ta='center' fz='sm' fw={500} c='gray.0'>
+                  Resolve
+                </Text>
+                <Group wrap='nowrap' justify='center' align='center' gap={10}>
+                  <ClickEditText
+                    color={currentResolve > 0 ? theme.colors.guide[4] : theme.colors.gray[5]}
+                    size='lg'
+                    value={`${currentResolve}`}
+                    height={40}
+                    miw={20}
+                    placeholder='RP'
+                    onChange={(value) => {
+                      if (!props.entity) return;
+                      confirmPool('resolve_current', value, getFinalResolveValue(props.id), props.setEntity);
+                    }}
+                  />
+                  <Box>
+                    <Text size='md' c='gray.4' style={{ cursor: 'default' }}>
+                      /
+                    </Text>
+                  </Box>
+                  <Box>
+                    <Anchor
+                      size='md'
+                      c='gray.2'
+                      style={{ cursor: 'pointer' }}
+                      onClick={() => {
+                        openDrawer({
+                          type: 'stat-hp',
+                          data: { id: props.id },
+                          extra: { addToHistory: true },
+                        });
+                      }}
+                      underline='hover'
+                    >
+                      {maxResolve}
+                    </Anchor>
+                  </Box>
+                </Group>
+              </Box>
+            </Group>
+          )}
+          <Group wrap='nowrap' justify='center' gap={0}>
+            <Button
+              variant='subtle'
+              color='gray.5'
+              size='compact-xs'
+              fw={400}
+              onClick={() => {
+                openDrawer({
+                  type: 'stat-resist-weak',
+                  data: { id: props.id },
+                  extra: { addToHistory: true },
+                });
+              }}
+            >
+              Resistances & Weaknesses
+            </Button>
+            {/* Take a Breather (stamina variant): spend 1 resolve to refill stamina */}
+            {staminaVariant && (
+              <Button
+                variant='subtle'
+                color='gray.5'
+                size='compact-xs'
+                fw={400}
+                disabled={currentResolve <= 0}
+                onClick={() => {
+                  if (!props.entity) return;
+                  handleTakeBreather(props.id, props.entity, props.setEntity);
+                }}
+              >
+                Breather
+              </Button>
+            )}
+          </Group>
         </Group>
       </Box>
     </BlurBox>

--- a/frontend/src/process/import/ftc/import-from-ftc.ts
+++ b/frontend/src/process/import/ftc/import-from-ftc.ts
@@ -103,8 +103,9 @@ export async function importFromFTC(d: FTC) {
     hp_current: data.hp ?? 0,
     hp_temp: data.temp_hp ?? 0,
     hero_points: data.hero_points ?? 1,
-    stamina_current: data.stamina ?? 0,
-    resolve_current: data.resolve ?? 0,
+    // -1 = "uninitialized / full" sentinel — the sheet renders negative pool values as their max
+    stamina_current: data.stamina ?? -1,
+    resolve_current: data.resolve ?? -1,
     details: {
       class: undefined,
       background: undefined,

--- a/frontend/src/process/variables/calculated-stats.ts
+++ b/frontend/src/process/variables/calculated-stats.ts
@@ -3,7 +3,13 @@ import { LivingEntity } from '@schemas/content';
 import { ProficiencyType, StoreID } from '@schemas/variables';
 import { SetterOrUpdater } from '@utils/type-fixing';
 import { addVariable, getVariable, getVariables } from './variable-manager';
-import { getFinalAcValue, getFinalHealthValue, getFinalProfValue } from './variable-helpers';
+import {
+  getFinalAcValue,
+  getFinalHealthValue,
+  getFinalProfValue,
+  getFinalResolveValue,
+  getFinalStaminaValue,
+} from './variable-helpers';
 import { labelToVariable } from './variable-utils';
 import { getDeepDiff } from '@utils/objects';
 
@@ -14,8 +20,9 @@ export function saveCalculatedStats(
 ) {
   setTimeout(() => {
     const maxHealth = getFinalHealthValue(id);
-    const maxStamina = 0;
-    const maxResolve = 0;
+    // Stamina variant pools — both helpers return 0 when the variant isn't enabled.
+    const maxStamina = getFinalStaminaValue(id);
+    const maxResolve = getFinalResolveValue(id);
     const ac = getFinalAcValue(id, getBestArmor(id, entity.inventory)?.item);
     const finalProfs: Record<string, { total: number; type: ProficiencyType }> = {};
 

--- a/frontend/src/process/variables/variable-helpers.ts
+++ b/frontend/src/process/variables/variable-helpers.ts
@@ -4,6 +4,7 @@ import { CastingSource, Item, LivingEntity } from '@schemas/content';
 import {
   ProficiencyType,
   StoreID,
+  VariableAttr,
   VariableBool,
   VariableListStr,
   VariableNum,
@@ -209,9 +210,51 @@ export function getHealthValueParts(id: StoreID) {
   };
 }
 
+/**
+ * Whether the Stamina variant rule (GM Core) is enabled for this store. Only ever set on
+ * character stores (via `character.variants.stamina`) — creatures & companions are unaffected.
+ */
+export function isStaminaVariant(id: StoreID) {
+  return getVariable<VariableBool>(id, 'STAMINA_VARIANT')?.value ?? false;
+}
+
 export function getFinalHealthValue(id: StoreID) {
   const { level, ancestryHp, classHp, bonusHp, conMod } = getHealthValueParts(id);
+  if (isStaminaVariant(id)) {
+    // Stamina variant: only half the class HP goes to max HP and Con no longer contributes
+    // (the other half of class HP + Con mod per level become stamina points instead).
+    return ancestryHp + bonusHp + Math.floor(classHp / 2) * level;
+  }
   return ancestryHp + bonusHp + (classHp + conMod) * level;
+}
+
+/**
+ * Max stamina points under the Stamina variant: (half class HP + Con mod) per level.
+ * Returns 0 when the variant isn't enabled for this store.
+ */
+export function getFinalStaminaValue(id: StoreID) {
+  if (!isStaminaVariant(id)) return 0;
+  const { level, classHp, conMod } = getHealthValueParts(id);
+  return Math.max((Math.floor(classHp / 2) + conMod) * level, 0);
+}
+
+/**
+ * The attribute variable the resolve pool is keyed off of — the class's key attribute
+ * (whatever the class DC uses). Returns null if no class has been selected yet.
+ */
+export function getResolveAttribute(id: StoreID) {
+  return getVariable<VariableProf>(id, 'CLASS_DC')?.value.attribute ?? null;
+}
+
+/**
+ * Max resolve points under the Stamina variant: equal to the class's key attribute modifier.
+ * Returns 0 when the variant isn't enabled for this store.
+ */
+export function getFinalResolveValue(id: StoreID) {
+  if (!isStaminaVariant(id)) return 0;
+  const attribute = getResolveAttribute(id);
+  const keyMod = attribute ? (getVariable<VariableAttr>(id, attribute)?.value.value ?? 0) : 0;
+  return Math.max(keyMod, 0);
 }
 
 export function getFinalAcValue(id: StoreID, item?: Item) {

--- a/frontend/src/process/variables/variable-manager.ts
+++ b/frontend/src/process/variables/variable-manager.ts
@@ -39,6 +39,7 @@ export const HIDDEN_VARIABLES = [
   'SPELL_SLOTS',
   'SPELL_DATA',
   'PROF_WITHOUT_LEVEL',
+  'STAMINA_VARIANT',
   'INJECT_SELECT_OPTIONS',
   'INJECT_TEXT',
 ];
@@ -184,6 +185,7 @@ export const DEFAULT_VARIABLES: Record<string, Variable> = {
   CORE_LANGUAGES: newVariable('list-str', 'CORE_LANGUAGES'),
 
   PROF_WITHOUT_LEVEL: newVariable('bool', 'PROF_WITHOUT_LEVEL', false), // Hidden
+  STAMINA_VARIANT: newVariable('bool', 'STAMINA_VARIANT', false), // Hidden
 
   MAX_HEALTH_ANCESTRY: newVariable('num', 'MAX_HEALTH_ANCESTRY'),
   MAX_HEALTH_CLASS_PER_LEVEL: newVariable('num', 'MAX_HEALTH_CLASS_PER_LEVEL'),

--- a/frontend/src/utils/use-character.tsx
+++ b/frontend/src/utils/use-character.tsx
@@ -280,6 +280,11 @@ export default function useCharacter(
     if (debouncedCharacter.variants?.proficiency_without_level) {
       setVariable('CHARACTER', 'PROF_WITHOUT_LEVEL', true);
     }
+    if (debouncedCharacter.variants?.stamina) {
+      // Stamina variant (GM Core): must be set before any getFinalHealthValue /
+      // getFinalStaminaValue calls below so max HP is computed with halved class HP.
+      setVariable('CHARACTER', 'STAMINA_VARIANT', true);
+    }
 
     // Add the extra items to the inventory from variables
     addExtraItems(


### PR DESCRIPTION
Implements the Gamemastery Guide Stamina variant rule end-to-end. The builder's Variants tab toggle (commented out since Mar 2024) is now live.

**Mechanics (per GMG p.200):**
- Max HP = ancestry + half class HP per level (Con no longer contributes)
- Stamina = (half class HP + Con mod) × level; Resolve = key attribute mod
- Full rest refills both pools; Take a Breather button spends 1 RP to restore all SP
- HP still governs dying/unconsciousness

**Implementation notes:**
- `STAMINA_VARIANT` hidden bool variable, set store-locally on `CHARACTER` only — creatures/companions unaffected. The old rest handler wrote stamina to every entity unconditionally; now gated.
- Pool values < 0 are a "full/uninitialized" sentinel rendered as max (DB columns default 0, which can't distinguish spent from never-initialized).
- Enabling the variant auto-enables the Gamemastery Guide content source (Take a Breather, Steel Your Resolve, Encouraging Words).
- `calculated_stats` now stores real `stamina_max`/`resolve_max` instead of hardcoded 0.
- Campaign settings switch fixed while uncommenting (updated the character instead of the campaign).
- stat-hp drawer shows variant-aware HP/SP/RP breakdowns.

**Deploy note:** 36 existing characters (mostly legacy-site imports) already have `variants.stamina = true`; they'll correctly gain pools and halved max HP on deploy. `confirmHealth` clamps any over-max HP on next load.

Verified live on a public sheet (lvl 3 Oracle: HP 33→18, SP 15, RP 4; edit/clamp, Breather, Rest, drawer breakdowns, mobile layout, and no change for non-variant characters).