### PR TITLE
feat(content): optional source cite on all content types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 .env.local
 .env.docker
 .env.*.local
+
+# Wayfinder maps / local planning docs
+.scratch/

--- a/docs/api-reference/openapi.json
+++ b/docs/api-reference/openapi.json
@@ -150,6 +150,15 @@
         "type": "object",
         "additionalProperties": true
       },
+      "ContentSourceCite": {
+        "type": "object",
+        "description": "Optional citation recording where a piece of content came from. Stored at `meta_data.source` on every content type. `book` is recorded as text even though `content_source_id` already identifies the source, because a page reference can belong to a different book than the row is filed under, which is what happens with reprints. `page` is text rather than a number so it can express spans such as `154-155`. All three fields are optional; an absent `source` means the content has not been cited yet.",
+        "properties": {
+          "book": { "type": "string", "description": "Book or product name, e.g. `Impossible Magic`." },
+          "page": { "type": "string", "description": "Page reference, e.g. `154` or `154-155`." },
+          "url": { "type": "string", "description": "Link to an external reference for this content (Archives of Nethys, Paizo, or elsewhere)." }
+        }
+      },
       "Trait": {
         "type": "object",
         "required": ["name", "content_source_id"],
@@ -173,7 +182,8 @@
               "class_trait": { "type": "boolean" },
               "ancestry_trait": { "type": "boolean" },
               "archetype_trait": { "type": "boolean" },
-              "versatile_heritage_trait": { "type": "boolean" }
+              "versatile_heritage_trait": { "type": "boolean" },
+              "source": { "$ref": "#/components/schemas/ContentSourceCite" }
             }
           }
         }
@@ -206,7 +216,13 @@
           "duration": { "type": "string" },
           "description": { "type": "string" },
           "heightened": { "type": "object", "additionalProperties": true },
-          "meta_data": { "type": "object", "additionalProperties": true },
+          "meta_data": {
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "source": { "$ref": "#/components/schemas/ContentSourceCite" }
+            }
+          },
           "content_source_id": { "type": "integer" },
           "version": { "type": "string" }
         }
@@ -243,7 +259,13 @@
           "size": { "$ref": "#/components/schemas/Size" },
           "craft_requirements": { "type": "string" },
           "usage": { "type": "string" },
-          "meta_data": { "type": "object", "additionalProperties": true },
+          "meta_data": {
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "source": { "$ref": "#/components/schemas/ContentSourceCite" }
+            }
+          },
           "operations": { "type": "array", "items": { "$ref": "#/components/schemas/Operation" } },
           "content_source_id": { "type": "integer" },
           "version": { "type": "string" }
@@ -275,7 +297,13 @@
           "description": { "type": "string" },
           "special": { "type": "string" },
           "type": { "$ref": "#/components/schemas/AbilityBlockType" },
-          "meta_data": { "type": "object", "additionalProperties": true },
+          "meta_data": {
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "source": { "$ref": "#/components/schemas/ContentSourceCite" }
+            }
+          },
           "traits": { "type": "array", "items": { "type": "integer" } },
           "content_source_id": { "type": "integer" },
           "version": { "type": "string" }
@@ -298,6 +326,14 @@
           "trait_id": { "type": "integer" },
           "artwork_url": { "type": "string" },
           "content_source_id": { "type": "integer" },
+          "meta_data": {
+            "type": "object",
+            "nullable": true,
+            "additionalProperties": true,
+            "properties": {
+              "source": { "$ref": "#/components/schemas/ContentSourceCite" }
+            }
+          },
           "version": { "type": "string" },
           "operations": { "type": "array", "items": { "$ref": "#/components/schemas/Operation" } }
         }
@@ -318,6 +354,14 @@
           "description": { "type": "string" },
           "operations": { "type": "array", "items": { "$ref": "#/components/schemas/Operation" } },
           "content_source_id": { "type": "integer" },
+          "meta_data": {
+            "type": "object",
+            "nullable": true,
+            "additionalProperties": true,
+            "properties": {
+              "source": { "$ref": "#/components/schemas/ContentSourceCite" }
+            }
+          },
           "version": { "type": "string" }
         }
       },
@@ -340,6 +384,14 @@
           "trait_id": { "type": "integer" },
           "artwork_url": { "type": "string" },
           "content_source_id": { "type": "integer" },
+          "meta_data": {
+            "type": "object",
+            "nullable": true,
+            "additionalProperties": true,
+            "properties": {
+              "source": { "$ref": "#/components/schemas/ContentSourceCite" }
+            }
+          },
           "version": { "type": "string" }
         }
       },
@@ -376,6 +428,14 @@
           "override_skill_training_base": { "type": ["integer", "null"] },
           "override_class_operations": { "type": "boolean" },
           "content_source_id": { "type": "integer" },
+          "meta_data": {
+            "type": "object",
+            "nullable": true,
+            "additionalProperties": true,
+            "properties": {
+              "source": { "$ref": "#/components/schemas/ContentSourceCite" }
+            }
+          },
           "deprecated": { "type": "boolean" },
           "version": { "type": "string" }
         }
@@ -397,6 +457,14 @@
           "trait_id": { "type": "integer" },
           "artwork_url": { "type": "string" },
           "content_source_id": { "type": "integer" },
+          "meta_data": {
+            "type": "object",
+            "nullable": true,
+            "additionalProperties": true,
+            "properties": {
+              "source": { "$ref": "#/components/schemas/ContentSourceCite" }
+            }
+          },
           "version": { "type": "string" },
           "dedication_feat_id": { "type": "integer" }
         }
@@ -418,6 +486,14 @@
           "trait_id": { "type": "integer" },
           "artwork_url": { "type": "string" },
           "content_source_id": { "type": "integer" },
+          "meta_data": {
+            "type": "object",
+            "nullable": true,
+            "additionalProperties": true,
+            "properties": {
+              "source": { "$ref": "#/components/schemas/ContentSourceCite" }
+            }
+          },
           "version": { "type": "string" },
           "heritage_id": { "type": "integer" }
         }
@@ -438,6 +514,14 @@
           "script": { "type": "string" },
           "description": { "type": "string" },
           "content_source_id": { "type": "integer" },
+          "meta_data": {
+            "type": "object",
+            "nullable": true,
+            "additionalProperties": true,
+            "properties": {
+              "source": { "$ref": "#/components/schemas/ContentSourceCite" }
+            }
+          },
           "rarity": { "$ref": "#/components/schemas/Rarity" },
           "availability": { "$ref": "#/components/schemas/Availability" }
         }
@@ -471,7 +555,13 @@
           "abilities_added": { "type": "array", "items": { "type": "integer" } },
           "inventory": { "type": "object", "additionalProperties": true },
           "spells": { "type": "object", "additionalProperties": true },
-          "meta_data": { "type": "object", "additionalProperties": true },
+          "meta_data": {
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "source": { "$ref": "#/components/schemas/ContentSourceCite" }
+            }
+          },
           "content_source_id": { "type": "integer" },
           "deprecated": { "type": "boolean" },
           "version": { "type": "string" }

--- a/frontend/src/ai/cleaning/item-cleaning.ts
+++ b/frontend/src/ai/cleaning/item-cleaning.ts
@@ -500,6 +500,10 @@ Pathfinder 2e has two editions — the legacy edition and the remaster (2023+). 
 - Before each tool call (or batch of tool calls), briefly explain in plain text what you're about to do and why. This reasoning will be logged.
 - Never invent IDs. Always fetch content by name to find the correct numeric ID.
 - meta_data must be returned as a plain JSON object (not a serialized string).
+- **Never invent, alter, or remove the "source" field in meta_data.** It is the item's
+  source citation (book / page / URL), maintained separately from cleaning. Return it
+  exactly as given, or omit it if the input had none — it is reattached automatically
+  either way.
 - **meta_data.category and meta_data.group mean different things for weapons vs armor.** Leave them absent on all other item types (GENERAL, SHIELD, RUNE, etc.).
   - **Armor** — category: the armor weight class ("light", "medium", "heavy", "unarmored_defense"). group: the armor specialization group — valid PF2e values: "chain", "composite", "leather", "plate", "skeletal", "wood"; valid SF2e values: "cloth", "ceramic", "polymer". (These MUST be lowercase to match the schema — Title Case will fail validation.)
   - **Weapons** — category: the proficiency category ("simple", "martial", "advanced", "unarmed_attack"). group: the weapon specialization group — valid PF2e values: "axe", "bomb", "bow", "brawling", "club", "crossbow", "dart", "firearm", "flail", "hammer", "knife", "pick", "polearm", "projectile", "shield", "sling", "spear", "sword"; valid SF2e values: "corrosive", "cryo", "flame", "grenade", "laser", "mental", "missile", "plasma", "poison", "shock", "sniper", "sonic". Any value not in these lists is wrong and must be corrected.
@@ -742,7 +746,15 @@ export const fixItem = async (item: Item, log: (type: string, data: any) => void
             if (!parsed.success) {
               result = `Schema validation failed — fix these issues and call returnFixedItem again:\n- ${formatZodError(candidate, parsed.error)}`;
             } else {
-              fixedItem = parsed.data as Item;
+              // Provenance is not the model's to rewrite. The agent rebuilds meta_data
+              // from scratch, so a source cite present on the input would simply be
+              // dropped by omission — passthrough can preserve an unknown key but cannot
+              // restore one the model never emitted. Pin the original cite back on.
+              const cleaned = parsed.data as Item;
+              if (item.meta_data?.source && cleaned.meta_data) {
+                cleaned.meta_data.source = item.meta_data.source;
+              }
+              fixedItem = cleaned;
               result = 'Done.';
             }
           } else {

--- a/frontend/src/schemas/content.ts
+++ b/frontend/src/schemas/content.ts
@@ -55,6 +55,34 @@ export type {
   ItemMetaGroupArmor,
 } from './shared';
 
+// ─── Content source provenance ────────────────────────────────────────────────
+
+// An optional citation for where a piece of content came from: which book, what page,
+// and a link to an external reference (Archives of Nethys, Paizo, or anywhere else).
+// Lives at `meta_data.source` on every content type.
+//
+// `book` is stored as text even though `content_source_id` already names the source,
+// because a page cite can belong to a *different* book than the row is filed under.
+// Reprints are exactly this: Musical Accompaniment is filed under Impossible Magic and
+// cites page 154 of it, while the legacy row is filed under Firebrands with its own page.
+//
+// `page` is text rather than a number so it can express spans ("154-155") and splits
+// ("154, 160"), which are common for classes and longer items.
+export const ContentSourceCiteSchema = z.object({
+  book: z.string().optional(),
+  page: z.string().optional(),
+  url: z.string().optional(),
+});
+export type ContentSourceCite = z.infer<typeof ContentSourceCiteSchema>;
+
+// For content types whose `meta_data` exists only to hold the cite — they carry no
+// type-specific fields of their own.
+const CiteOnlyMetaDataSchema = z
+  .object({ source: ContentSourceCiteSchema.optional() })
+  .passthrough()
+  .nullable()
+  .optional();
+
 // ─── Trait ────────────────────────────────────────────────────────────────────
 
 export const TraitSchema = z.object({
@@ -74,7 +102,9 @@ export const TraitSchema = z.object({
       archetype_trait: z.boolean().optional(),
       versatile_heritage_trait: z.boolean().optional(),
       companion_type_trait: z.boolean().optional(),
+      source: ContentSourceCiteSchema.optional(),
     })
+    .passthrough()
     .nullable(),
   content_source_id: z.number(),
 });
@@ -203,6 +233,7 @@ export interface Item {
     cleaning?: {
       updatedAt: string;
     };
+    source?: ContentSourceCite;
   } | null;
   operations: Operation[] | null;
   content_source_id: number;
@@ -335,7 +366,9 @@ export const ItemSchema: z.ZodType<Item> = z.lazy(() =>
             updatedAt: z.string(),
           })
           .optional(),
+        source: ContentSourceCiteSchema.optional(),
       })
+      .passthrough()
       .nullable(),
     operations: z.array(OperationSchema).nullable(),
     content_source_id: z.number(),
@@ -407,16 +440,19 @@ export const SpellSchema = z.object({
       data: z.record(z.string(), z.any()).optional(),
     })
     .nullable(),
-  meta_data: z.object({
-    focus: z.boolean().optional(),
-    damage: z.array(z.object({})).optional(),
-    type: z.string().optional(),
-    ritual: z.record(z.string(), z.any()).or(z.boolean()).optional(),
-    foundry: z.record(z.string(), z.any()).optional(),
-    unselectable: z.boolean().optional(),
-    deprecated: z.boolean().optional(),
-    image_url: z.string().optional(),
-  }),
+  meta_data: z
+    .object({
+      focus: z.boolean().optional(),
+      damage: z.array(z.object({})).optional(),
+      type: z.string().optional(),
+      ritual: z.record(z.string(), z.any()).or(z.boolean()).optional(),
+      foundry: z.record(z.string(), z.any()).optional(),
+      unselectable: z.boolean().optional(),
+      deprecated: z.boolean().optional(),
+      image_url: z.string().optional(),
+      source: ContentSourceCiteSchema.optional(),
+    })
+    .passthrough(),
   content_source_id: z.number(),
   version: z.string(),
 });
@@ -451,7 +487,9 @@ export const AbilityBlockSchema = z.object({
       skill: z.union([z.string(), z.array(z.string())]).optional(),
       image_url: z.string().optional(),
       foundry: z.record(z.string(), z.any()).optional(),
+      source: ContentSourceCiteSchema.optional(),
     })
+    .passthrough()
     .nullable(),
   traits: z.array(z.number()).nullable(),
   content_source_id: z.number(),
@@ -475,6 +513,7 @@ export const ClassSchema = z.object({
   deprecated: z.boolean().nullable(),
   content_source_id: z.number(),
   version: z.string(),
+  meta_data: CiteOnlyMetaDataSchema,
 });
 export type Class = z.infer<typeof ClassSchema>;
 
@@ -506,6 +545,7 @@ export const ClassArchetypeSchema = z.object({
   content_source_id: z.number(),
   deprecated: z.boolean().nullable(),
   version: z.string(),
+  meta_data: CiteOnlyMetaDataSchema,
 });
 export type ClassArchetype = z.infer<typeof ClassArchetypeSchema>;
 
@@ -524,6 +564,7 @@ export const ArchetypeSchema = z.object({
   deprecated: z.boolean().nullable(),
   version: z.string(),
   dedication_feat_id: z.number().nullable(),
+  meta_data: CiteOnlyMetaDataSchema,
 });
 export type Archetype = z.infer<typeof ArchetypeSchema>;
 
@@ -542,6 +583,7 @@ export const VersatileHeritageSchema = z.object({
   deprecated: z.boolean().nullable(),
   version: z.string(),
   heritage_id: z.number(),
+  meta_data: CiteOnlyMetaDataSchema,
 });
 export type VersatileHeritage = z.infer<typeof VersatileHeritageSchema>;
 
@@ -560,6 +602,7 @@ export const AncestrySchema = z.object({
   deprecated: z.boolean().nullable(),
   version: z.string(),
   operations: z.array(OperationSchema).nullable(),
+  meta_data: CiteOnlyMetaDataSchema,
 });
 export type Ancestry = z.infer<typeof AncestrySchema>;
 
@@ -577,6 +620,7 @@ export const BackgroundSchema = z.object({
   deprecated: z.boolean().nullable(),
   content_source_id: z.number(),
   version: z.string(),
+  meta_data: CiteOnlyMetaDataSchema,
 });
 export type Background = z.infer<typeof BackgroundSchema>;
 
@@ -594,6 +638,7 @@ export const LanguageSchema = z.object({
   deprecated: z.boolean().nullable(),
   rarity: RaritySchema,
   availability: AvailabilitySchema.nullable(),
+  meta_data: CiteOnlyMetaDataSchema,
 });
 export type Language = z.infer<typeof LanguageSchema>;
 
@@ -705,6 +750,23 @@ const CharacterVariantsSchema = z.object({
 
 // ─── LivingEntity ─────────────────────────────────────────────────────────────
 
+// Extracted so Creature can extend it with a source cite. Character shares the same
+// shape but is not content and carries no cite.
+const LivingEntityMetaDataSchema = z.object({
+  active_modes: z.array(z.string()).optional(),
+  given_item_ids: z.array(z.number()).optional(),
+  reset_hp: z.boolean().optional(),
+  calculated_stats: z
+    .object({
+      hp_max: z.number().optional(),
+      stamina_max: z.number().optional(),
+      resolve_max: z.number().optional(),
+      ac: z.number().optional(),
+      profs: z.record(z.string(), z.object({ total: z.number(), type: ProficiencyTypeSchema })),
+    })
+    .optional(),
+});
+
 export const LivingEntitySchema = z.object({
   id: z.number().optional(),
   name: z.string(),
@@ -738,22 +800,7 @@ export const LivingEntitySchema = z.object({
       notes: z.record(z.string(), z.string()).optional(),
     })
     .nullable(),
-  meta_data: z
-    .object({
-      active_modes: z.array(z.string()).optional(),
-      given_item_ids: z.array(z.number()).optional(),
-      reset_hp: z.boolean().optional(),
-      calculated_stats: z
-        .object({
-          hp_max: z.number().optional(),
-          stamina_max: z.number().optional(),
-          resolve_max: z.number().optional(),
-          ac: z.number().optional(),
-          profs: z.record(z.string(), z.object({ total: z.number(), type: ProficiencyTypeSchema })),
-        })
-        .optional(),
-    })
-    .nullable(),
+  meta_data: LivingEntityMetaDataSchema.passthrough().nullable(),
 });
 export type LivingEntity = z.infer<typeof LivingEntitySchema>;
 
@@ -777,6 +824,11 @@ export const CreatureSchema = LivingEntitySchema.extend({
   content_source_id: z.number(),
   deprecated: z.boolean().nullable(),
   version: z.string(),
+  meta_data: LivingEntityMetaDataSchema.extend({
+    source: ContentSourceCiteSchema.optional(),
+  })
+    .passthrough()
+    .nullable(),
 });
 export type Creature = z.infer<typeof CreatureSchema>;
 

--- a/supabase/migrations/20260827000000_content_meta_data_jsonb.sql
+++ b/supabase/migrations/20260827000000_content_meta_data_jsonb.sql
@@ -1,0 +1,74 @@
+-- Normalise `meta_data` across the content corpus: jsonb everywhere, present everywhere,
+-- and indexed.
+--
+-- Groundwork for optional per-row source provenance (book / page / URL stored under
+-- `meta_data`). Three problems stood in the way:
+--
+--  1. Type drift. `spell` and `trait` were already jsonb; `ability_block`, `item` and
+--     `creature` were plain `json`, which has no containment operators and cannot carry
+--     a GIN index. Any "which rows have provenance?" query was impossible on the three
+--     biggest tables.
+--  2. Missing entirely. Seven content tables had no `meta_data` column at all, so those
+--     content types had nowhere to put it.
+--  3. Unindexed. There were zero GIN indexes on `meta_data` anywhere in the database.
+--
+-- Verified safe before writing this (see the effort's research notes):
+--  * No generated column reads `meta_data` — every `search_tsv` is built from `name` and
+--    `description` only, so nothing is recomputed by the type change.
+--  * No view and no RLS policy references `meta_data`.
+--  * The `updated_at` / content-source-bump triggers are row-level DML triggers. This
+--    migration is pure DDL, so it fires none of them and invalidates no client cache.
+--  * jsonb silently drops duplicate keys where json keeps them. Checked every affected
+--    row by comparing json_object_keys against jsonb_object_keys: zero rows differ, so
+--    the conversion is lossless.
+--
+-- `content_source.meta_data` is deliberately NOT converted. It holds the per-source
+-- `counts` blob written by _shared/helpers.ts and never carries provenance — a source is
+-- the book, it does not cite one.
+
+-- ─── 1. json -> jsonb on the three drifted tables ────────────────────────────
+-- Full table rewrite under ACCESS EXCLUSIVE. Small: ability_block is the largest at
+-- ~27k rows / ~515 kB of meta_data.
+
+do $$
+declare
+  t text;
+begin
+  foreach t in array array['ability_block', 'item', 'creature'] loop
+    execute format('alter table public.%I alter column meta_data type jsonb using meta_data::jsonb', t);
+  end loop;
+end $$;
+
+-- ─── 2. Add meta_data where it was missing ───────────────────────────────────
+-- Nullable with no default, so this is a metadata-only catalog change: instant, no
+-- rewrite, no lock held over data.
+
+do $$
+declare
+  t text;
+begin
+  foreach t in array array[
+    'ancestry', 'archetype', 'background', 'class',
+    'class_archetype', 'versatile_heritage', 'language'
+  ] loop
+    execute format('alter table public.%I add column if not exists meta_data jsonb', t);
+  end loop;
+end $$;
+
+-- ─── 3. GIN indexes on all 12 provenance-carrying content tables ─────────────
+-- Default jsonb_ops rather than jsonb_path_ops: the coverage queries this exists for
+-- ("which rows carry a cite?") want the key-existence operators (?, ?|, ?&), and
+-- jsonb_path_ops supports only @>.
+
+do $$
+declare
+  t text;
+begin
+  foreach t in array array[
+    'ability_block', 'ancestry', 'archetype', 'background', 'class',
+    'class_archetype', 'creature', 'item', 'language', 'spell',
+    'trait', 'versatile_heritage'
+  ] loop
+    execute format('create index if not exists %I on public.%I using gin (meta_data)', t || '_meta_data_gin', t);
+  end loop;
+end $$;


### PR DESCRIPTION
Adds an optional per-row source citation — book, page, and URL — at `meta_data.source` on every content type.

## Already applied to production

The DDL and two data changes are **already live**; this PR is the tree catching up. Nothing here needs to be run again.

- The migration was applied 2026-08-27 (~18s). Verified lossless: the `ability_block` key histogram is identical before and after, and zero content-source cache tokens were bumped (pure DDL fires no row triggers).
- 25 rows in content source 832 had `meta_data.source` as a **string** (`"SWFinder importer"`), which collided with the new object. Renamed to `meta_data.swfinder_source`; value preserved verbatim. `source` is now free across all 12 content tables.
- Spell 8837 carries the first real cite (Impossible Magic pg. 154).

## Schema

`meta_data` is now `jsonb` on all 12 content tables, exists on the seven that lacked it, and has a GIN index. `content_source` is deliberately excluded — it is the book, it does not cite one.

`book` is stored as text even though `content_source_id` identifies the source, because a page reference can belong to a different book than the row is filed under. `page` is text so it can express spans (`154-155`) and splits (`154, 160`).

## Fixes a latent data-loss bug

Worth reviewing on its own merits, independent of provenance.

Every content `meta_data` was a closed `z.object()`, which silently strips unknown keys — no error, no warning. The editor modals round-trip `meta_data` opaquely from that stripped cache, so **opening a row and saving it erased any key the schema didn't list**. `swfinder_source`, `swfinder_rank` and `canSelectMultipleTimes` on `ability_block` were all exposed to this.

All content `meta_data` objects are now `.passthrough()`. There was already precedent in `operations.ts`, which carries a comment describing the identical failure.

`item-cleaning.ts` needed more: the agent rebuilds `meta_data` from scratch, so passthrough cannot preserve a key the model simply omits. The cite is pinned back explicitly after validation, and the system prompt forbids altering it.

## Out of scope

No UI. Cites are written by SQL and, later, by a backfill matcher. Display in the drawer is a separate effort, as is backfilling the ~45k existing rows from Archives of Nethys.

## Verification

`tsc --noEmit` and `eslint` clean. Prod-shaped records parsed through the real schemas: the cite survives on spell, ability_block and class; `swfinder_*` keys now survive instead of being dropped; `meta_data` accepts null and absent on the newly-added types.