### PR TITLE
Preserve interrupted saves and correct earned-level skill progression

### DIFF
--- a/docs/api-reference/authentication.mdx
+++ b/docs/api-reference/authentication.mdx
@@ -178,17 +178,29 @@ responses). Concurrent rejected requests share that refresh. A request retries a
 the same account; permission failures do not trigger refresh. Signing in or recovering
 the session clears the persistent session-expired notice.
 
-Ambiguous network and gateway failures retry only explicitly read-only requests, once.
-Writes, AI requests, and vector population are not repeated after a lost response,
-because the server may already have performed the work. A timeout never starts a
-replacement request.
+Ambiguous network and gateway failures retry only explicitly read-only requests, once,
+at the request layer. Other mutations, AI requests and vector population are not
+repeated automatically. The character editor has a separate guarded recovery flow:
+a failed save retains its submitted snapshot, reads the authoritative character,
+merges pending intent, and writes with the current server version. This handles a
+committed write whose response was lost, including later edits returning a value to
+its original state.
 
-Unsynced character edits are buffered locally without bearer tokens and scoped
-to the account editing the character, including authorized GM edits. Replay uses the
-current authenticated session and the saved server version. A failed response, conflict,
-permission rejection, or missing saved row leaves the copy intact. A successful save
-removes only its matching snapshot; newer queued edits retain their data and advance
-to the acknowledged server version. Signing out preserves these account-scoped copies.
+Unsynced character edits are buffered locally without bearer tokens, separately for
+each account, character and browser page. Saving one tab does not rebase or replace
+another tab's newer draft. Reopening loads recoverable drafts into the editor's normal
+merge/calculation/save queue; restoration itself sends no write. Successful saves
+remove only matching recovered snapshots, preserving any newer edits. Signing out
+preserves these account-scoped copies.
+
+The editor distinguishes **Saved**, **Saving**, pending edits, offline drafts and failed
+sync. Completed failures retry with backoff (up to 30 seconds between attempts), on
+reconnect, and when the page becomes visible or focused. **Retry now** uses the same
+serialized queue. Account changes, read-only access, conflicts and incomplete
+calculations still gate persistence. A browser storage failure displays **Not saved:
+keep this page open**, rather than claiming the edit is durable. A failed initial
+character request offers **Retry loading** on the same route; a network outage is not
+treated as an authorization denial.
 
 An older copy without a server version is kept for explicit recovery instead of
 silently overwriting newer server data. When a retained copy needs attention, the

--- a/docs/development.mdx
+++ b/docs/development.mdx
@@ -275,6 +275,20 @@ The `characters/calculationRecovery.cy.ts` and `characters/saveRecovery.cy.ts` s
 verify worker failure/retry and retained-copy download in the rendered app, including
 desktop and mobile screenshots. Both create and clean up their own local test character.
 
+The `characters/connectionRecovery.cy.ts` spec interrupts real character writes, lets a
+real committed response exceed the client timeout, and prepares spells at phone width
+with 4× CPU throttling before interrupting saving and reopening the page. Assertions read the local database
+through the API as well as the UI. It uses only its own test characters. These scenarios
+simulate flaky transport, constrained CPU and page lifecycle boundaries, not iOS/Android
+process eviction or a measured physical-device performance profile. The save-hook regressions also cover uncertain writes,
+intentional reversions, separate-tab drafts, storage exhaustion, and account changes.
+
+The `characters/skillProgression.cy.ts` spec creates an official Fighter/Skill Mastery
+fixture through the local API, runs the real operations worker, and checks master Medicine
+and its earlier expert-increase selector on desktop and mobile. The engine regression
+suite also covers Medic, repeated mastery, source-level caps, removal/regrant and creature
+store isolation.
+
 The same suite runs in CI on every PR via the `e2e` workflow. See [`.github/workflows/e2e.yml`](https://github.com/wanderers-guide/wanderers-guide/blob/main/.github/workflows/e2e.yml).
 
 ## Running the API tests

--- a/docs/guides/content-data.mdx
+++ b/docs/guides/content-data.mdx
@@ -34,12 +34,21 @@ preserves unsynced character drafts.
 
 The builder waits for the current character's authoritative save context before
 exposing editable controls. A cached route row cannot make the form ready early.
+A failed load leaves the character route available for retry. Save status distinguishes
+server confirmation from a locally retained edit; reconnect and retry use one serialized
+save queue. Each browser page keeps its own recovery copy, so concurrent tabs cannot
+silently overwrite another tab's local draft.
 
 Concurrent character edits merge at nested fields and stable entry IDs. Independent
 changes survive. When both writers change the same value, saving pauses and offers
 **Keep my edits**, **Use saved version**, and **Download my copy**. The local input and
 its original base remain buffered until the conflict is resolved. Choosing the saved
 version removes the matching rejected draft so reloading cannot restore that edit.
+
+Calculation completion applies every guarded state update; it does not debounce several
+updates into only the last one. Health normalization reads the latest HP when applying
+the result, so a slow calculation cannot replace newer damage or healing with an older
+clamped value. Input debouncing remains in place before running operations.
 
 ### Public vs. homebrew
 

--- a/docs/guides/operations.mdx
+++ b/docs/guides/operations.mdx
@@ -104,6 +104,18 @@ Adjust a value. The exact behaviour depends on the variable type:
 - **`bool`**: set to true.
 - **`str`**: replace.
 
+Skill adjustments resolve in earned-level order. Training and fixed-rank grants precede
+increases earned at the same level. An earlier increase consumed reaching expert cannot
+be counted again when a later feat grants master. Increasing the character's level alone
+does not spend that old increase again. Numeric increases use their source's level cap
+(master from 7, legendary from 15); explicit rank grants retain their authored rank.
+Active level-threshold conditions pass their activation level to descendant adjustments.
+Selector previews use this same progression at the selected occurrence, so a later feat
+cannot make an earlier valid choice appear disabled. Removing a grant rebuilds progression
+from the remaining occurrences. Self-guarded proficiency grants resolve before sibling
+conditional text that reads the resulting proficiency (including Medic's Battle Medicine
+frequency). These mechanics do not invent missing content prerequisites.
+
 ```jsonc
 // Numeric
 { "id": "...", "type": "adjValue", "data": { "variable": "MAX_HEALTH", "value": 5 } }

--- a/frontend/cypress/e2e/characters/characterBuilder.cy.ts
+++ b/frontend/cypress/e2e/characters/characterBuilder.cy.ts
@@ -1,34 +1,44 @@
 describe('Characters', () => {
+  let characterId: number | undefined;
+  let token: string;
   beforeEach(() => {
+    characterId = undefined;
+    cy.intercept('POST', '**/auth/v1/token*').as('signIn');
     cy.login(Cypress.env('TEST_EMAIL'), Cypress.env('TEST_PASSWORD'));
+    cy.wait('@signIn').then(({ response }) => {
+      token = response?.body.access_token;
+    });
     cy.visit('/characters');
   });
 
   it('should show empty characters', () => {
+    cy.intercept('POST', '**/functions/v1/find-character', { statusCode: 200, body: { status: 'success', data: [] } });
+    cy.visit('/characters');
     cy.contains('No characters found').should('exist');
   });
 
   describe('Character builder', () => {
     beforeEach(() => {
+      cy.intercept('POST', '**/functions/v1/create-character').as('created');
       cy.get('button[aria-label="Create Character"]').click();
+      cy.wait('@created').then(({ response }) => {
+        characterId = response?.body.data.id;
+      });
       cy.location('pathname', { timeout: 10000 }).should('include', '/builder');
     });
 
     afterEach(() => {
-      cy.get('button').contains('User Name').click();
-      cy.get('div.mantine-Menu-dropdown').contains('Characters').click();
-      cy.wait(500);
-      cy.location('pathname').should('eq', '/characters');
-
-      const removeCharacter = ($el: HTMLElement) => {
-        cy.wrap($el).as('btn');
-        cy.get('@btn').click();
-        cy.contains('Delete Character').click();
-        cy.get('button').contains('Delete').click();
-      };
-
-      cy.get('button[aria-label="Options"]').each(removeCharacter);
-      cy.contains('No characters found').should('exist');
+      // Clean up only this test's fixture; other local characters may already exist.
+      if (!characterId || !token) return;
+      cy.request({
+        method: 'POST',
+        url: `${Cypress.env('functions_url')}/delete-content`,
+        headers: { Authorization: `Bearer ${token}` },
+        body: { id: characterId, type: 'character' },
+        log: false,
+      })
+        .its('body.status')
+        .should('eq', 'success');
     });
 
     it('should create a lvl 1 human fighter', () => {

--- a/frontend/cypress/e2e/characters/connectionRecovery.cy.ts
+++ b/frontend/cypress/e2e/characters/connectionRecovery.cy.ts
@@ -1,0 +1,193 @@
+/** Real editor/API regression: a dropped save must recover without another edit or reload. */
+describe('Interrupted character saves', () => {
+  let characterId: number | undefined;
+  let token: string;
+  let actorId: string;
+
+  beforeEach(() => {
+    characterId = undefined;
+    cy.intercept('POST', '**/auth/v1/token*').as('signIn');
+    cy.login(Cypress.env('TEST_EMAIL'), Cypress.env('TEST_PASSWORD'));
+    cy.wait('@signIn').then(({ response }) => {
+      token = response?.body.access_token;
+      actorId = response?.body.user.id;
+    });
+    cy.intercept('POST', '**/functions/v1/create-character').as('create');
+    cy.get('button[aria-label="Create Character"]').click();
+    cy.wait('@create').then(({ response }) => {
+      characterId = response?.body.data.id;
+    });
+    cy.get('input[placeholder="Unknown Wanderer"]', { timeout: 30000 }).should('be.visible');
+  });
+
+  afterEach(() => {
+    cy.then(() =>
+      Cypress.automation('remote:debugger:protocol', { command: 'Emulation.setCPUThrottlingRate', params: { rate: 1 } })
+    );
+    if (!characterId || !token) return;
+    cy.request({
+      method: 'POST',
+      url: `${Cypress.env('functions_url')}/delete-content`,
+      headers: { Authorization: `Bearer ${token}` },
+      body: { id: characterId, type: 'character' },
+      log: false,
+    })
+      .its('body.status')
+      .should('eq', 'success');
+  });
+
+  const readCharacter = () =>
+    cy
+      .request({
+        method: 'POST',
+        url: `${Cypress.env('functions_url')}/find-character`,
+        headers: { Authorization: `Bearer ${token}` },
+        body: { id: characterId },
+        log: false,
+      })
+      .its('body.data');
+
+  it('saves the retained edit when the connection returns, without requiring more typing', () => {
+    let disrupted = true;
+    cy.intercept('POST', '**/functions/v1/update-character', (req) => {
+      if (disrupted) {
+        req.alias = 'droppedSave';
+        req.destroy();
+      } else {
+        req.alias = 'recoveredSave';
+        req.continue();
+      }
+    });
+    cy.get('input[placeholder="Unknown Wanderer"]').type('Kept through a connection drop');
+    cy.wait('@droppedSave', { timeout: 15000 });
+    cy.contains('Not synced: retrying automatically', { timeout: 40000 }).should('be.visible');
+    cy.window().should((win) => {
+      const key = Object.keys(win.localStorage).find((key) =>
+        key.startsWith(`autosave-character-${characterId}-${actorId}:writer:`)
+      );
+      const draft = JSON.parse(win.localStorage.getItem(key ?? '') ?? '{}');
+      expect(draft.body?.name).to.eq('Kept through a connection drop');
+    });
+    cy.window().then((win) => {
+      disrupted = false;
+      win.dispatchEvent(new Event('online'));
+    });
+    cy.wait('@recoveredSave', { timeout: 15000 }).its('response.body.status').should('eq', 'success');
+    cy.request({
+      method: 'POST',
+      url: `${Cypress.env('functions_url')}/find-character`,
+      headers: { Authorization: `Bearer ${token}` },
+      body: { id: characterId },
+      log: false,
+    })
+      .its('body.data.name')
+      .should('eq', 'Kept through a connection drop');
+    cy.reload();
+    cy.get('input[placeholder="Unknown Wanderer"]', { timeout: 30000 }).should(
+      'have.value',
+      'Kept through a connection drop'
+    );
+  });
+
+  it('retains the newest edit when the server commits but its response times out', () => {
+    let committed = false;
+    let first = true;
+    cy.intercept('POST', '**/functions/v1/update-character', (req) => {
+      if (first) {
+        first = false;
+        req.continue((res) => {
+          committed = res.body.status === 'success';
+          res.setDelay(31000);
+        });
+      } else {
+        req.alias = 'latestSave';
+        req.continue();
+      }
+    });
+    cy.get('input[placeholder="Unknown Wanderer"]').type('Committed before timeout');
+    cy.wrap(null).should(() => expect(committed).to.eq(true));
+    readCharacter().its('name').should('eq', 'Committed before timeout');
+    cy.get('input[placeholder="Unknown Wanderer"]').clear().type('Newest edit during timeout');
+    cy.get('[data-testid="character-save-status"]').should('contain', 'Saving');
+    cy.wait('@latestSave', { timeout: 45000 }).its('response.body.status').should('eq', 'success');
+    cy.get('[data-testid="character-save-status"]').should('contain', 'Saved');
+    readCharacter().its('name').should('eq', 'Newest edit during timeout');
+    cy.reload();
+    cy.get('input[placeholder="Unknown Wanderer"]', { timeout: 30000 }).should(
+      'have.value',
+      'Newest edit during timeout'
+    );
+  });
+
+  it('recovers prepared spells after interruption and reopening at phone width', () => {
+    cy.get('input[placeholder="Unknown Wanderer"]').type('Mobile wizard recovery');
+    cy.get('button[aria-label="Next Page"]').click();
+    cy.contains('Select an ancestry, background, and class to get started.').should('exist');
+    cy.buildABC('Elf', 'Acolyte', 'Wizard');
+    cy.get('button[aria-label="Next Page"]').click();
+    cy.location('pathname').should('include', '/sheet');
+    cy.get('[data-testid="character-save-status"]', { timeout: 30000 }).should('contain', 'Saved');
+    cy.viewport(390, 844);
+    cy.then(() =>
+      Cypress.automation('remote:debugger:protocol', { command: 'Emulation.setCPUThrottlingRate', params: { rate: 4 } })
+    );
+    cy.get('button[aria-label="Panel Grid"]', { timeout: 10000 }).should('be.visible').click();
+    cy.contains('button', /^Spells$/).click();
+    let disrupted = true;
+    cy.intercept('POST', '**/functions/v1/update-character', (req) => {
+      if (disrupted) req.reply({ statusCode: 503, body: { status: 'error', message: 'Test connection interruption' } });
+      else {
+        req.alias = 'spellsSaved';
+        req.continue((res) => {
+          res.setDelay(750);
+          res.setThrottle(32);
+        });
+      }
+    });
+    cy.get('[data-wg-name="prepared-wizard"]').contains('Manage').click();
+    cy.contains('Add Spell').click();
+    const chooseCharm = () => {
+      cy.get('input[placeholder="Search spells"]').last().type('Charm');
+      cy.get('input[placeholder="Search spells"]')
+        .last()
+        .closest('.mantine-Modal-body')
+        .contains('p', /^Charm$/)
+        .parents('.mantine-Group-root')
+        .filter(':has(button)')
+        .first()
+        .contains('button', /^Select$/)
+        .click();
+    };
+    chooseCharm();
+    cy.get('[data-wg-name="rank-1"]').contains('Select Spell').first().click();
+    chooseCharm();
+    cy.get('button[aria-label="Dismiss save notice"]', { timeout: 30000 }).click();
+    cy.get('#character-save-failed').should('not.exist');
+    cy.get('button.mantine-Modal-close').last().click();
+    cy.contains('Not synced: retrying automatically', { timeout: 30000 }).should('be.visible');
+    cy.screenshot('mobile-spells-waiting-to-sync');
+    cy.window().then((win) => win.dispatchEvent(new Event('pagehide')));
+    cy.reload();
+    cy.get('button[aria-label="Panel Grid"]', { timeout: 30000 }).should('be.visible').click();
+    cy.contains('button', /^Spells$/).click();
+    cy.get('[data-wg-name="rank-group-1"]').contains('Charm').should('be.visible');
+    cy.window().then((win) => {
+      disrupted = false;
+      win.dispatchEvent(new Event('online'));
+    });
+    cy.wait('@spellsSaved', { timeout: 30000 }).its('response.body.status').should('eq', 'success');
+    cy.get('[data-testid="character-save-status"]', { timeout: 30000 }).should('contain', 'Saved');
+    readCharacter()
+      .its('spells')
+      .then((spells) => {
+        expect(spells.list.length).to.be.greaterThan(0);
+        expect(spells.slots.some((slot: { spell_id?: number }) => !!slot.spell_id)).to.eq(true);
+      });
+    cy.reload();
+    cy.get('button[aria-label="Panel Grid"]', { timeout: 30000 }).should('be.visible').click();
+    cy.contains('button', /^Spells$/).click();
+    cy.get('[data-wg-name="rank-group-1"]').contains('Charm').should('be.visible');
+    cy.screenshot('mobile-spells-saved-after-reopen');
+    cy.document().then((doc) => expect(doc.documentElement.scrollWidth).to.be.at.most(doc.documentElement.clientWidth));
+  });
+});

--- a/frontend/cypress/e2e/characters/preparedCaster.cy.ts
+++ b/frontend/cypress/e2e/characters/preparedCaster.cy.ts
@@ -1,8 +1,18 @@
 describe('Character builder', () => {
+  let characterId: number | undefined;
+  let token: string;
   before(() => {
+    cy.intercept('POST', '**/auth/v1/token*').as('signIn');
     cy.login(Cypress.env('TEST_EMAIL'), Cypress.env('TEST_PASSWORD'));
+    cy.wait('@signIn').then(({ response }) => {
+      token = response?.body.access_token;
+    });
     cy.visit('/characters');
+    cy.intercept('POST', '**/functions/v1/create-character').as('created');
     cy.get('button[aria-label="Create Character"]').click();
+    cy.wait('@created').then(({ response }) => {
+      characterId = response?.body.data.id;
+    });
     cy.location('pathname', { timeout: 10000 }).should('include', '/builder');
 
     cy.get('input[placeholder="Unknown Wanderer"]', { timeout: 30000 }).type('Wizard 1');
@@ -19,19 +29,16 @@ describe('Character builder', () => {
   });
 
   after(() => {
-    cy.visit('/characters');
-    cy.location('pathname', { timeout: 10000 }).should('eq', '/characters');
-    cy.intercept('POST', '**/functions/v1/delete-content').as('deleteCharacter');
-
-    const removeCharacter = ($el: HTMLElement) => {
-      cy.wrap($el).as('btn');
-      cy.get('@btn').click();
-      cy.contains('Delete Character').click();
-      cy.get('button').contains('Delete').click();
-      cy.wait('@deleteCharacter').its('response.body.status').should('eq', 'success');
-    };
-
-    cy.get('button[aria-label="Options"]').each(removeCharacter);
+    if (!characterId || !token) return;
+    cy.request({
+      method: 'POST',
+      url: `${Cypress.env('functions_url')}/delete-content`,
+      headers: { Authorization: `Bearer ${token}` },
+      body: { id: characterId, type: 'character' },
+      log: false,
+    })
+      .its('body.status')
+      .should('eq', 'success');
   });
 
   it('should cast only one prepared spell', () => {

--- a/frontend/cypress/e2e/characters/saveRecovery.cy.ts
+++ b/frontend/cypress/e2e/characters/saveRecovery.cy.ts
@@ -59,7 +59,10 @@ describe('Buffered character recovery', () => {
       .its('name')
       .should('eq', 'Unsynced local copy');
     cy.window().then((win) => {
-      const retained = win.localStorage.getItem(`autosave-character-recovery-${characterId}-${actorId}`);
+      const key = Object.keys(win.localStorage).find((key) =>
+        key.startsWith(`autosave-character-${characterId}-${actorId}:writer:legacy-account`)
+      );
+      const retained = win.localStorage.getItem(key ?? '');
       expect(JSON.parse(retained ?? '{}').body.name).to.eq('Unsynced local copy');
     });
   });
@@ -98,7 +101,10 @@ describe('Buffered character recovery', () => {
       .should('eq', 'My conflicting edit');
     cy.contains('button', 'Use saved version').click();
     cy.contains('Conflicting character edits').should('not.exist');
-    cy.get('input[placeholder="Unknown Wanderer"]', { timeout: 30000 }).should('have.value', 'Changed on another device');
+    cy.get('input[placeholder="Unknown Wanderer"]', { timeout: 30000 }).should(
+      'have.value',
+      'Changed on another device'
+    );
     cy.reload();
     cy.get('input[placeholder="Unknown Wanderer"]', { timeout: 30000 }).should(
       'have.value',

--- a/frontend/cypress/e2e/characters/skillProgression.cy.ts
+++ b/frontend/cypress/e2e/characters/skillProgression.cy.ts
@@ -1,0 +1,133 @@
+/** Run official Fighter/Skill Mastery selections through the real API, worker, builder, and modal. */
+describe('Historical skill progression', () => {
+  let characterId: number | undefined;
+  let token: string;
+  const increasePath = 'class-feature-19379_28017953-a9b0-463c-a188-44430105d177';
+  const masteryPath = 'class-feature-19301_bf2954a7-f45b-470b-a91b-93348b6b0bdc';
+  const selections: Record<string, string> = {
+    'class_720d2fe6-f042-4353-8313-1293375b1301-0': 'SKILL_MEDICINE',
+    'class_720d2fe6-f042-4353-8313-1293375b1301-1': 'SKILL_ARCANA',
+    'class_720d2fe6-f042-4353-8313-1293375b1301-2': 'SKILL_NATURE',
+    [increasePath]: 'SKILL_MEDICINE',
+    [masteryPath]: '20544',
+    [`${masteryPath}_20544_ec29035a-a15e-413f-bcc7-ad5a0c5d2aee`]: 'SKILL_MEDICINE',
+    [`${masteryPath}_20544_db311cb5-5d14-4d53-afa2-41470feb090e`]: 'SKILL_ARCANA',
+  };
+
+  before(() => {
+    cy.intercept('POST', '**/auth/v1/token*').as('signIn');
+    cy.login(Cypress.env('TEST_EMAIL'), Cypress.env('TEST_PASSWORD'));
+    cy.wait('@signIn').then(({ response }) => {
+      token = response?.body.access_token;
+      cy.request({
+        method: 'POST',
+        url: `${Cypress.env('functions_url')}/find-class`,
+        headers: { Authorization: `Bearer ${token}` },
+        body: { id: 20 },
+        log: false,
+      }).then(({ body }) => {
+        expect(body.status).to.eq('success');
+        expect(body.data.name).to.eq('Fighter');
+        cy.request({
+          method: 'POST',
+          url: `${Cypress.env('functions_url')}/create-character`,
+          headers: { Authorization: `Bearer ${token}` },
+          body: {
+            name: 'Historical skill progression',
+            level: 15,
+            details: { class: body.data },
+            content_sources: { enabled: [1] },
+            inventory: { items: [] },
+            operation_data: { selections },
+          },
+          log: false,
+        }).then(({ body: created }) => {
+          expect(created.status).to.eq('success');
+          characterId = created.data.id;
+        });
+      });
+    });
+  });
+
+  after(() => {
+    if (!characterId || !token) return;
+    cy.request({
+      method: 'POST',
+      url: `${Cypress.env('functions_url')}/delete-content`,
+      headers: { Authorization: `Bearer ${token}` },
+      body: { id: characterId, type: 'character' },
+      log: false,
+    })
+      .its('body.status')
+      .should('eq', 'success');
+  });
+
+  const openBuilder = () => {
+    cy.visit(`/builder/${characterId}`);
+    cy.get('input[placeholder="Unknown Wanderer"]', { timeout: 30000 }).should(
+      'have.value',
+      'Historical skill progression'
+    );
+    cy.get('button[aria-label="Next Page"]').click();
+    cy.get('[data-wg-name="level-3"]', { timeout: 60000 }).should('be.visible');
+  };
+
+  const openEarlyIncrease = () => {
+    cy.get('[data-wg-name="level-3"]').within(() => {
+      cy.contains('button', /^Level 3/).click();
+      cy.get('[data-wg-name="Skill Increase"]').within(() => {
+        cy.contains('button', /Skill Increase/).click();
+        cy.get('.selection-choice-base').contains('button', 'Medicine', { timeout: 10000 }).click();
+      });
+    });
+    cy.get('.mantine-Modal-body').last().as('skillModal');
+    cy.get('@skillModal').find('input[placeholder^="Search "]').type('Medicine');
+    cy.get('@skillModal')
+      .contains('p', /^Medicine$/)
+      .closest('.mantine-Group-root')
+      .as('medicinePreview');
+    cy.get('@medicinePreview').find('.mantine-Badge-root').should('have.text', 'E');
+    // This is a real pointer action: the old final-rank preview disabled this level-3 choice.
+    cy.get('@medicinePreview').parent().parent().should('not.have.css', 'pointer-events', 'none');
+  };
+
+  it('keeps Medicine master at level 15 and the level-3 expert choice selectable on desktop and mobile', () => {
+    cy.viewport(1280, 900);
+    openBuilder();
+    cy.contains('button', /^Skills$/).click();
+    cy.contains('button', /Medicine/)
+      .find('.mantine-Badge-root')
+      .should('have.text', 'M');
+
+    openEarlyIncrease();
+    cy.screenshot('skill-increase-historical-desktop');
+    cy.viewport(390, 844);
+    cy.get('@medicinePreview').find('.mantine-Badge-root').should('have.text', 'E');
+    cy.document().then((document) => {
+      expect(document.documentElement.scrollWidth).to.be.at.most(document.documentElement.clientWidth);
+    });
+    cy.screenshot('skill-increase-historical-mobile');
+    cy.get('@medicinePreview').click();
+    cy.get('.mantine-Modal-body').should('not.exist');
+
+    cy.request({
+      method: 'POST',
+      url: `${Cypress.env('functions_url')}/find-character`,
+      headers: { Authorization: `Bearer ${token}` },
+      body: { id: characterId },
+      log: false,
+    })
+      .its('body.data.operation_data.selections')
+      .should('deep.equal', selections);
+
+    cy.viewport(1280, 900);
+    openBuilder();
+    cy.contains('button', /^Skills$/).click();
+    cy.contains('button', /Medicine/)
+      .find('.mantine-Badge-root')
+      .should('have.text', 'M');
+    openEarlyIncrease();
+    cy.get('@medicinePreview').click();
+    cy.get('.mantine-Modal-body').should('not.exist');
+  });
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,7 @@
     "predeploy": "tsc && vite build",
     "deploy": "gh-pages -d dist",
     "lint": "eslint src --ext ts,tsx --report-unused-disable-directives",
-    "test:rules": "node --test scripts/feat-selection.test.mjs scripts/language-operations.test.mjs scripts/eidolon-runes.test.mjs scripts/item-drawers.test.mjs scripts/inventory-panel.test.mjs scripts/operation-removal.test.mjs",
+    "test:rules": "node --test scripts/feat-selection.test.mjs scripts/language-operations.test.mjs scripts/eidolon-runes.test.mjs scripts/item-drawers.test.mjs scripts/inventory-panel.test.mjs scripts/operation-removal.test.mjs scripts/skill-progression.test.mjs",
     "test:infra": "node --test scripts/operation-lifecycle.test.mjs scripts/session-recovery.test.mjs scripts/character-save-lifecycle.test.mjs scripts/content-cache.test.mjs scripts/browser-recovery.test.mjs",
     "preview": "vite preview",
     "start:local": "vite",

--- a/frontend/scripts/character-save-lifecycle.test.mjs
+++ b/frontend/scripts/character-save-lifecycle.test.mjs
@@ -50,6 +50,10 @@ class HookHost {
     this.request = async (type, body) =>
       type === 'find-character' ? row(body.id) : [{ ...row(body.id), ...body, updated_at: 'version-2' }];
     this.calculate = () => new Promise(() => {});
+    this.confirmHealth = () => {};
+    this.saveCalculatedStats = () => {};
+    this.deferCharacterCommits = false;
+    this.pendingCharacterCommit = null;
   }
   useRef(value) {
     const index = this.cursor++;
@@ -61,8 +65,11 @@ class HookHost {
     return [
       this.slots[index],
       (value) => {
-        this.slots[index] = typeof value === 'function' ? value(this.slots[index]) : value;
-        this.dirty = true;
+        const next = typeof value === 'function' ? value(this.slots[index]) : value;
+        if (!Object.is(this.slots[index], next)) {
+          this.slots[index] = next;
+          this.dirty = true;
+        }
       },
     ];
   }
@@ -97,10 +104,15 @@ class HookHost {
         Promise.resolve()
           .then(() => submitted.mutationFn(save))
           .then(
-            (result) => submitted.onSuccess?.(result, save),
-            (error) => submitted.onError?.(error, save)
-          )
-          .finally(() => submitted.onSettled?.(undefined, undefined, save));
+            (result) => {
+              submitted.onSuccess?.(result, save);
+              submitted.onSettled?.(result, undefined, save);
+            },
+            (error) => {
+              submitted.onError?.(error, save);
+              submitted.onSettled?.(undefined, error, save);
+            }
+          );
       },
     };
   }
@@ -130,6 +142,12 @@ class HookHost {
 }
 class Storage {
   data = new Map();
+  get length() {
+    return this.data.size;
+  }
+  key(index) {
+    return [...this.data.keys()][index] ?? null;
+  }
   getItem(key) {
     return this.data.get(key) ?? null;
   }
@@ -158,6 +176,16 @@ globalThis.__saveHooks = {
   notify: (notice) => harness.notices.push(notice),
   download: (body, name) => harness.downloads.push({ body, name }),
   calculate: () => harness.calculate(),
+  confirmHealth: (...args) => harness.confirmHealth(...args),
+  saveCalculatedStats: (...args) => harness.saveCalculatedStats(...args),
+  debounce: (value) => harness.debouncedCharacter ?? value,
+  debounceCallback:
+    (callback) =>
+    (...args) => {
+      // Mantine coalesces setter callbacks, replacing every earlier updater.
+      if (harness.deferCharacterCommits) harness.pendingCharacterCommit = () => callback(...args);
+      else callback(...args);
+    },
   supabase: { auth: { getSession: async () => ({ data: { session: harness.session } }) } },
 };
 const boundaries = {
@@ -166,7 +194,7 @@ const boundaries = {
     'export const jsx = (type,props) => ({type,props}); export const jsxs = jsx; export const Fragment = "fragment";',
   jotai: 'export const {useAtom,useAtomValue} = globalThis.__saveHooks;',
   '@mantine/hooks':
-    'export const {useDidUpdate} = globalThis.__saveHooks; export const useDebouncedValue = value => [value]; export const useDebouncedCallback = callback => callback;',
+    'export const {useDidUpdate} = globalThis.__saveHooks; export const useDebouncedValue = value => [globalThis.__saveHooks.debounce(value)]; export const useDebouncedCallback = globalThis.__saveHooks.debounceCallback;',
   '@tanstack/react-query': 'export const {useMutation} = globalThis.__saveHooks; export const useQuery = () => {};',
   '@requests/request-manager':
     'export const {makeRequest} = globalThis.__saveHooks; export const hasSessionExpiredNotice = () => false;',
@@ -187,21 +215,33 @@ const boundaries = {
   './numbers': 'export const hashData = value => JSON.stringify(value);',
   './objects': 'export const getDeepDiff = (a,b) => JSON.stringify(a) === JSON.stringify(b) ? {} : { changed: true };',
   './type-fixing': 'export const convertToSetEntity = value => value;',
-  '@conditions/condition-handler': 'export const applyConditions = () => {};',
-  '@items/inv-utils': 'export const applyEquipmentPenalties = () => {};',
-  '@pages/character_sheet/entity-handler': 'export const confirmHealth = () => {};',
-  '@variables/calculated-stats': 'export const saveCalculatedStats = () => {};',
-  '@variables/variable-manager': 'export const setVariable = () => {};',
+  '@conditions/condition-handler':
+    'export const applyConditions = () => {}; export const getConditionByName = name => ({name,value:1});',
+  '@items/inv-utils':
+    'export const applyEquipmentPenalties = () => {}; export const filterByTraitType = () => []; export const getBestArmor = () => undefined;',
+  '@content/collect-content':
+    'export const collectEntitySpellcasting = () => ({}); export const getFocusPoints = () => ({max:0});',
+  '@pages/character_sheet/entity-handler': 'export const confirmHealth = globalThis.__saveHooks.confirmHealth;',
+  '@variables/calculated-stats': 'export const saveCalculatedStats = globalThis.__saveHooks.saveCalculatedStats;',
+  '@variables/variable-manager':
+    'export const setVariable = () => {}; export const getVariable = () => undefined; export const getVariables = () => ({}); export const addVariable = () => {};',
+  './variable-manager':
+    'export const getVariable = () => undefined; export const getVariables = () => ({}); export const addVariable = () => {};',
+  './variable-helpers':
+    'export const getFinalHealthValue = () => 10; export const getFinalStaminaValue = () => 0; export const getFinalResolveValue = () => 0; export const getFinalAcValue = () => 15; export const getFinalProfValue = () => "0";',
+  './variable-utils': 'export const labelToVariable = value => value;',
+  '@utils/objects':
+    'export const getDeepDiff = (a,b) => JSON.stringify(a) === JSON.stringify(b) ? {} : { changed: true };',
   '@items/inv-handlers': 'export const addExtraItems = () => {}; export const checkBulkLimit = () => {};',
   '@variables/variable-helpers':
-    'export const getFinalHealthValue = () => 10; export const getHealthValueParts = () => ({classHp: 6});',
+    'export const getFinalHealthValue = () => 10; export const getHealthValueParts = () => ({classHp: 6}); export const getFinalResolveValue = () => 0; export const getFinalStaminaValue = () => 0; export const isStaminaVariant = () => false;',
 };
 await build({
   absWorkingDir: root,
   define: { 'import.meta.env.PROD': 'false' },
   stdin: {
     contents:
-      "export {default} from './src/utils/use-character'; export * from './src/utils/character-save-buffer'; export * from './src/utils/character-merge';",
+      "export {default} from './src/utils/use-character'; export * from './src/utils/character-save-buffer'; export * from './src/utils/character-merge'; export {confirmHealth as actualConfirmHealth} from './src/pages/character_sheet/entity-handler'; export {saveCalculatedStats as actualSaveCalculatedStats} from './src/process/variables/calculated-stats';",
     resolveDir: root,
   },
   bundle: true,
@@ -228,7 +268,11 @@ const {
   default: useCharacter,
   bufferCharacterSave,
   getBufferedCharacterSave,
+  journalCharacterSaveSubmission,
   mergeCharacterOnConflict,
+  mergeCharacterSave,
+  actualConfirmHealth,
+  actualSaveCalculatedStats,
 } = await import(pathToFileURL(join(directory, 'hook.mjs')).href);
 const row = (id = 1) => ({
   id,
@@ -356,7 +400,7 @@ test('an empty success payload remains a failed save with a retained draft', asy
   harness.edit({ name: 'Retained edit' });
   await harness.flush();
   assert.equal(getBufferedCharacterSave(1, 'owner').draft.body.name, 'Retained edit');
-  assert.equal(harness.notices.filter((value) => value.id === 'character-save-failed').length, 1);
+  assert.equal(harness.value.saveState, 'failed');
   harness.unmount();
 });
 
@@ -581,6 +625,263 @@ test('choosing the saved version discards the matching conflict draft before nav
   harness.render();
   await harness.flush();
   assert.equal(harness.character.name, 'Remote name');
+  assert.equal(getBufferedCharacterSave(1, 'owner').status, 'none');
+  harness.unmount();
+});
+
+test('a completed failed save retries through the editor when connectivity returns', async () => {
+  let online = false;
+  harness.request = async (type, body) =>
+    type === 'find-character' ? row() : online ? [{ ...row(), ...body, updated_at: 'version-2' }] : null;
+  harness.render();
+  await harness.flush();
+  harness.edit({ name: 'Survives interruption' });
+  await harness.flush();
+  assert.equal(getBufferedCharacterSave(1, 'owner').draft.body.name, 'Survives interruption');
+  online = true;
+  events.get('online')?.();
+  await harness.flush();
+  assert.equal(harness.requests.filter((request) => request.type === 'update-character').length, 2);
+  assert.equal(getBufferedCharacterSave(1, 'owner').status, 'none');
+  harness.unmount();
+});
+
+test('an uncertain write preserves a later deliberate revert whether it committed or not', () => {
+  const base = { ...row(), hp_current: 20 };
+  const submitted = { ...base, hp_current: 10 };
+  for (const remote of [base, { ...submitted, updated_at: 'version-2' }]) {
+    const merged = mergeCharacterSave(base, { ...base, name: 'Later edit' }, remote, submitted);
+    assert.equal(merged.character.hp_current, 20);
+    assert.equal(merged.character.name, 'Later edit');
+    assert.deepEqual(merged.conflicts, []);
+  }
+  assert.deepEqual(mergeCharacterSave(base, base, { ...base, hp_current: 5 }, submitted).conflicts, ['hp_current']);
+});
+
+test('a lost acknowledgement and a later intentional revert survive reconnect', async () => {
+  let server = { ...row(), hp_current: 20 };
+  const first = deferred();
+  let writes = 0;
+  harness.request = async (type, body) => {
+    if (type === 'find-character') return server;
+    writes++;
+    server = { ...server, ...body, updated_at: `version-${writes + 1}` };
+    return writes === 1 ? first.promise : [server];
+  };
+  harness.render();
+  await harness.flush();
+  harness.edit({ hp_current: 10 });
+  await harness.flush();
+  harness.edit({ hp_current: 20 });
+  await harness.flush();
+  assert.equal(getBufferedCharacterSave(1, 'owner').draft.body.hp_current, 20);
+  assert.equal(getBufferedCharacterSave(1, 'owner').draft.submission.body.hp_current, 10);
+  first.resolve(null);
+  await harness.flush();
+  assert.equal(harness.value.saveState, 'failed');
+  events.get('focus')();
+  await harness.flush();
+  assert.equal(server.hp_current, 20);
+  assert.equal(writes, 2);
+  assert.equal(getBufferedCharacterSave(1, 'owner').status, 'none');
+  harness.unmount();
+});
+
+test('reopening reconciles an uncertain submission before saving the latest input', async () => {
+  const base = { ...row(), hp_current: 20 };
+  bufferCharacterSave(base, 'owner', base.updated_at, { base, requiresCalculation: false });
+  journalCharacterSaveSubmission(1, 'owner', { ...base, hp_current: 10 }, base.updated_at);
+  let server = { ...base, hp_current: 10, updated_at: 'version-2' };
+  harness.request = async (type, body) => {
+    if (type === 'find-character') return server;
+    server = { ...server, ...body, updated_at: 'version-3' };
+    return [server];
+  };
+  harness.render();
+  await harness.flush();
+  assert.equal(harness.character.hp_current, 20);
+  assert.equal(server.hp_current, 20);
+  assert.equal(harness.requests.filter((request) => request.type === 'update-character').length, 1);
+  harness.unmount();
+});
+
+test('independent drafts from two tabs merge without granting stale data a newer version', async () => {
+  const base = { ...row(), hp_current: 20 };
+  bufferCharacterSave({ ...base, name: 'Offline rename' }, 'owner', base.updated_at, {
+    base,
+    requiresCalculation: false,
+    writerId: 'other-tab',
+  });
+  let server = { ...base, hp_current: 10, updated_at: 'version-2' };
+  harness.request = async (type, body) => {
+    if (type === 'find-character') return server;
+    assert.equal(body.expected_updated_at, 'version-2');
+    server = { ...server, ...body, updated_at: 'version-3' };
+    return [server];
+  };
+  harness.render();
+  await harness.flush();
+  assert.equal(server.hp_current, 10);
+  assert.equal(server.name, 'Offline rename');
+  assert.equal(getBufferedCharacterSave(1, 'owner', 'other-tab').status, 'none');
+  harness.unmount();
+});
+
+test('failed initial loading stays on the character route and can retry', async () => {
+  harness.request = async () => {
+    throw new Error('Connection unavailable');
+  };
+  harness.render();
+  await harness.flush();
+  assert.equal(harness.value.loadError, true);
+  assert.equal(window.location.href, '');
+  assert.equal(harness.character, null);
+  harness.request = async () => row();
+  harness.value.retryLoad();
+  await harness.flush();
+  assert.equal(harness.value.loadError, false);
+  assert.equal(harness.character.name, row().name);
+  harness.unmount();
+});
+
+test('a full local store never reports the pending edit as saved or durable', async () => {
+  harness.render();
+  await harness.flush();
+  localStorage.setItem = () => {
+    throw new Error('Quota exceeded');
+  };
+  harness.request = async () => null;
+  harness.edit({ name: 'Memory-only edit' });
+  await harness.flush();
+  assert.equal(harness.value.draftStored, false);
+  assert.equal(harness.value.saveState, 'failed');
+  assert.equal(harness.character.name, 'Memory-only edit');
+  harness.unmount();
+});
+
+test('a completed calculation cannot submit a stale debounced route snapshot over restored edits', async () => {
+  bufferCharacterSave({ ...row(), name: 'Recovered name' }, 'owner', 'version-1', {
+    base: row(),
+    requiresCalculation: false,
+    writerId: 'closed-page',
+  });
+  const calculation = deferred();
+  harness.debouncedCharacter = row();
+  harness.options = {
+    type: 'EXECUTE_OPS',
+    data: { content: {}, context: 'CHARACTER-SHEET', onFinishLoading: () => {} },
+  };
+  harness.calculate = () => calculation.promise;
+  harness.render();
+  await harness.flush();
+  assert.equal(harness.character.name, 'Recovered name');
+  calculation.resolve({});
+  await harness.flush();
+  const saves = harness.requests.filter((request) => request.type === 'update-character');
+  assert.equal(saves.length, 1);
+  assert.equal(saves[0].body.name, 'Recovered name');
+  harness.unmount();
+});
+
+test('a slow calculation cannot replace a newer HP edit with its earlier clamped snapshot', async () => {
+  const calculation = deferred();
+  const original = { ...row(), hp_current: 20, meta_data: { reset_hp: false } };
+  harness.options = {
+    type: 'EXECUTE_OPS',
+    data: { content: { items: [] }, context: 'CHARACTER-SHEET', onFinishLoading() {} },
+  };
+  harness.confirmHealth = actualConfirmHealth;
+  harness.calculate = () => calculation.promise;
+  harness.request = async (type, body) =>
+    type === 'find-character' ? original : [{ ...original, ...body, updated_at: 'version-2' }];
+  harness.render();
+  await harness.flush();
+  harness.edit({ hp_current: 5, name: 'Latest name', notes: 'Latest notes' });
+  await harness.flush();
+  assert.equal(harness.character.hp_current, 5);
+  calculation.resolve({});
+  await harness.flush();
+  assert.equal(harness.character.hp_current, 5);
+  assert.equal(harness.character.name, 'Latest name');
+  assert.equal(harness.character.notes, 'Latest notes');
+  const saved = harness.requests.filter((request) => request.type === 'update-character');
+  assert.ok(saved.every((request) => request.body.hp_current === 5));
+  harness.unmount();
+});
+
+test('delayed calculated-stat persistence preserves newer HP, name, and notes', async () => {
+  let current = { ...row(), hp_current: 20, meta_data: { reset_hp: false } };
+  actualSaveCalculatedStats('CHARACTER', current, (update) => {
+    current = typeof update === 'function' ? update(current) : update;
+  });
+  current = { ...current, hp_current: 5, name: 'Latest name', notes: 'Latest notes' };
+  await new Promise((resolve) => setTimeout(resolve, 120));
+  assert.equal(current.hp_current, 5);
+  assert.equal(current.name, 'Latest name');
+  assert.equal(current.notes, 'Latest notes');
+  assert.equal(current.meta_data.calculated_stats.hp_max, 10);
+});
+
+test('HP normalization delivered after another HP edit uses the latest value', async () => {
+  const calculation = deferred();
+  const original = { ...row(), hp_current: 20, meta_data: { reset_hp: false } };
+  harness.options = {
+    type: 'EXECUTE_OPS',
+    data: { content: { items: [] }, context: 'CHARACTER-SHEET', onFinishLoading() {} },
+  };
+  harness.confirmHealth = actualConfirmHealth;
+  harness.deferCharacterCommits = true;
+  harness.calculate = () => calculation.promise;
+  harness.request = async (type, body) =>
+    type === 'find-character' ? original : [{ ...original, ...body, updated_at: 'version-2' }];
+  harness.render();
+  await harness.flush();
+  calculation.resolve({});
+  await harness.flush();
+  harness.edit({ hp_current: 5 });
+  const deliver = harness.pendingCharacterCommit;
+  harness.pendingCharacterCommit = null;
+  deliver?.();
+  await harness.flush();
+  assert.equal(harness.character.hp_current, 5);
+  harness.unmount();
+});
+
+test('one calculation preserves both health normalization and calculated-stat completion updates', async () => {
+  const calculation = deferred();
+  const original = { ...row(), hp_current: 20, meta_data: { reset_hp: false } };
+  harness.options = {
+    type: 'EXECUTE_OPS',
+    data: { content: { items: [] }, context: 'CHARACTER-SHEET', onFinishLoading() {} },
+  };
+  harness.confirmHealth = actualConfirmHealth;
+  harness.saveCalculatedStats = actualSaveCalculatedStats;
+  harness.deferCharacterCommits = true;
+  harness.calculate = () => calculation.promise;
+  harness.request = async (type, body) =>
+    type === 'find-character' ? original : [{ ...original, ...body, updated_at: 'version-2' }];
+  harness.render();
+  await harness.flush();
+  calculation.resolve({});
+  await harness.flush();
+  await new Promise((resolve) => setTimeout(resolve, 120));
+  const deliver = harness.pendingCharacterCommit;
+  harness.pendingCharacterCommit = null;
+  deliver?.();
+  await harness.flush();
+  assert.equal(harness.character.hp_current, 10);
+  assert.equal(harness.character.meta_data.calculated_stats.hp_max, 10);
+  harness.unmount();
+});
+
+test('JSON-normalized save acknowledgements clear the draft and show Saved', async () => {
+  harness.request = async (type, body) =>
+    type === 'find-character' ? row() : JSON.parse(JSON.stringify([{ ...row(), ...body, updated_at: 'version-2' }]));
+  harness.render();
+  await harness.flush();
+  harness.edit({ name: 'Confirmed JSON save', details: { description: undefined } });
+  await harness.flush();
+  assert.equal(harness.value.saveState, 'saved');
   assert.equal(getBufferedCharacterSave(1, 'owner').status, 'none');
   harness.unmount();
 });

--- a/frontend/scripts/session-recovery.test.mjs
+++ b/frontend/scripts/session-recovery.test.mjs
@@ -235,91 +235,6 @@ test('a timeout never sends a replacement write', async () => {
   }
 });
 
-test('buffered saves contain no bearer token and replay with the current authenticated token', async () => {
-  api.bufferCharacterSave(character(), 'owner', 'version-1');
-  assert.equal(savedDraft().draft.actorId, 'owner');
-  assert.equal(savedDraft().draft.body.expected_updated_at, 'version-1');
-  assert.ok(!savedDraft().raw.includes('token'));
-  session = signedIn('new-current-token');
-  assert.deepEqual(await api.replayBufferedCharacterSave(1), { status: 'saved' });
-  assert.equal(calls[0].headers.Authorization, 'Bearer new-current-token');
-  assert.deepEqual(savedDraft(), { status: 'none' });
-});
-
-test('drafts survive every semantic rejection, empty response, and forbidden/conflict envelope', async () => {
-  for (const response of [
-    ok({ __conflict: true, character: { id: 1 } }),
-    ok({ __forbidden: true }),
-    ok([]),
-    ok([{ id: 2 }]),
-    { data: { status: 'fail', data: {} }, error: null },
-    { data: { status: 'error', message: 'failed' }, error: null },
-    { data: { data: [{ id: 1 }] }, error: null },
-  ]) {
-    api.bufferCharacterSave(character(), 'owner', 'version-1');
-    invoke = async () => response;
-    assert.equal((await api.replayBufferedCharacterSave(1)).status, 'retained');
-    assert.equal(savedDraft().draft.body.name, 'Local draft');
-  }
-});
-
-test('network failures retain the draft and remain bounded', async () => {
-  api.bufferCharacterSave(character(), 'owner', 'version-1');
-  invoke = async () => ({ data: null, error: new FunctionsFetchError('offline') });
-  assert.equal((await api.replayBufferedCharacterSave(1)).status, 'retained');
-  assert.equal(calls.length, 1);
-  assert.equal(savedDraft().draft.body.name, 'Local draft');
-});
-
-test('simultaneous replay attempts send one write', async () => {
-  api.bufferCharacterSave(character(), 'owner', 'version-1');
-  const results = await Promise.all([api.replayBufferedCharacterSave(1), api.replayBufferedCharacterSave(1)]);
-  assert.deepEqual(results, [{ status: 'saved' }, { status: 'saved' }]);
-  assert.equal(calls.length, 1);
-});
-
-test('acknowledging an older replay never removes a newer draft', async () => {
-  api.bufferCharacterSave(character(), 'owner', 'version-1');
-  invoke = async () => {
-    api.bufferCharacterSave(character('Newer edit'), 'owner', 'version-1');
-    return ok();
-  };
-  await api.replayBufferedCharacterSave(1);
-  assert.equal(savedDraft().draft.body.name, 'Newer edit');
-});
-
-test('account switching cannot replay another actor draft, and GM drafts use their own actor', async () => {
-  api.bufferCharacterSave(character(), 'owner', 'version-1');
-  session = signedIn('gm-token', 'gm');
-  assert.deepEqual(await api.replayBufferedCharacterSave(1), { status: 'none' });
-  assert.equal(calls.length, 0);
-  api.bufferCharacterSave(character('GM edit'), 'gm', 'version-1');
-  await api.replayBufferedCharacterSave(1);
-  assert.equal(calls[0].headers.Authorization, 'Bearer gm-token');
-  assert.equal(savedDraft('owner').draft.body.name, 'Local draft');
-});
-
-test('legacy unversioned buffers expose a recoverable body and drop their expired bearer token', async () => {
-  const token = `header.${Buffer.from(JSON.stringify({ sub: 'owner' })).toString('base64url')}.expired-signature`;
-  localStorage.setItem('autosave-character-1', JSON.stringify({ token, body: { id: 1, name: 'Legacy draft' } }));
-  const result = await api.replayBufferedCharacterSave(1);
-  assert.equal(result.status, 'retained');
-  assert.equal(result.reason, 'unversioned');
-  assert.equal(result.body.name, 'Legacy draft');
-  assert.equal(calls.length, 0);
-  assert.equal(localStorage.getItem('autosave-character-1'), null);
-  assert.ok(!savedDraft().raw.includes(token));
-});
-
-test('malformed drafts and signed-out sessions remain locally recoverable', async () => {
-  localStorage.setItem('autosave-character-1-owner', 'invalid json');
-  assert.equal((await api.replayBufferedCharacterSave(1)).reason, 'invalid');
-  assert.equal(localStorage.getItem('autosave-character-1-owner'), 'invalid json');
-  session = null;
-  assert.equal((await api.replayBufferedCharacterSave(1)).reason, 'signed-out');
-  assert.equal(calls.length, 0);
-});
-
 test('logout clears account caches but preserves every account draft', () => {
   api.bufferCharacterSave(character(), 'owner', 'version-1');
   api.bufferCharacterSave(character(), 'gm', 'version-1');
@@ -354,22 +269,6 @@ test('ambiguous lost responses retry reads once and never duplicate mutations', 
   assert.equal(calls.length, 2);
 });
 
-test('a rejected copy survives subsequent editing, successful replay, and remount discovery', async () => {
-  api.bufferCharacterSave(character('Rejected original'), 'owner', 'version-1');
-  invoke = async () => ok({ __conflict: true });
-  assert.equal((await api.replayBufferedCharacterSave(1)).recovery.name, 'Rejected original');
-  api.bufferCharacterSave(character('Latest draft'), 'owner', 'version-2');
-  invoke = async () => ok();
-  const replayed = await api.replayBufferedCharacterSave(1);
-  assert.equal(replayed.status, 'saved');
-  assert.equal(replayed.recovery.name, 'Rejected original');
-  const remounted = await api.replayBufferedCharacterSave(1);
-  assert.equal(remounted.status, 'none');
-  assert.equal(remounted.recovery.name, 'Rejected original');
-  session = signedIn('other-token', 'other');
-  assert.deepEqual(await api.replayBufferedCharacterSave(1), { status: 'none' });
-});
-
 test('a signed-out request is explicitly anonymous even if sign-in races invocation', async () => {
   session = null;
   invoke = async () => {
@@ -378,30 +277,6 @@ test('a signed-out request is explicitly anonymous even if sign-in races invocat
   };
   await api.makeRequest('find-character', { id: 1 });
   assert.equal(calls[0].headers.Authorization, 'Bearer anonymous-project-key');
-});
-
-test('pending calculation input is never replayed without a matching valid base and server version', async () => {
-  for (const options of [
-    { base: { id: 2, name: 'Other character', level: 1 }, expected_updated_at: 'version-1' },
-    { base: { id: 1 }, expected_updated_at: 'version-1' },
-    { base: undefined, expected_updated_at: 'version-1' },
-    { base: { id: 1, name: 'Character', level: 1 }, expected_updated_at: undefined },
-  ]) {
-    localStorage.setItem(
-      'autosave-character-1-owner',
-      JSON.stringify({
-        version: 1,
-        actorId: 'owner',
-        requiresCalculation: true,
-        base: options.base,
-        body: { id: 1, name: 'Retained input', expected_updated_at: options.expected_updated_at },
-      })
-    );
-    const result = await api.replayBufferedCharacterSave(1);
-    assert.equal(result.status, 'retained');
-    assert.equal(result.body.name, 'Retained input');
-    assert.equal(calls.length, 0);
-  }
 });
 
 test('an older acknowledgement cannot discard newly calculation-required input with identical fields', () => {
@@ -420,4 +295,293 @@ test('strict reads distinguish a successful missing record from transport and JS
   await assert.rejects(api.makeRequest('find-language', {}, false, { throwOnFailure: true }), /Request failed/);
   invoke = async () => http(500, { message: 'Unavailable' });
   await assert.rejects(api.makeRequest('find-language', {}, false, { throwOnFailure: true }), /Request failed/);
+});
+
+test('acknowledging one tab cannot advance another tab draft past independent saved HP', () => {
+  const base = { ...character('Original'), hp_current: 20 };
+  const tabA = { ...base, hp_current: 10 };
+  const tabB = { ...base, name: 'Offline rename' };
+  api.bufferCharacterSave(tabB, 'owner', 'version-1', {
+    requiresCalculation: false,
+    base,
+    writerId: 'tab-b',
+  });
+  api.acknowledgeBufferedCharacterSave(1, 'owner', tabA, 'version-1', 'version-2', false, 'tab-a');
+  const retained = api.getBufferedCharacterSave(1, 'owner', 'tab-b');
+  assert.equal(retained.draft.body.expected_updated_at, 'version-1');
+  assert.equal(retained.draft.base.hp_current, 20);
+  assert.equal(retained.draft.body.name, 'Offline rename');
+});
+
+test('two offline tabs retain independent durable copies', () => {
+  for (const writerId of ['tab-a', 'tab-b']) {
+    api.bufferCharacterSave(character(writerId), 'owner', 'version-1', {
+      requiresCalculation: false,
+      base: character('Original'),
+      writerId,
+    });
+  }
+  assert.equal(api.getBufferedCharacterSave(1, 'owner', 'tab-a').draft.body.name, 'tab-a');
+  assert.equal(api.getBufferedCharacterSave(1, 'owner', 'tab-b').draft.body.name, 'tab-b');
+});
+
+test('a same-tab newer intentional revert is rebased onto its acknowledged in-flight save', () => {
+  const base = { ...character('Original'), hp_current: 20 };
+  const submitted = { ...base, hp_current: 10 };
+  api.bufferCharacterSave(base, 'owner', 'version-1', {
+    requiresCalculation: false,
+    base,
+    writerId: 'tab-a',
+  });
+  api.acknowledgeBufferedCharacterSave(1, 'owner', submitted, 'version-1', 'version-2', false, 'tab-a');
+  const retained = api.getBufferedCharacterSave(1, 'owner', 'tab-a');
+  assert.equal(retained.draft.body.hp_current, 20);
+  assert.equal(retained.draft.base.hp_current, 10);
+  assert.equal(retained.draft.body.expected_updated_at, 'version-2');
+});
+
+test('restoration discovers every versioned copy without a network write or destructive claim', () => {
+  for (const writerId of ['tab-a', 'tab-b']) {
+    api.bufferCharacterSave(character(writerId), 'owner', 'version-1', {
+      requiresCalculation: writerId === 'tab-b',
+      base: character('Original'),
+      writerId,
+    });
+  }
+  const before = [...localStorage.data.entries()];
+  const loaded = api.loadBufferedCharacterSaves(1, 'owner');
+  assert.equal(loaded.status, 'loaded');
+  assert.equal(loaded.records.length, 2);
+  assert.deepEqual(loaded.retained, []);
+  assert.deepEqual(
+    loaded.records.map((record) => record.draft.body.name),
+    ['tab-a', 'tab-b']
+  );
+  assert.deepEqual(api.loadBufferedCharacterSaves(1, 'owner'), loaded);
+  assert.deepEqual([...localStorage.data.entries()], before);
+  assert.equal(calls.length, 0);
+});
+
+test('acknowledging a recovered copy preserves a newer edit written by its original tab', () => {
+  const options = { requiresCalculation: false, base: character('Original'), writerId: 'other-tab' };
+  api.bufferCharacterSave(character('Recovered edit'), 'owner', 'version-1', options);
+  const record = api.loadBufferedCharacterSaves(1, 'owner').records[0];
+  api.bufferCharacterSave(character('Newer edit'), 'owner', 'version-1', options);
+  assert.equal(api.acknowledgeBufferedCharacterRecovery(record).status, 'unchanged');
+  assert.equal(api.getBufferedCharacterSave(1, 'owner', 'other-tab').draft.body.name, 'Newer edit');
+  const newer = api.loadBufferedCharacterSaves(1, 'owner').records[0];
+  assert.equal(api.acknowledgeBufferedCharacterRecovery(newer).status, 'removed');
+  assert.deepEqual(api.getBufferedCharacterSave(1, 'owner', 'other-tab'), { status: 'none' });
+});
+
+test('restoration only exposes the requested actor drafts, including campaign editor copies', () => {
+  for (const actor of ['owner', 'gm']) {
+    api.bufferCharacterSave(character(actor), actor, 'version-1', {
+      requiresCalculation: false,
+      base: character('Original'),
+    });
+  }
+  assert.deepEqual(api.loadBufferedCharacterSaves(1, 'other'), { status: 'loaded', records: [], retained: [] });
+  assert.equal(api.loadBufferedCharacterSaves(1, 'gm').records[0].draft.body.name, 'gm');
+  assert.equal(api.loadBufferedCharacterSaves(1, 'owner').records[0].draft.body.name, 'owner');
+  assert.equal(calls.length, 0);
+});
+
+test('legacy bearer-token copies migrate without network access and remain explicit recovery', () => {
+  const token = `header.${Buffer.from(JSON.stringify({ sub: 'owner' })).toString('base64url')}.expired-signature`;
+  localStorage.setItem('autosave-character-1', JSON.stringify({ token, body: { id: 1, name: 'Legacy draft' } }));
+  const foreign = api.loadBufferedCharacterSaves(1, 'gm');
+  assert.deepEqual(foreign, { status: 'loaded', records: [], retained: [] });
+  assert.ok(localStorage.getItem('autosave-character-1').includes(token));
+  const result = api.loadBufferedCharacterSaves(1, 'owner');
+  assert.deepEqual(result.records, []);
+  assert.equal(result.retained[0].reason, 'unversioned');
+  assert.equal(result.retained[0].body.name, 'Legacy draft');
+  assert.equal(localStorage.getItem('autosave-character-1'), null);
+  assert.ok([...localStorage.data.values()].every((raw) => !raw.includes(token)));
+  assert.equal(calls.length, 0);
+});
+
+test('legacy account drafts migrate independently from new page drafts and preserve existing recovery', () => {
+  const legacy = {
+    version: 1,
+    actorId: 'owner',
+    body: { ...character('Old tab draft'), expected_updated_at: 'version-1' },
+    base: character('Original'),
+  };
+  localStorage.setItem('autosave-character-1-owner', JSON.stringify(legacy));
+  localStorage.setItem(
+    'autosave-character-recovery-1-owner',
+    JSON.stringify({
+      ...legacy,
+      body: { ...legacy.body, name: 'Previously rejected copy' },
+    })
+  );
+  api.bufferCharacterSave(character('Current tab draft'), 'owner', 'version-1', {
+    requiresCalculation: false,
+    base: character('Original'),
+  });
+  const result = api.loadBufferedCharacterSaves(1, 'owner');
+  assert.equal(result.records.length, 2);
+  assert.deepEqual(result.records.map((record) => record.draft.body.name).sort(), [
+    'Current tab draft',
+    'Old tab draft',
+  ]);
+  assert.equal(result.retained[0].body.name, 'Previously rejected copy');
+  assert.equal(result.retained[0].reason, 'recovery');
+  assert.equal(localStorage.getItem('autosave-character-1-owner'), null);
+});
+
+test('invalid and incomplete drafts stay available without automatic restoration', () => {
+  const inputs = [
+    { body: { id: 1, name: 'Unversioned' }, base: character('Original') },
+    { body: { id: 1, name: 'Missing base', expected_updated_at: 'version-1' } },
+    { body: { id: 1, name: 'Wrong base', expected_updated_at: 'version-1' }, base: { ...character(), id: 2 } },
+    { body: { id: 1, name: 'Invalid base', expected_updated_at: 'version-1' }, base: { id: 1 } },
+  ];
+  for (const [index, input] of inputs.entries()) {
+    localStorage.setItem(
+      `autosave-character-1-owner:writer:test-${index}`,
+      JSON.stringify({
+        version: 2,
+        actorId: 'owner',
+        writerId: `test-${index}`,
+        requiresCalculation: true,
+        ...input,
+      })
+    );
+  }
+  localStorage.setItem('autosave-character-1-owner:writer:broken', 'invalid json');
+  const result = api.loadBufferedCharacterSaves(1, 'owner');
+  assert.deepEqual(result.records, []);
+  assert.equal(result.retained.length, 5);
+  assert.equal(result.retained.filter((record) => record.body).length, 4);
+  assert.equal(localStorage.length, 5);
+  assert.equal(calls.length, 0);
+});
+
+test('lost-acknowledgement submissions survive newer edits and an intentional return to the original value', () => {
+  const base = { ...character('Original'), hp_current: 20 };
+  const submitted = { ...base, hp_current: 10 };
+  const options = { requiresCalculation: false, base };
+  api.bufferCharacterSave(submitted, 'owner', 'version-1', options);
+  assert.equal(api.journalCharacterSaveSubmission(1, 'owner', submitted, 'version-1').status, 'stored');
+  api.bufferCharacterSave(base, 'owner', 'version-1', options);
+  const record = api.loadBufferedCharacterSaves(1, 'owner').records[0];
+  assert.equal(record.draft.body.hp_current, 20);
+  assert.equal(record.draft.submission.body.hp_current, 10);
+  assert.equal(record.draft.submission.expectedUpdatedAt, 'version-1');
+  assert.ok(!record.raw.includes('current-token'));
+  api.acknowledgeBufferedCharacterSave(1, 'owner', submitted, 'version-1', 'version-2');
+  assert.equal(savedDraft().draft.body.hp_current, 20);
+  assert.equal(savedDraft().draft.base.hp_current, 10);
+  assert.equal(savedDraft().draft.submission, undefined);
+  api.acknowledgeBufferedCharacterSave(1, 'owner', base, 'version-2', 'version-3');
+  assert.deepEqual(savedDraft(), { status: 'none' });
+});
+
+test('a stale acknowledgement never erases a different newer in-flight submission', () => {
+  const base = { ...character('Original'), hp_current: 20 };
+  const submitted = { ...base, hp_current: 10 };
+  api.bufferCharacterSave(base, 'owner', 'version-2', { requiresCalculation: false, base: submitted });
+  api.journalCharacterSaveSubmission(1, 'owner', base, 'version-2');
+  assert.equal(api.acknowledgeBufferedCharacterSave(1, 'owner', base, 'version-1', 'version-2').status, 'unchanged');
+  assert.equal(savedDraft().draft.submission.expectedUpdatedAt, 'version-2');
+});
+
+test('storage quota failures are explicit and preserve the previous durable copy', () => {
+  api.bufferCharacterSave(character('Durable copy'), 'owner', 'version-1');
+  const prior = savedDraft().raw;
+  localStorage.setItem = () => {
+    throw new Error('Quota exceeded');
+  };
+  assert.equal(api.bufferCharacterSave(character('Unsaved copy'), 'owner', 'version-1').status, 'unavailable');
+  assert.equal(savedDraft().raw, prior);
+  assert.equal(api.journalCharacterSaveSubmission(1, 'owner', character(), 'version-1').status, 'unavailable');
+});
+
+test('denied storage reads are explicit instead of pretending there are no unsynced edits', () => {
+  localStorage.getItem = () => {
+    throw new Error('Storage denied');
+  };
+  assert.equal(api.getBufferedCharacterSave(1, 'owner').status, 'unavailable');
+  assert.equal(api.loadBufferedCharacterSaves(1, 'owner').status, 'unavailable');
+  assert.equal(api.bufferCharacterSave(character(), 'owner', 'version-1').status, 'unavailable');
+  assert.equal(
+    api.acknowledgeBufferedCharacterSave(1, 'owner', character(), 'version-1', 'version-2').status,
+    'unavailable'
+  );
+});
+
+test('legacy migration never deletes the only copy when storage is full', () => {
+  const legacy = JSON.stringify({
+    version: 1,
+    actorId: 'owner',
+    body: { ...character(), expected_updated_at: 'version-1' },
+    base: character('Original'),
+  });
+  localStorage.setItem('autosave-character-1-owner', legacy);
+  localStorage.setItem = () => {
+    throw new Error('Quota exceeded');
+  };
+  assert.equal(api.loadBufferedCharacterSaves(1, 'owner').status, 'unavailable');
+  assert.equal(localStorage.getItem('autosave-character-1-owner'), legacy);
+});
+
+test('repeated unversioned edits retain the first and latest copies without filling storage', () => {
+  for (let index = 0; index < 20; index++) api.bufferCharacterSave(character(`Edit ${index}`), 'owner');
+  const result = api.loadBufferedCharacterSaves(1, 'owner');
+  assert.equal(localStorage.length, 2);
+  assert.deepEqual(result.records, []);
+  assert.deepEqual(result.retained.map((record) => record.body.name).sort(), ['Edit 0', 'Edit 19']);
+});
+
+test('atomic reconciliation persists final intent and clears an obsolete journal without altering foreign copies', () => {
+  const base = { ...character('Original'), hp_current: 20 };
+  const submitted = { ...base, hp_current: 10 };
+  const remote = { ...base, name: 'Remote rename', updated_at: 'version-2' };
+  const merged = { ...remote, hp_current: 10 };
+  api.bufferCharacterSave(submitted, 'owner', 'version-1', { requiresCalculation: false, base });
+  api.journalCharacterSaveSubmission(1, 'owner', submitted, 'version-1');
+  api.bufferCharacterSave(character('Other tab'), 'owner', 'version-1', {
+    requiresCalculation: false,
+    base,
+    writerId: 'other-tab',
+  });
+  const foreign = api.getBufferedCharacterSave(1, 'owner', 'other-tab').raw;
+  assert.equal(
+    api.reconcileBufferedCharacterSave(merged, 'owner', remote, { requiresCalculation: false }).status,
+    'stored'
+  );
+  const own = savedDraft().draft;
+  assert.equal(own.body.name, 'Remote rename');
+  assert.equal(own.body.hp_current, 10);
+  assert.equal(own.base.hp_current, 20);
+  assert.equal(own.body.expected_updated_at, 'version-2');
+  assert.equal(own.submission, undefined);
+  assert.equal(api.getBufferedCharacterSave(1, 'owner', 'other-tab').raw, foreign);
+  assert.equal(
+    api
+      .loadBufferedCharacterSaves(1, 'owner')
+      .records.find((record) => record.draft.writerId === api.CHARACTER_SAVE_WRITER_ID).draft.submission,
+    undefined
+  );
+});
+
+test('reconciliation retires an already accepted copy only after required calculation completes', () => {
+  const base = { ...character('Original'), hp_current: 20 };
+  const accepted = { ...base, hp_current: 10, updated_at: 'version-2' };
+  api.bufferCharacterSave(accepted, 'owner', 'version-1', { requiresCalculation: false, base });
+  api.journalCharacterSaveSubmission(1, 'owner', accepted, 'version-1');
+  assert.equal(
+    api.reconcileBufferedCharacterSave(accepted, 'owner', accepted, { requiresCalculation: true }).status,
+    'stored'
+  );
+  assert.equal(savedDraft().draft.requiresCalculation, true);
+  assert.equal(savedDraft().draft.submission, undefined);
+  assert.equal(
+    api.reconcileBufferedCharacterSave(accepted, 'owner', accepted, { requiresCalculation: false }).status,
+    'removed'
+  );
+  assert.deepEqual(savedDraft(), { status: 'none' });
 });

--- a/frontend/scripts/skill-progression.test.mjs
+++ b/frontend/scripts/skill-progression.test.mjs
@@ -1,0 +1,320 @@
+import assert from 'node:assert/strict';
+import { after, before, beforeEach, test } from 'node:test';
+import { createOperationEngine, readContentRows } from './operation-test-harness.mjs';
+
+let engine;
+let fixtures;
+let content;
+const official = (id) => fixtures.find(({ table, row }) => table === 'ability_block' && row.id === id).row;
+const rank = (name) => engine.compileProficiencyType(engine.getVariable('CHARACTER', name).value);
+
+/** Exercise the real class controller and its public normalization boundary with official rows. */
+async function calculate(character, packageContent = content) {
+  const result = await engine._executeCharacterOperations({
+    character,
+    content: packageContent,
+    context: 'CHARACTER-BUILDER',
+  });
+  engine.normalizeProficiencies('CHARACTER');
+  assert.deepEqual(result.errors, []);
+  return result;
+}
+
+/** Persist the same namespaced selection paths used by the builder, including repeated feat occurrences. */
+function chooseFeature(character, featureId, value) {
+  const path = `class-feature-${featureId}_${official(featureId).operations[0].id}`;
+  character.operation_data.selections[path] = `${value}`;
+  return `${path}_${value}`;
+}
+
+function chooseMastery(character, featureId, masteryId, master, expert) {
+  const path = chooseFeature(character, featureId, masteryId);
+  const [masterOperation, expertOperation] = official(masteryId).operations;
+  character.operation_data.selections[`${path}_${masterOperation.id}`] = master;
+  character.operation_data.selections[`${path}_${expertOperation.id}`] = expert;
+}
+
+function fighter(level, trained = ['SKILL_MEDICINE', 'SKILL_ARCANA', 'SKILL_NATURE']) {
+  const character = {
+    id: 1,
+    level,
+    details: { class: fixtures.find(({ table, row }) => table === 'class' && row.id === 20).row },
+    inventory: { items: [] },
+    content_sources: { enabled: [1, 14, 256] },
+    operation_data: { selections: {} },
+  };
+  engine.getClassSkillTrainings('CHARACTER', 3).forEach((operation, index) => {
+    character.operation_data.selections[`class_${operation.id}`] = trained[index];
+  });
+  return character;
+}
+
+before(async () => {
+  engine = await createOperationEngine();
+  fixtures = await readContentRows([
+    { table: 'class', id: 20 },
+    { table: 'trait', id: 1339 },
+    ...[19297, 19298, 19301, 19302, 19379, 19380, 19381, 19385, 31987, 22191, 20544, 33685, 22339].map((id) => ({
+      table: 'ability_block',
+      id,
+    })),
+  ]);
+  content = {
+    abilityBlocks: fixtures.filter(({ table }) => table === 'ability_block').map(({ row }) => row),
+    classes: fixtures.filter(({ table }) => table === 'class').map(({ row }) => row),
+    traits: fixtures.filter(({ table }) => table === 'trait').map(({ row }) => row),
+    ancestries: [],
+    backgrounds: [],
+    languages: [],
+    items: [],
+    spells: [],
+    archetypes: [],
+    versatileHeritages: [],
+    classArchetypes: [],
+    sources: [],
+    defaultSources: { INFO: [1, 14, 256], PAGE: [1, 14, 256] },
+  };
+});
+after(async () => engine?.cleanup());
+beforeEach(() => {
+  engine.resetVariables();
+  engine.setFixtures(fixtures);
+});
+
+test('Medic Dedication plus the level-7 increase reaches master in both official versions', async () => {
+  for (const medicId of [31987, 22191]) {
+    const character = fighter(7);
+    chooseFeature(character, 19297, medicId);
+    chooseFeature(character, 19381, 'SKILL_MEDICINE');
+    await calculate(character);
+    assert.equal(rank('SKILL_MEDICINE'), 'M', official(medicId).name);
+  }
+});
+
+test('Medic Dedication Battle Medicine text agrees with the final master proficiency', async () => {
+  const character = fighter(7);
+  chooseFeature(character, 19297, 31987);
+  chooseFeature(character, 19381, 'SKILL_MEDICINE');
+  await calculate(character);
+  assert.equal(rank('SKILL_MEDICINE'), 'M');
+  const injections = engine.getVariable('CHARACTER', 'INJECT_TEXT').value.map(JSON.parse);
+  const battleMedicine = injections.filter(({ type, id }) => type === 'feat' && id === 19946);
+  assert.equal(battleMedicine.length, 1);
+  assert.match(battleMedicine[0].text, /Once per hour/);
+});
+
+test('an early expert increase is not spent again when Skill Mastery reaches level 15', async () => {
+  for (const masteryId of [20544, 33685, 22339]) {
+    const character = fighter(10);
+    chooseFeature(character, 19379, 'SKILL_MEDICINE');
+    chooseMastery(character, 19301, masteryId, 'SKILL_MEDICINE', 'SKILL_ARCANA');
+    await calculate(character);
+    assert.equal(rank('SKILL_MEDICINE'), 'M', `${official(masteryId).name}, level 10`);
+    assert.equal(rank('SKILL_ARCANA'), 'E');
+
+    character.level = 15;
+    await calculate(character);
+    assert.equal(rank('SKILL_MEDICINE'), 'M', `${official(masteryId).name}, no new Medicine increase`);
+
+    chooseFeature(character, 19385, 'SKILL_MEDICINE');
+    await calculate(character);
+    assert.equal(rank('SKILL_MEDICINE'), 'L', 'an actual level-15 increase still reaches legendary');
+  }
+});
+
+test('Skill Mastery raises a skill trained by an earlier increase to expert, not master', async () => {
+  const character = fighter(10, ['SKILL_MEDICINE', 'SKILL_NATURE', 'SKILL_SOCIETY']);
+  chooseFeature(character, 19297, 22191);
+  chooseFeature(character, 19379, 'SKILL_ARCANA');
+  chooseMastery(character, 19301, 20544, 'SKILL_MEDICINE', 'SKILL_ARCANA');
+  await calculate(character);
+  assert.equal(rank('SKILL_MEDICINE'), 'M');
+  assert.equal(rank('SKILL_ARCANA'), 'E');
+});
+
+test('repeated Skill Mastery selections retain independent choices and recalculate after removal', async () => {
+  const character = fighter(12, ['SKILL_MEDICINE', 'SKILL_ARCANA', 'SKILL_NATURE']);
+  chooseFeature(character, 19297, 22191);
+  chooseMastery(character, 19301, 20544, 'SKILL_MEDICINE', 'SKILL_ARCANA');
+  chooseMastery(character, 19302, 20544, 'SKILL_ARCANA', 'SKILL_NATURE');
+  await calculate(character);
+  assert.deepEqual(['SKILL_MEDICINE', 'SKILL_ARCANA', 'SKILL_NATURE'].map(rank), ['M', 'M', 'E']);
+
+  const secondSelection = `class-feature-19302_${official(19302).operations[0].id}`;
+  for (const path of Object.keys(character.operation_data.selections)) {
+    if (path.startsWith(secondSelection)) delete character.operation_data.selections[path];
+  }
+  await calculate(character);
+  assert.deepEqual(['SKILL_MEDICINE', 'SKILL_ARCANA', 'SKILL_NATURE'].map(rank), ['M', 'E', 'T']);
+});
+
+test('an earlier skill selector shows its historical transition after later feats and level changes', async () => {
+  const character = fighter(15);
+  chooseFeature(character, 19379, 'SKILL_MEDICINE');
+  chooseMastery(character, 19301, 20544, 'SKILL_MEDICINE', 'SKILL_ARCANA');
+  const result = await calculate(character);
+  const earlyIncrease = result.ors.classFeatureResults.find(({ baseSource }) => baseSource.id === 19379);
+  const medicine = earlyIncrease.baseResults[0].selection.options.find(({ variable }) => variable === 'SKILL_MEDICINE');
+  assert.deepEqual(medicine._skill_preview, { from: 'T', to: 'E', limitedByLevel: false });
+  const masteryFeature = result.ors.classFeatureResults.find(({ baseSource }) => baseSource.id === 19301);
+  const masteryMedicine = masteryFeature.baseResults[0].result.results[0].selection.options.find(
+    ({ variable }) => variable === 'SKILL_MEDICINE'
+  );
+  assert.deepEqual(masteryMedicine._skill_preview, { from: 'E', to: 'M', limitedByLevel: false });
+});
+
+test('saved early choices cannot become master merely because the character later reaches level 7', async () => {
+  const character = fighter(7);
+  chooseFeature(character, 19379, 'SKILL_MEDICINE');
+  chooseFeature(character, 19380, 'SKILL_MEDICINE');
+  const result = await calculate(character);
+  assert.equal(rank('SKILL_MEDICINE'), 'E');
+  const unavailableIncrease = result.ors.classFeatureResults.find(({ baseSource }) => baseSource.id === 19380);
+  const medicine = unavailableIncrease.baseResults[0].selection.options.find(
+    ({ variable }) => variable === 'SKILL_MEDICINE'
+  );
+  assert.deepEqual(medicine._skill_preview, { from: 'E', to: 'E', limitedByLevel: true });
+  chooseFeature(character, 19381, 'SKILL_MEDICINE');
+  await calculate(character);
+  assert.equal(rank('SKILL_MEDICINE'), 'M');
+});
+
+test('removing a later rank grant reconstructs only the still-owned increases', async () => {
+  const track = { path: 'progression', node: { value: null, children: {} } };
+  const increase = { id: 'increase', type: 'adjValue', data: { variable: 'SKILL_MEDICINE', value: { value: '1' } } };
+  const training = { id: 'training', type: 'adjValue', data: { variable: 'SKILL_MEDICINE', value: { value: 'T' } } };
+  const give = { id: 'medic', type: 'giveAbilityBlock', data: { type: 'feat', abilityBlockId: 22191 } };
+  const remove = { id: 'remove', type: 'removeAbilityBlock', data: { type: 'feat', abilityBlockId: 22191 } };
+  engine.setVariable('CHARACTER', 'LEVEL', 15);
+  await engine.runOperations('CHARACTER', track, [training], { sourceLevel: 1 });
+  await engine.runOperations('CHARACTER', track, [give], { sourceLevel: 2 });
+  await engine.runOperations('CHARACTER', track, [increase], { sourceLevel: 7 });
+  assert.equal(rank('SKILL_MEDICINE'), 'M');
+  await engine.runOperations('CHARACTER', track, [remove], { sourceLevel: 10 });
+  assert.equal(rank('SKILL_MEDICINE'), 'E');
+  await engine.runOperations('CHARACTER', track, [give], { sourceLevel: 12 });
+  assert.equal(rank('SKILL_MEDICINE'), 'E', 're-acquiring expert does not spend the level-7 increase twice');
+  await engine.runOperations('CHARACTER', track, [{ ...increase, id: 'later-increase' }], { sourceLevel: 15 });
+  assert.equal(rank('SKILL_MEDICINE'), 'M');
+});
+
+test('repeated full rebuilds preserve the same ranks, previews, and selected occurrence count', async () => {
+  const character = fighter(15);
+  chooseFeature(character, 19379, 'SKILL_MEDICINE');
+  chooseMastery(character, 19301, 20544, 'SKILL_MEDICINE', 'SKILL_ARCANA');
+  chooseMastery(character, 19302, 20544, 'SKILL_ARCANA', 'SKILL_NATURE');
+  const first = await calculate(character);
+  for (let index = 0; index < 10; index++) {
+    const next = await calculate(character);
+    assert.deepEqual(next.ors, first.ors);
+    assert.deepEqual(['SKILL_MEDICINE', 'SKILL_ARCANA', 'SKILL_NATURE'].map(rank), ['M', 'M', 'E']);
+  }
+});
+
+test('explicit grants above the normal cap and penalties retain their intended effects', async () => {
+  const track = { path: 'exception', node: { value: null, children: {} } };
+  engine.setVariable('CHARACTER', 'LEVEL', 1);
+  await engine.runOperations('CHARACTER', track, [
+    { id: 'exceptional-grant', type: 'adjValue', data: { variable: 'SKILL_MEDICINE', value: { value: 'M' } } },
+    { id: 'bounded-increase', type: 'adjValue', data: { variable: 'SKILL_MEDICINE', value: { value: '1' } } },
+  ]);
+  assert.equal(rank('SKILL_MEDICINE'), 'M');
+  await engine.runOperations('CHARACTER', track, [
+    { id: 'penalty', type: 'adjValue', data: { variable: 'SKILL_MEDICINE', value: { value: '-1' } } },
+  ]);
+  assert.equal(rank('SKILL_MEDICINE'), 'E');
+});
+
+test('creature skill choices use their own level and lore variables, never their owner store', async () => {
+  engine.setVariable('CHARACTER', 'LEVEL', 1);
+  engine.addVariable('CHARACTER', 'prof', 'SKILL_LORE_OWNER_ONLY', { value: 'T', attribute: 'ATTRIBUTE_INT' });
+  const choice = official(19381).operations[0];
+  const creature = {
+    id: 2,
+    name: 'Progression fixture',
+    level: 7,
+    abilities_base: [],
+    abilities_added: [],
+    operations: [
+      { id: 'expert', type: 'adjValue', data: { variable: 'SKILL_MEDICINE', value: { value: 'E' } } },
+      {
+        id: 'own-lore',
+        type: 'createValue',
+        data: { variable: 'SKILL_LORE_CREATURE_ONLY', type: 'prof', value: { value: 'T', attribute: 'ATTRIBUTE_INT' } },
+      },
+      choice,
+    ],
+    operation_data: { selections: { [`creature_${choice.id}`]: 'SKILL_MEDICINE' } },
+  };
+  const result = await engine._executeCreatureOperations({
+    id: 'creature-fixture',
+    creature,
+    content,
+    charStore: engine.exportVariableStore('CHARACTER'),
+  });
+  assert.equal(engine.compileProficiencyType(result.store.variables.SKILL_MEDICINE.value), 'M');
+  const choices = result.ors.creatureResults.find((entry) => entry?.selection?.id === choice.id).selection.options;
+  assert.ok(choices.some(({ variable }) => variable === 'SKILL_LORE_CREATURE_ONLY'));
+  assert.ok(!choices.some(({ variable }) => variable === 'SKILL_LORE_OWNER_ONLY'));
+  assert.deepEqual(choices.find(({ variable }) => variable === 'SKILL_MEDICINE')._skill_preview, {
+    from: 'E',
+    to: 'M',
+    limitedByLevel: false,
+  });
+  assert.equal(engine.getVariable('CHARACTER', 'SKILL_MEDICINE').value.value, 'U');
+});
+
+test('full skill progression crosses the public calculation boundary without losing previews', async () => {
+  const character = fighter(15);
+  chooseFeature(character, 19379, 'SKILL_MEDICINE');
+  chooseMastery(character, 19301, 20544, 'SKILL_MEDICINE', 'SKILL_ARCANA');
+  const results = await engine.executeOperations(
+    { type: 'CHARACTER', data: { character, content, context: 'CHARACTER-BUILDER' } },
+    { directExecution: true }
+  );
+  assert.equal(rank('SKILL_MEDICINE'), 'M');
+  assert.ok(!JSON.stringify(results).includes('_skill_context'));
+  assert.ok(!JSON.stringify(engine.exportVariableStore('CHARACTER')).includes('skillContexts'));
+  const earlyIncrease = results.classFeatureResults.find(({ baseSource }) => baseSource.id === 19379);
+  assert.deepEqual(
+    earlyIncrease.baseResults[0].selection.options.find(({ variable }) => variable === 'SKILL_MEDICINE')._skill_preview,
+    { from: 'T', to: 'E', limitedByLevel: false }
+  );
+});
+
+test('root content with level-gated increases uses the activation level, preserving custom progression', async () => {
+  const increaseAt = (level) => ({
+    id: `at-${level}`,
+    type: 'conditional',
+    data: {
+      conditions: [{ id: `level-${level}`, name: 'LEVEL', operator: 'GREATER_THAN_OR_EQUALS', value: level }],
+      trueOperations: [
+        { id: `increase-${level}`, type: 'adjValue', data: { variable: 'SKILL_MEDICINE', value: { value: '1' } } },
+      ],
+      falseOperations: [],
+    },
+  });
+  const packageContent = {
+    ...content,
+    sources: [
+      {
+        id: 999,
+        name: 'Custom progression',
+        operations: [
+          { id: 'training', type: 'adjValue', data: { variable: 'SKILL_MEDICINE', value: { value: 'E' } } },
+          increaseAt(7),
+          increaseAt(15),
+        ],
+      },
+    ],
+  };
+  for (const [level, expected] of [
+    [6, 'E'],
+    [7, 'M'],
+    [14, 'M'],
+    [15, 'L'],
+  ]) {
+    await calculate(fighter(level), packageContent);
+    assert.equal(rank('SKILL_MEDICINE'), expected, `level ${level}`);
+  }
+});

--- a/frontend/src/common/CharacterLoadError.tsx
+++ b/frontend/src/common/CharacterLoadError.tsx
@@ -1,0 +1,17 @@
+import { Alert, Button, Center, Stack } from '@mantine/core';
+
+/** A failed connection must not turn a character route into an unauthorized page. */
+export function CharacterLoadError({ onRetry }: { onRetry: () => void }) {
+  return (
+    <Center py='xl' px='sm'>
+      <Alert color='yellow' title='Could not load character'>
+        <Stack gap='xs'>
+          Check your connection and try again.
+          <Button variant='light' onClick={onRetry}>
+            Retry loading
+          </Button>
+        </Stack>
+      </Alert>
+    </Center>
+  );
+}

--- a/frontend/src/common/CharacterSaveStatus.tsx
+++ b/frontend/src/common/CharacterSaveStatus.tsx
@@ -1,0 +1,47 @@
+import { Button, Group, Text } from '@mantine/core';
+
+export type CharacterSaveState = 'saved' | 'pending' | 'saving' | 'failed' | 'offline' | 'conflict' | 'read-only';
+
+/** Distinguish server confirmation from a local draft throughout every character editor. */
+export function CharacterSaveStatus({
+  state,
+  draftStored,
+  onRetry,
+}: {
+  state: CharacterSaveState;
+  draftStored: boolean;
+  onRetry: () => void;
+}) {
+  const message =
+    state === 'saved'
+      ? 'Saved'
+      : state === 'read-only'
+        ? 'View only'
+        : state === 'conflict'
+          ? 'Saving paused: resolve conflicting edits'
+          : !draftStored
+            ? 'Not saved: keep this page open'
+            : state === 'failed'
+              ? 'Not synced: retrying automatically'
+              : state === 'offline'
+                ? 'Offline: changes kept on this device'
+                : state === 'saving'
+                  ? 'Saving…'
+                  : 'Changes waiting to save';
+  return (
+    <Group gap='xs' justify='flex-end' px='xs' py='xs' w='100%' data-testid='character-save-status'>
+      <Text
+        size='xs'
+        c={state === 'failed' || state === 'conflict' || !draftStored ? 'orange' : 'dimmed'}
+        role='status'
+      >
+        {message}
+      </Text>
+      {(state === 'failed' || state === 'offline') && (
+        <Button size='compact-xs' variant='subtle' onClick={onRetry}>
+          Retry now
+        </Button>
+      )}
+    </Group>
+  );
+}

--- a/frontend/src/common/select/SelectContent.tsx
+++ b/frontend/src/common/select/SelectContent.tsx
@@ -58,6 +58,7 @@ import { hasArchetypeClassFeatTraits, hasTraitType } from '@utils/traits';
 import { getStatBlockDisplay, getStatDisplay } from '@variables/initial-stats-display';
 import { meetsPrerequisites } from '@variables/prereq-detection';
 import { getFinalProfValue } from '@variables/variable-helpers';
+import { previewSkillAdjustment, SkillSelectionPreviewSchema } from '@variables/skill-progression';
 import {
   getAllAncestryTraitVariables,
   getAllArchetypeTraitVariables,
@@ -1382,6 +1383,7 @@ interface GenericAbilityBlock extends AbilityBlock {
   _custom_select?: GenericData;
   _is_core?: boolean;
   _source_level?: number;
+  _skill_preview?: unknown;
 }
 export function GenericSelectionOption(props: {
   option: GenericAbilityBlock;
@@ -1493,14 +1495,16 @@ export function GenericSelectionOption(props: {
           : props.skillAdjustment;
   }
 
-  let limitedByLevel = false;
-  if (props.skillAdjustment === '1') {
-    if (nextProf && nextProf === 'M' && (props.option._source_level ?? 1) < 7) {
-      limitedByLevel = true;
-    } else if (nextProf && nextProf === 'L' && (props.option._source_level ?? 1) < 15) {
-      limitedByLevel = true;
-    }
+  // The engine knows the rank at this occurrence; later feats must not rewrite an earlier choice's preview.
+  const calculatedPreview = SkillSelectionPreviewSchema.safeParse(props.option._skill_preview);
+  if (calculatedPreview.success) {
+    currentProf = calculatedPreview.data.from;
+    nextProf = calculatedPreview.data.to;
   }
+  const limitedByLevel = calculatedPreview.success
+    ? calculatedPreview.data.limitedByLevel
+    : props.skillAdjustment === '1' &&
+      previewSkillAdjustment(currentProf ?? 'U', '1', props.option._source_level ?? 1).limitedByLevel;
 
   let alreadyProficient =
     !props.selected &&
@@ -1510,6 +1514,9 @@ export function GenericSelectionOption(props: {
         maxProficiencyType(currentProf ?? 'U', props.skillAdjustment) === currentProf));
 
   if (nextProf === null) {
+    alreadyProficient = true;
+  }
+  if (calculatedPreview.success && !props.selected && calculatedPreview.data.from === calculatedPreview.data.to) {
     alreadyProficient = true;
   }
 

--- a/frontend/src/pages/character_builder/CharBuilderCreation.tsx
+++ b/frontend/src/pages/character_builder/CharBuilderCreation.tsx
@@ -1,3 +1,5 @@
+import { CharacterSaveStatus } from '@common/CharacterSaveStatus';
+import { CharacterLoadError } from '@common/CharacterLoadError';
 import D20Loader from '@assets/images/D20Loader';
 import { characterState } from '@atoms/characterAtoms';
 import { drawerState } from '@atoms/navAtoms';
@@ -178,17 +180,28 @@ export function CharBuilderCreationInner(props: {
 
   const [levelItemValue, setLevelItemValue] = useState<string | null>(null);
 
-  const { character, setCharacter, results, operationError, isCalculating, retryOperations } = useCharacter(
-    props.characterId,
-    {
-      type: 'EXECUTE_OPS',
-      data: {
-        content: props.content,
-        context: 'CHARACTER-BUILDER',
-        onFinishLoading: props.onFinishLoading,
-      },
-    }
-  );
+  const {
+    character,
+    setCharacter,
+    results,
+    operationError,
+    isCalculating,
+    retryOperations,
+    saveState,
+    draftStored,
+    retrySave,
+    loadError,
+    retryLoad,
+  } = useCharacter(props.characterId, {
+    type: 'EXECUTE_OPS',
+    data: {
+      content: props.content,
+      context: 'CHARACTER-BUILDER',
+      onFinishLoading: props.onFinishLoading,
+    },
+  });
+
+  if (loadError) return <CharacterLoadError onRetry={retryLoad} />;
 
   if (operationError) return <OperationError loading={isCalculating} onRetry={retryOperations} />;
 
@@ -206,6 +219,7 @@ export function CharBuilderCreationInner(props: {
 
   return (
     <Group gap={0} px={isMobile ? undefined : 'sm'}>
+      <CharacterSaveStatus state={saveState} draftStored={draftStored} onRetry={retrySave} />
       {isMobile ? (
         <Drawer
           opened={statPanelOpened}

--- a/frontend/src/pages/character_builder/CharBuilderHome.tsx
+++ b/frontend/src/pages/character_builder/CharBuilderHome.tsx
@@ -1,3 +1,5 @@
+import { CharacterSaveStatus } from '@common/CharacterSaveStatus';
+import { CharacterLoadError } from '@common/CharacterLoadError';
 import { generateNames } from '@ai/fantasygen-dev/name-controller';
 import { GroupLinkSwitch, LinkSwitch, LinksGroup } from '@common/LinksGroup';
 import {
@@ -98,9 +100,12 @@ export default function CharBuilderHome(props: { characterId: number; pageHeight
   const queryClient = useQueryClient();
   const [_drawer, openDrawer] = useAtom(drawerState);
 
-  const { character, setCharacter, isLoading } = useCharacter(props.characterId, {
-    type: 'SIMPLE',
-  });
+  const { character, setCharacter, isLoading, saveState, draftStored, retrySave, loadError, retryLoad } = useCharacter(
+    props.characterId,
+    {
+      type: 'SIMPLE',
+    }
+  );
 
   const [loadingGenerateName, setLoadingGenerateName] = useState(false);
   const [displayNameInput, refreshNameInput] = useRefresh();
@@ -1306,6 +1311,8 @@ export default function CharBuilderHome(props: { characterId: number; pageHeight
 
   // The route's cached character may render before the save hook finishes loading
   // its authoritative version. Keep inputs closed until that save context is ready.
+  if (loadError) return <CharacterLoadError onRetry={retryLoad} />;
+
   if (isLoading)
     return (
       <Center h={300}>
@@ -1315,6 +1322,7 @@ export default function CharBuilderHome(props: { characterId: number; pageHeight
 
   return (
     <Stack gap={topGap}>
+      <CharacterSaveStatus state={saveState} draftStored={draftStored} onRetry={retrySave} />
       <Group justify='center' ref={ref} wrap='nowrap'>
         <Stack>
           <Box>

--- a/frontend/src/pages/character_sheet/CharacterSheetPage.tsx
+++ b/frontend/src/pages/character_sheet/CharacterSheetPage.tsx
@@ -1,3 +1,5 @@
+import { CharacterSaveStatus } from '@common/CharacterSaveStatus';
+import { CharacterLoadError } from '@common/CharacterLoadError';
 import D20Loader from '@assets/images/D20Loader';
 import { glassStyle } from '@utils/colors';
 import BlurBox from '@common/BlurBox';
@@ -217,17 +219,26 @@ function CharacterSheetInner(props: { content: ContentPackage; characterId: numb
 
   // EXECUTE_OPS triggers the character's operation pipeline and calls
   // onFinishLoading when it completes, which dismisses the loading screen.
-  const { character, setCharacter, isLoading, operationError, isCalculating, retryOperations } = useCharacter(
-    props.characterId,
-    {
-      type: 'EXECUTE_OPS',
-      data: {
-        content: props.content,
-        context: 'CHARACTER-SHEET',
-        onFinishLoading: props.onFinishLoading,
-      },
-    }
-  );
+  const {
+    character,
+    setCharacter,
+    isLoading,
+    operationError,
+    isCalculating,
+    retryOperations,
+    saveState,
+    draftStored,
+    retrySave,
+    loadError,
+    retryLoad,
+  } = useCharacter(props.characterId, {
+    type: 'EXECUTE_OPS',
+    data: {
+      content: props.content,
+      context: 'CHARACTER-SHEET',
+      onFinishLoading: props.onFinishLoading,
+    },
+  });
 
   setPageTitle(character && character.name.trim() ? character.name : 'Sheet');
 
@@ -249,11 +260,14 @@ function CharacterSheetInner(props: { content: ContentPackage; characterId: numb
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [character, isLoading, props.content]);
 
+  if (loadError) return <CharacterLoadError onRetry={retryLoad} />;
+
   if (operationError) return <OperationError loading={isCalculating} onRetry={retryOperations} />;
 
   return (
     <Center>
       <Box maw={1000} w='100%' pb={isPhone ? 100 : 'sm'}>
+        <CharacterSaveStatus state={saveState} draftStored={draftStored} onRetry={retrySave} />
         <Box ref={ref}>
           <Stack gap='xs' style={{ position: 'relative' }}>
             {/* Top stat sections: layout collapses from 3 → 2 → 1 columns on smaller screens */}

--- a/frontend/src/process/operations/operation-controller.ts
+++ b/frontend/src/process/operations/operation-controller.ts
@@ -33,8 +33,16 @@ import {
   importVariableStore,
   resetVariables,
   setVariable,
+  getSkillSelectionPreview,
 } from '@variables/variable-manager';
-import { isAttributeValue, labelToVariable, variableToLabel } from '@variables/variable-utils';
+import {
+  isAttributeValue,
+  isExtendedProficiencyType,
+  isProficiencyType,
+  labelToVariable,
+  variableToLabel,
+} from '@variables/variable-utils';
+import { SkillEffectContextSchema } from '@variables/skill-progression';
 import { hashData, rankNumber } from '@utils/numbers';
 import { StoreID, VariableListStr, VariableStore } from '@schemas/variables';
 import {
@@ -90,6 +98,7 @@ function defineSelectionTree(entity: LivingEntity) {
  * @param operations - Array of operations to execute
  * @param options - Operation options
  * @param sourceLabel - Label for the source (for logging/debugging)
+ * @param sourceLevel - Level when this source's choices are earned; nested selections inherit it.
  * @returns - Array of operation results
  */
 async function _executeOps(
@@ -98,7 +107,8 @@ async function _executeOps(
   operations: Operation[],
   options?: OperationOptions,
   sourceLabel?: string,
-  grantedContent?: { id: number; name: string; prefix?: string }
+  grantedContent?: { id: number; name: string; prefix?: string },
+  sourceLevel = 1
 ) {
   const execute = async (): Promise<OperationResult[]> => {
     const selectionNode = getRootSelection().children[primarySource];
@@ -106,7 +116,7 @@ async function _executeOps(
       varId,
       { path: `${primarySource}_${selectionNode?.value}`, node: selectionNode },
       operations,
-      cloneDeep(options),
+      { ...cloneDeep(options), sourceLevel },
       sourceLabel
     );
     if (grantedContent?.prefix && areVariableEffectScopesActive(getVariableEffectScopes(varId))) {
@@ -797,7 +807,9 @@ async function executeCharacterOperations(
       'character',
       character.options?.custom_operations ? (character.custom_operations ?? []) : [],
       options,
-      'Custom'
+      'Custom',
+      undefined,
+      character.level
     );
 
     let classResults: OperationResult[] = [];
@@ -910,7 +922,9 @@ async function executeCharacterOperations(
             `ancestry-section-${section.id}`,
             section.operations ?? [],
             options,
-            `${section.name} (Lvl. ${section.level})`
+            `${section.name} (Lvl. ${section.level})`,
+            undefined,
+            section.level ?? 1
           );
 
           ancestrySectionResults.push({
@@ -933,7 +947,8 @@ async function executeCharacterOperations(
           feature.operations ?? [],
           options,
           `${feature.name} (Lvl. ${feature.level})`,
-          { id: feature.id, name: feature.name, prefix: 'CLASS_FEATURE' }
+          { id: feature.id, name: feature.name, prefix: 'CLASS_FEATURE' },
+          feature.level ?? 1
         );
 
         classFeatureResults.push({
@@ -963,7 +978,9 @@ async function executeCharacterOperations(
         `item-${invItem.item.id}`,
         getItemOperations(invItem.item, content),
         options,
-        invItem.item.name
+        invItem.item.name,
+        undefined,
+        character.level
       );
 
       if (results.length > 0) {
@@ -983,7 +1000,8 @@ async function executeCharacterOperations(
         mode.operations ?? [],
         options,
         `${mode.name} Mode`,
-        { id: mode.id, name: mode.name }
+        { id: mode.id, name: mode.name },
+        character.level
       );
 
       if (results.length > 0) {
@@ -1042,11 +1060,46 @@ async function executeCharacterOperations(
   setEidolonRunesInStore(character);
   setCalculatedStatsInStore('CHARACTER', character);
 
+  const mergedResults = mergeOperationResults(results, conditionalResults) as typeof results;
+  for (const group of [
+    mergedResults.characterResults,
+    mergedResults.classResults,
+    mergedResults.class2Results,
+    mergedResults.ancestryResults,
+    mergedResults.backgroundResults,
+    ...mergedResults.contentSourceResults.map(({ baseResults }) => baseResults),
+    ...mergedResults.classFeatureResults.map(({ baseResults }) => baseResults),
+    ...mergedResults.ancestrySectionResults.map(({ baseResults }) => baseResults),
+    ...mergedResults.itemResults.map(({ baseResults }) => baseResults),
+    ...mergedResults.modeResults.map(({ baseResults }) => baseResults),
+  ]) {
+    addSkillSelectionPreviews('CHARACTER', group);
+  }
   return {
     store: exportVariableStore('CHARACTER'),
-    ors: mergeOperationResults(results, conditionalResults) as typeof results,
+    ors: mergedResults,
     errors,
   };
+}
+
+/** Export only computed choice previews after grants from every pass are available. */
+function addSkillSelectionPreviews(id: StoreID, results: OperationResult[]): void {
+  for (const result of results) {
+    for (const option of result?.selection?.options ?? []) {
+      const context = SkillEffectContextSchema.safeParse(option._skill_context);
+      const adjustment: unknown = option.value?.value;
+      if (
+        context.success &&
+        typeof option.variable === 'string' &&
+        (isProficiencyType(adjustment) || (typeof adjustment === 'string' && isExtendedProficiencyType(adjustment)))
+      ) {
+        option._skill_preview = getSkillSelectionPreview(id, option.variable, adjustment, context.data);
+      }
+      delete option._skill_context;
+    }
+    if (result?.result?.source) delete result.result.source._skill_context;
+    if (result?.result?.results) addSkillSelectionPreviews(id, result.result.results);
+  }
 }
 
 export async function _executeCreatureOperations(data: {
@@ -1096,18 +1149,30 @@ async function executeCreatureOperations(
   ];
 
   const operationsPassthrough = async (options?: OperationOptions) => {
-    let creatureResults = await _executeOps(id, 'creature', creature.operations ?? [], options, creature.name);
+    let creatureResults = await _executeOps(
+      id,
+      'creature',
+      creature.operations ?? [],
+      options,
+      creature.name,
+      undefined,
+      getEntityLevel(creature)
+    );
 
     let abilityResults: {
       baseSource: AbilityBlock;
       baseResults: OperationResult[];
     }[] = [];
     for (const ability of abilities) {
-      const results = await _executeOps(id, `ability-${ability.id}`, ability.operations ?? [], options, ability.name, {
-        id: ability.id,
-        name: ability.name,
-        prefix: 'FEAT',
-      });
+      const results = await _executeOps(
+        id,
+        `ability-${ability.id}`,
+        ability.operations ?? [],
+        options,
+        ability.name,
+        { id: ability.id, name: ability.name, prefix: 'FEAT' },
+        getEntityLevel(creature)
+      );
 
       abilityResults.push({
         baseSource: ability,
@@ -1135,7 +1200,9 @@ async function executeCreatureOperations(
         `item-${invItem.item.id}`,
         getItemOperations(invItem.item, content),
         options,
-        invItem.item.name
+        invItem.item.name,
+        undefined,
+        getEntityLevel(creature)
       );
 
       if (results.length > 0) {
@@ -1182,9 +1249,16 @@ async function executeCreatureOperations(
   // Set calculated stats
   setCalculatedStatsInStore(id, creature);
 
+  const mergedResults = mergeOperationResults(results, conditionalResults) as typeof results;
+  for (const group of [
+    mergedResults.creatureResults,
+    ...mergedResults.abilityResults.map(({ baseResults }) => baseResults),
+    ...mergedResults.itemResults.map(({ baseResults }) => baseResults),
+  ])
+    addSkillSelectionPreviews(id, group);
   return {
     store: exportVariableStore(id),
-    ors: mergeOperationResults(results, conditionalResults) as typeof results,
+    ors: mergedResults,
     errors,
   };
 }

--- a/frontend/src/process/operations/operation-runner.ts
+++ b/frontend/src/process/operations/operation-runner.ts
@@ -41,6 +41,8 @@ import {
   areVariableEffectScopesActive,
   withVariableEffectScope,
   withVariableEffectScopes,
+  withSkillEffectContext,
+  getSkillEffectContext,
   removeVariableEffects,
   filterVariableList,
   VariableEffectScope,
@@ -245,11 +247,27 @@ export async function runOperations(
   const results: OperationResult[] = [];
   traversal.depth++;
   try {
-    for (const operation of operations) {
+    const orderedOperations = operations.map((operation, index) => ({ operation, index }));
+    if (options?.doOnlyConditionals || options?.doConditionals) {
+      // Resolve self-guarded rank grants before sibling effects that read the granted proficiency.
+      orderedOperations.sort(
+        (left, right) =>
+          Number(getSelfGrantProficiencyVariables(right.operation).size > 0) -
+          Number(getSelfGrantProficiencyVariables(left.operation).size > 0)
+      );
+    }
+    for (const { operation, index } of orderedOperations) {
       if (!areVariableEffectScopesActive(getVariableEffectScopes(varId))) break;
       if (++traversal.work > MAX_OPERATION_WORK)
         throw new Error('Content operations exceed the execution work limit (100000).');
-      results.push(await runOp(operation));
+      const scope = getVariableEffectScopes(varId).at(-1);
+      const occurrence = scope ? `${scope.key}@${scope.revision}` : 'root';
+      results[index] = await withSkillEffectContext(
+        varId,
+        `${occurrence}/${selectionTrack.path}/${operation.id}`,
+        options?.sourceLevel ?? getVariable<VariableNum>(varId, 'LEVEL')?.value ?? 1,
+        () => runOp(operation)
+      );
     }
     return results;
   } finally {
@@ -267,10 +285,10 @@ async function runSelect(
   let optionList: ObjectWithUUID[] = [];
 
   if (operation.data.modeType === 'FILTERED' && operation.data.optionsFilters) {
-    optionList = await determineFilteredSelectionList('CHARACTER', operation.id, operation.data.optionsFilters);
+    optionList = await determineFilteredSelectionList(varId, operation.id, operation.data.optionsFilters);
   } else if (operation.data.modeType === 'PREDEFINED' && operation.data.optionsPredefined) {
     optionList = await determinePredefinedSelectionList(
-      'CHARACTER',
+      varId,
       operation.id,
       operation.data.optionType,
       operation.data.optionsPredefined
@@ -284,7 +302,7 @@ async function runSelect(
   let foundSkills: string[] = [];
   for (const option of optionList) {
     if (option.variable) {
-      const variable = getVariable('CHARACTER', option.variable);
+      const variable = getVariable(varId, option.variable);
       if (variable?.type === 'prof' && variable.name.startsWith('SKILL_')) {
         foundSkills.push(variable.name);
       }
@@ -292,6 +310,10 @@ async function runSelect(
   }
   const skillAdjustment =
     optionList.length > 0 && foundSkills.length === optionList.length ? optionList[0]?.value?.value : undefined;
+  const skillContext = getSkillEffectContext(varId);
+  if (skillAdjustment && skillContext) {
+    optionList = optionList.map((option) => ({ ...option, _skill_context: skillContext }));
+  }
 
   // Find selected option
   if (selectionTrack.node && selectionTrack.node.value) {
@@ -1082,6 +1104,22 @@ async function runRemoveSpell(
   return null;
 }
 
+/** Identify only conditional guards that grant a rank to the proficiency they check. */
+function getSelfGrantProficiencyVariables(operation: Operation): Set<string> {
+  if (operation.type !== 'conditional') return new Set();
+  const checked = new Set((operation.data.conditions ?? []).map((condition) => condition.name));
+  return new Set(
+    [...(operation.data.trueOperations ?? []), ...(operation.data.falseOperations ?? [])]
+      .filter(
+        (op): op is OperationAdjValue =>
+          op.type === 'adjValue' &&
+          checked.has(op.data.variable) &&
+          isProficiencyType((op.data.value as { value?: unknown })?.value)
+      )
+      .map((op) => op.data.variable)
+  );
+}
+
 async function runConditional(
   varId: StoreID,
   selectionTrack: SelectionTrack,
@@ -1097,14 +1135,7 @@ async function runConditional(
   // fires and the increase is consumed reaching the rank the grant should have provided
   // (Medic Dedication at trained + a level-7 increase compiled to expert, not master).
   // Threshold conditions that gate anything else keep the increase-inclusive read below.
-  const selfGrantProfVars = new Set(
-    [...(operation.data.trueOperations ?? []), ...(operation.data.falseOperations ?? [])]
-      .filter(
-        (op): op is OperationAdjValue =>
-          op.type === 'adjValue' && isProficiencyType((op.data.value as { value?: unknown })?.value)
-      )
-      .map((op) => op.data.variable)
-  );
+  const selfGrantProfVars = getSelfGrantProficiencyVariables(operation);
 
   const makeCheck = (check: ConditionCheckData) => {
     let variable = getVariable(varId, check.name);
@@ -1239,6 +1270,23 @@ async function runConditional(
     }
   }
 
+  // A level-gated root/class/ancestry operation is earned when its gate opens, not at the root's level 1.
+  const levelGates = (operation.data.conditions ?? []).filter((check) => check.name === 'LEVEL');
+  let sourceLevel = options?.sourceLevel ?? getVariable<VariableNum>(varId, 'LEVEL')?.value ?? 1;
+  for (const check of levelGates) {
+    const threshold = Number(check.value);
+    if (!Number.isFinite(threshold)) continue;
+    if (isTrue && (check.operator === 'GREATER_THAN_OR_EQUALS' || check.operator === 'EQUALS')) {
+      sourceLevel = Math.max(sourceLevel, Math.ceil(threshold));
+    } else if (isTrue && check.operator === 'GREATER_THAN') {
+      sourceLevel = Math.max(sourceLevel, Math.floor(threshold) + 1);
+    } else if (!isTrue && operation.data.conditions?.length === 1) {
+      // With multiple conditions, a false result does not identify which condition failed.
+      if (check.operator === 'LESS_THAN') sourceLevel = Math.max(sourceLevel, Math.ceil(threshold));
+      if (check.operator === 'LESS_THAN_OR_EQUALS') sourceLevel = Math.max(sourceLevel, Math.floor(threshold) + 1);
+    }
+  }
+
   let results: OperationResult[] = [];
   if (isTrue) {
     results = await runOperations(
@@ -1247,6 +1295,7 @@ async function runConditional(
       operation.data.trueOperations ?? [],
       {
         ...options,
+        sourceLevel,
         doOnlyConditionals: false,
         doConditionals: true,
       },
@@ -1259,6 +1308,7 @@ async function runConditional(
       operation.data.falseOperations ?? [],
       {
         ...options,
+        sourceLevel,
         doOnlyConditionals: false,
         doConditionals: true,
       },

--- a/frontend/src/process/variables/skill-progression.ts
+++ b/frontend/src/process/variables/skill-progression.ts
@@ -1,0 +1,76 @@
+import { ExtendedProficiencyType, ProficiencyType, ProficiencyTypeSchema, ProficiencyValue } from '@schemas/variables';
+import { z } from 'zod';
+
+const RANKS: readonly ProficiencyType[] = ['U', 'T', 'E', 'M', 'L'];
+
+export const SkillEffectContextSchema = z.object({ key: z.string(), level: z.number(), order: z.number() });
+export type SkillEffectContext = z.infer<typeof SkillEffectContextSchema>;
+export type SkillAdjustment = {
+  context: SkillEffectContext;
+  value: ExtendedProficiencyType;
+  attribute?: string;
+  assignment?: boolean;
+};
+export const SkillSelectionPreviewSchema = z.object({
+  from: ProficiencyTypeSchema,
+  to: ProficiencyTypeSchema,
+  limitedByLevel: z.boolean(),
+});
+export type SkillSelectionPreview = z.infer<typeof SkillSelectionPreviewSchema>;
+
+/** A spent skill increase is limited by the level when it was earned. Rank grants may exceed this cap. */
+export function getSkillIncreaseCap(level: number): ProficiencyType {
+  return level >= 15 ? 'L' : level >= 7 ? 'M' : 'E';
+}
+
+/** Calculate both the applied rank and the selector preview from one transition rule. */
+export function previewSkillAdjustment(
+  from: ProficiencyType,
+  value: ExtendedProficiencyType,
+  level: number
+): SkillSelectionPreview {
+  const current = RANKS.indexOf(from);
+  if (value === '1') {
+    const next = Math.min(current + 1, RANKS.length - 1);
+    const limitedByLevel = next > RANKS.indexOf(getSkillIncreaseCap(level));
+    return { from, to: limitedByLevel ? from : RANKS[next], limitedByLevel };
+  }
+  if (value === '-1') return { from, to: RANKS[Math.max(0, current - 1)], limitedByLevel: false };
+  return { from, to: RANKS[Math.max(current, RANKS.indexOf(value))], limitedByLevel: false };
+}
+
+/** Training/grants precede spent increases at the same level; independent occurrences retain their order. */
+export function compareSkillAdjustments(left: SkillAdjustment, right: SkillAdjustment): number {
+  const isStep = (value: ExtendedProficiencyType): number => (value === '1' || value === '-1' ? 1 : 0);
+  return (
+    left.context.level - right.context.level ||
+    isStep(left.value) - isStep(right.value) ||
+    left.context.order - right.context.order
+  );
+}
+
+/**
+ * Replay earned ranks in order. An increase consumed reaching expert cannot reappear on a later master grant.
+ * Preserve the public base-rank/increase representation so existing sheets and exported stores stay compatible.
+ */
+export function resolveSkillAdjustments(
+  baseline: ProficiencyValue,
+  adjustments: readonly SkillAdjustment[]
+): ProficiencyValue {
+  let granted = baseline.value;
+  let rank = RANKS[Math.max(0, Math.min(RANKS.length - 1, RANKS.indexOf(granted) + (baseline.increases ?? 0)))];
+  let attribute = baseline.attribute;
+  for (const adjustment of [...adjustments].sort(compareSkillAdjustments)) {
+    if (adjustment.assignment && adjustment.value !== '1' && adjustment.value !== '-1') {
+      granted = adjustment.value;
+      rank = adjustment.value;
+    } else {
+      rank = previewSkillAdjustment(rank, adjustment.value, adjustment.context.level).to;
+      if (adjustment.value !== '1' && adjustment.value !== '-1') {
+        granted = RANKS[Math.max(RANKS.indexOf(granted), RANKS.indexOf(adjustment.value))];
+      }
+    }
+    if (adjustment.attribute) attribute = adjustment.attribute;
+  }
+  return { value: granted, increases: RANKS.indexOf(rank) - RANKS.indexOf(granted), attribute };
+}

--- a/frontend/src/process/variables/variable-manager.ts
+++ b/frontend/src/process/variables/variable-manager.ts
@@ -10,6 +10,8 @@ import {
   VariableListStr,
   ExtendedVariableValue,
   ProficiencyType,
+  ProficiencyValue,
+  ExtendedProficiencyType,
 } from '@schemas/variables';
 import {
   isAttributeValue,
@@ -33,6 +35,16 @@ import {
 } from './variable-utils';
 import { cloneDeep, isBoolean, isEqual, isNumber, isString, uniq } from 'lodash-es';
 import { throwError } from '@utils/error-handling';
+import {
+  compareSkillAdjustments,
+  getSkillIncreaseCap,
+  previewSkillAdjustment,
+  resolveSkillAdjustments,
+  SkillAdjustment,
+  SkillEffectContext,
+  SkillSelectionPreview,
+} from './skill-progression';
+export { getSkillIncreaseCap } from './skill-progression';
 
 export const HIDDEN_VARIABLES = [
   'SKILL_LORE____',
@@ -412,7 +424,8 @@ export function addVariable(
   source?: string
 ): Variable {
   const value = cloneDeep(defaultValue);
-  return mutateVariable(id, () => applyAddVariable(id, type, name, value, source));
+  const context = getSkillEffectContext(id);
+  return mutateVariable(id, () => applyAddVariable(id, type, name, value, source, context));
 }
 
 /** Delete a variable through the same replayable write path. */
@@ -423,7 +436,8 @@ export function removeVariable(id: StoreID, name: string): void {
 /** Record assignment intent, including assignments that are currently hidden by a higher value. */
 export function setVariable(id: StoreID, name: string, value: VariableValue, source?: string): void {
   const input = cloneDeep(value);
-  mutateVariable(id, () => applySetVariable(id, name, input, source));
+  const context = getSkillEffectContext(id);
+  mutateVariable(id, () => applySetVariable(id, name, input, source, context));
 }
 
 /** Record adjustments, including currently redundant rank and list grants. */
@@ -434,7 +448,8 @@ export function adjVariable(
   source?: string
 ): void {
   const input = cloneDeep(amount);
-  mutateVariable(id, () => applyAdjVariable(id, name, input, source));
+  const context = getSkillEffectContext(id);
+  mutateVariable(id, () => applyAdjVariable(id, name, input, source, context));
 }
 
 /** Record removal as a filter, so replay never restores another removed grant from an old list snapshot. */
@@ -446,7 +461,7 @@ export function filterVariableList(id: StoreID, name: string, keep: (value: stri
 }
 
 /** A particular grant occurrence, retained by deferred writes until execution finishes. */
-export type VariableEffectScope = { key: string; content: string; revoked: boolean };
+export type VariableEffectScope = { key: string; content: string; revoked: boolean; revision: number };
 type VariableIntent = { scopes: VariableEffectScope[]; apply: () => unknown };
 type VariableEffects = {
   baseline: VariableStore;
@@ -457,6 +472,9 @@ type VariableEffects = {
   replayWork: number;
   active: VariableEffectScope[];
   applying: boolean;
+  skillContext?: SkillEffectContext;
+  skillContexts: Map<string, SkillEffectContext>;
+  skills: Map<string, { baseline: ProficiencyValue; adjustments: SkillAdjustment[] }>;
 };
 const variableEffects = new WeakMap<VariableStore, VariableEffects>();
 
@@ -473,6 +491,8 @@ export function beginVariableEffects(id: StoreID): void {
       replayWork: 0,
       active: [],
       applying: false,
+      skillContexts: new Map(),
+      skills: new Map(),
     });
   }
 }
@@ -480,6 +500,77 @@ export function beginVariableEffects(id: StoreID): void {
 /** Release provenance after success or failure so later UI writes are ordinary variable edits. */
 export function finishVariableEffects(id: StoreID): void {
   variableEffects.delete(getVariableStore(id));
+}
+
+/** Attach a stable source occurrence and earned level to writes across all operation passes. */
+export async function withSkillEffectContext<T>(
+  id: StoreID,
+  key: string,
+  level: number,
+  run: () => Promise<T>
+): Promise<T> {
+  beginVariableEffects(id);
+  const effects = variableEffects.get(getVariableStore(id))!;
+  let context = effects.skillContexts.get(key);
+  if (!context) {
+    context = { key, level, order: effects.skillContexts.size };
+    effects.skillContexts.set(key, context);
+  }
+  const previous = effects.skillContext;
+  effects.skillContext = context;
+  try {
+    return await run();
+  } finally {
+    effects.skillContext = previous;
+  }
+}
+
+/** Expose execution provenance only while building results; it is never persisted in a character. */
+export function getSkillEffectContext(id: StoreID): SkillEffectContext | undefined {
+  return variableEffects.get(getVariableStore(id))?.skillContext;
+}
+
+/** Build a selector's before/after ranks at its own occurrence, excluding later character choices. */
+export function getSkillSelectionPreview(
+  id: StoreID,
+  name: string,
+  value: ExtendedProficiencyType,
+  context: SkillEffectContext
+): SkillSelectionPreview | undefined {
+  const effects = variableEffects.get(getVariableStore(id));
+  const variable = getVariable<VariableProf>(id, name);
+  if (!effects || variable?.type !== 'prof' || !name.startsWith('SKILL_')) return undefined;
+  const progression = effects.skills.get(name);
+  const choice: SkillAdjustment = { context, value };
+  const prior =
+    progression?.adjustments.filter(
+      (adjustment) => adjustment.context.key !== context.key && compareSkillAdjustments(adjustment, choice) < 0
+    ) ?? [];
+  const baseline = progression?.baseline ?? variable.value;
+  for (const _adjustment of prior) boundVariableReplay(effects);
+  return previewSkillAdjustment(compileProficiencyType(resolveSkillAdjustments(baseline, prior)), value, context.level);
+}
+
+/** Record skill transitions in the existing removal journal's replay, with no second persisted state. */
+function applySkillAdjustment(
+  id: StoreID,
+  variable: VariableProf,
+  value: ExtendedProficiencyType,
+  attribute: string | undefined,
+  context: SkillEffectContext | undefined,
+  assignment = false
+): boolean {
+  const effects = variableEffects.get(getVariableStore(id));
+  if (!effects || !context || !variable.name.startsWith('SKILL_')) return false;
+  let progression = effects.skills.get(variable.name);
+  if (!progression) {
+    progression = { baseline: cloneDeep(variable.value), adjustments: [] };
+    effects.skills.set(variable.name, progression);
+  }
+  progression.adjustments.push({ context, value, attribute, assignment });
+  for (const _adjustment of progression.adjustments) boundVariableReplay(effects);
+  variable.value = resolveSkillAdjustments(progression.baseline, progression.adjustments);
+  return true;
 }
 
 /** Retain every write intention, including grants that currently lose to a higher rank or duplicate value. */
@@ -537,7 +628,7 @@ export async function withVariableEffectScope<T>(
   const effects = variableEffects.get(getVariableStore(id))!;
   let scope = effects.scopes.get(key);
   if (!scope || (scope.revoked && allowRegrant)) {
-    scope = { key, content, revoked: false };
+    scope = { key, content, revoked: false, revision: effects.allScopes.size };
     effects.scopes.set(key, scope);
     effects.allScopes.add(scope);
   }
@@ -578,6 +669,7 @@ export function removeVariableEffects(id: StoreID, content: string): void {
   Object.assign(store.variables, baseline.variables);
   store.bonuses = baseline.bonuses;
   store.history = baseline.history;
+  effects.skills.clear();
   effects.applying = true;
   try {
     for (const intent of effects.intents) {
@@ -702,13 +794,14 @@ function applyAddVariable(
   type: VariableType,
   name: string,
   defaultValue?: VariableValue,
-  source?: string
+  source?: string,
+  context?: SkillEffectContext
 ) {
   let variable = getVariables(id)[name];
   if (variable) {
     // Already exists
     if (defaultValue && type === 'prof') {
-      adjVariable(id, name, defaultValue, source);
+      applyAdjVariable(id, name, defaultValue, source, context);
     }
   } else {
     // New variable
@@ -727,6 +820,7 @@ function applyAddVariable(
  */
 function applyRemoveVariable(id: StoreID, name: string) {
   delete getVariables(id)[name];
+  variableEffects.get(getVariableStore(id))?.skills.delete(name);
 }
 
 /**
@@ -763,7 +857,13 @@ export function exportVariableStore(id: StoreID): VariableStore {
  * @param name - name of the variable to set
  * @param value - VariableValue
  */
-function applySetVariable(id: StoreID, name: string, value: VariableValue, source?: string) {
+function applySetVariable(
+  id: StoreID,
+  name: string,
+  value: VariableValue,
+  source?: string,
+  context?: SkillEffectContext
+) {
   let variable = getVariables(id)[name];
   if (!variable) {
     // throwError(`Invalid variable name: ${name}`);
@@ -795,7 +895,9 @@ function applySetVariable(id: StoreID, name: string, value: VariableValue, sourc
     variable.value.value = value.value;
     variable.value.partial = value.partial;
   } else if (isVariableProf(variable) && isProficiencyValue(value)) {
-    if (isProficiencyType(value.value)) {
+    if (applySkillAdjustment(id, variable, value.value, value.attribute, context, true)) {
+      // The execution journal owns the complete skill assignment.
+    } else if (isProficiencyType(value.value)) {
       variable.value.value = value.value;
     }
     if (value.attribute) {
@@ -807,16 +909,6 @@ function applySetVariable(id: StoreID, name: string, value: VariableValue, sourc
 
   // Add to history
   addVariableHistory(id, variable.name, variable.value, oldValue, source ?? 'Updated');
-}
-
-/**
- * Adjusts a variable by a given amount
- * @param name - name of the variable to adjust
- * @param amount - new value to adjust by
- */
-/** The highest rank a skill increase itself may target at the given level. */
-export function getSkillIncreaseCap(level: number): ProficiencyType {
-  return level >= 15 ? 'L' : level >= 7 ? 'M' : 'E';
 }
 
 /**
@@ -846,21 +938,10 @@ export function getLevelCappedProficiencyType(id: StoreID, variable: VariablePro
 }
 
 /**
- * Clamps every SKILL_* proficiency's spent increases to what's legal for the entity's
- * level, so rank grants and skill increases compose per RAW instead of stacking past
- * the level gates.
- *
- * Skill increases may only raise a skill to expert (any level), master (7th+), or
- * legendary (15th+). Auto-scaling rank grants (e.g. Acrobat Dedication's master-at-7th)
- * execute in the conditional round, after every numeric increase, so an increase spent
- * before such a grant activates would otherwise re-apply on top of the granted rank and
- * over-compile (trained + 1 increase + master grant = legendary). Clamping increases to
- * the level cap absorbs exactly the redundant ones while:
- *  - increases stacked on grants below the cap keep working (e.g. a swashbuckler
- *    style's training + a later skill increase still compiles to expert),
- *  - rank grants above the cap are untouched (mythic/apostle feats may exceed gates),
- *  - negative increases (penalties) are never modified.
- * Runs after operation execution for each store (see operations.main.ts).
+ * Final fallback for ordinary/imported stores without execution provenance. Operation
+ * journals already resolve each increase at its earned level; this keeps external
+ * values within the current level cap without lowering exceptional rank grants or
+ * changing negative increases. Runs after each store commits in operations.main.ts.
  * @param id - Variable store ID to normalize
  */
 export function normalizeProficiencies(id: StoreID) {
@@ -884,7 +965,13 @@ export function normalizeProficiencies(id: StoreID) {
   }
 }
 
-function applyAdjVariable(id: StoreID, name: string, amount: VariableValue | ExtendedVariableValue, source?: string) {
+function applyAdjVariable(
+  id: StoreID,
+  name: string,
+  amount: VariableValue | ExtendedVariableValue,
+  source?: string,
+  context?: SkillEffectContext
+) {
   let variable = getVariables(id)[name];
   if (!variable) {
     // throwError(`Invalid variable name: ${name}`);
@@ -895,7 +982,9 @@ function applyAdjVariable(id: StoreID, name: string, amount: VariableValue | Ext
   if (isVariableProf(variable)) {
     if (isProficiencyValue(amount) || isExtendedProficiencyValue(amount)) {
       const { value, attribute } = amount;
-      if (isProficiencyType(value)) {
+      if (applySkillAdjustment(id, variable, value, attribute ?? undefined, context)) {
+        // The earned-level timeline already applied this adjustment.
+      } else if (isProficiencyType(value)) {
         variable.value.value = maxProficiencyType(variable.value.value, value);
       } else if (isExtendedProficiencyType(value)) {
         if (!variable.value.increases) {

--- a/frontend/src/schemas/operations.ts
+++ b/frontend/src/schemas/operations.ts
@@ -15,11 +15,13 @@ import {
 // Runtime-flexible content entity that carries selection metadata.
 // .catchall(z.any()) models the [key: string]: any index signature.
 
-export const ObjectWithUUIDSchema = z.object({
-  _select_uuid: z.string(),
-  _content_type: ContentTypeSchema,
-  _meta_data: z.record(z.string(), z.any()).optional(),
-}).catchall(z.any());
+export const ObjectWithUUIDSchema = z
+  .object({
+    _select_uuid: z.string(),
+    _content_type: ContentTypeSchema,
+    _meta_data: z.record(z.string(), z.any()).optional(),
+  })
+  .catchall(z.any());
 export type ObjectWithUUID = z.infer<typeof ObjectWithUUIDSchema>;
 
 // ─── Enums ────────────────────────────────────────────────────────────────────
@@ -100,6 +102,7 @@ export type ConditionCheckData = z.infer<typeof ConditionCheckDataSchema>;
 // ─── Operation Options ────────────────────────────────────────────────────────
 
 export const OperationOptionsSchema = z.object({
+  sourceLevel: z.number().optional(),
   doOnlyValueCreation: z.boolean().optional(),
   doConditionals: z.boolean().optional(),
   doOnlyConditionals: z.boolean().optional(),

--- a/frontend/src/utils/character-merge.ts
+++ b/frontend/src/utils/character-merge.ts
@@ -4,6 +4,19 @@ import { SAVED_CHARACTER_FIELDS } from './character-save-buffer';
 
 type CharacterMerge = { character: Character; conflicts: string[] };
 
+/** Preserve edits made after an uncertain write, including deliberate returns to the old value. */
+export function mergeCharacterSave(
+  base: Record<string, unknown> | null,
+  local: Record<string, unknown> | null,
+  remote: Character,
+  submitted?: Record<string, unknown>
+): CharacterMerge {
+  if (!submitted) return mergeCharacterOnConflict(base, local, remote);
+  const attempt = mergeCharacterOnConflict(base, submitted, remote);
+  const latest = mergeCharacterOnConflict(submitted, local, attempt.character);
+  return { character: latest.character, conflicts: [...new Set([...attempt.conflicts, ...latest.conflicts])] };
+}
+
 /** Merge independent nested edits; retain local values at explicitly reported conflicts. */
 export function mergeCharacterOnConflict(
   base: Record<string, unknown> | null,

--- a/frontend/src/utils/character-save-buffer.ts
+++ b/frontend/src/utils/character-save-buffer.ts
@@ -1,10 +1,8 @@
 import type { Character } from '@schemas/content';
-import { makeRequest } from '@requests/request-manager';
-import { supabase } from '../supabase-client';
 import { z } from 'zod';
 import { isEqual } from 'lodash-es';
 
-/** The fields persisted by update-character, shared by regular and buffered saves. */
+/** The fields persisted by update-character, shared by saving and durable recovery. */
 export const SAVED_CHARACTER_FIELDS = [
   'name',
   'level',
@@ -29,123 +27,287 @@ export const SAVED_CHARACTER_FIELDS = [
   'campaign_id',
 ] as const;
 
-const bodySchema = z
-  .object({
-    id: z.number(),
-    expected_updated_at: z.string().optional(),
-  })
-  .catchall(z.unknown());
-const draftSchema = z.object({
-  version: z.literal(1),
-  actorId: z.string().min(1),
-  body: bodySchema,
-  requiresCalculation: z.boolean().optional(),
-  base: bodySchema.extend({ name: z.string(), level: z.number() }).optional(),
-});
-const legacySchema = z.object({ token: z.string(), body: bodySchema });
-const savedRowsSchema = z.array(z.object({ id: z.number() }).passthrough()).min(1);
-type CharacterSaveDraft = z.infer<typeof draftSchema>;
-export type BufferedSaveResult = (
-  | { status: 'none' | 'saved' }
-  | { status: 'needs-calculation'; body: Record<string, unknown>; base: Record<string, unknown> }
-  | {
-      status: 'retained';
-      reason: 'signed-out' | 'different-account' | 'unversioned' | 'rejected' | 'invalid';
-      body?: Record<string, unknown>;
-      key?: string;
-    }
-) & { recovery?: Record<string, unknown> };
-const replays = new Map<string, Promise<BufferedSaveResult>>();
-
-/** Each account keeps its own drafts, including edits made with campaign permissions. */
-function bufferKey(characterId: number, actorId: string): string {
-  return `autosave-character-${characterId}-${actorId}`;
-}
-
-/** Preserve the first rejected snapshot separately from the editable current draft. */
-function preserveRecovery(draft: CharacterSaveDraft): void {
-  const key = `autosave-character-recovery-${draft.body.id}-${draft.actorId}`;
-  if (!localStorage.getItem(key)) localStorage.setItem(key, JSON.stringify(draft));
-}
-
-/** Find an account's retained snapshot for an explicit download/recovery action. */
-export function getBufferedCharacterRecovery(characterId: number, actorId: string): Record<string, unknown> | null {
+/** Compare persisted JSON, ignoring undefined object properties that never reach the API. */
+export function characterSaveValuesEqual(left: unknown, right: unknown): boolean {
+  if (isEqual(left, right)) return true;
+  // Optional empty columns may be absent locally and null in a database row.
+  if (left == null || right == null) return left == null && right == null;
   try {
-    const raw = localStorage.getItem(`autosave-character-recovery-${characterId}-${actorId}`);
-    if (!raw) return null;
-    const parsed = draftSchema.safeParse(JSON.parse(raw));
-    return parsed.success && parsed.data.actorId === actorId && parsed.data.body.id === characterId
-      ? parsed.data.body
-      : null;
-  } catch (error) {
-    console.error('Could not read the retained character copy:', error);
-    return null;
+    return isEqual(JSON.parse(JSON.stringify(left)), JSON.parse(JSON.stringify(right)));
+  } catch {
+    return false;
   }
 }
 
-/** Store a draft synchronously for pagehide; authentication tokens never belong in it. */
+const bodySchema = z.object({ id: z.number(), expected_updated_at: z.string().optional() }).catchall(z.unknown());
+const baseSchema = bodySchema.extend({ name: z.string(), level: z.number() });
+const draftSchema = z.object({
+  version: z.literal(2),
+  actorId: z.string().min(1),
+  writerId: z.string().min(1),
+  body: bodySchema,
+  requiresCalculation: z.boolean().optional(),
+  base: baseSchema.optional(),
+  submission: z.object({ body: bodySchema, expectedUpdatedAt: z.string().min(1) }).optional(),
+});
+const oldDraftSchema = draftSchema.omit({ version: true, writerId: true, submission: true }).extend({
+  version: z.literal(1),
+});
+const legacySchema = z.object({ token: z.string(), body: bodySchema });
+
+/** A page owns its writes across navigation; another tab or reload gets a new owner. */
+export const CHARACTER_SAVE_WRITER_ID: string = crypto.randomUUID();
+export type CharacterSaveDraft = z.infer<typeof draftSchema>;
+export type BufferedCharacterSaveRecord = { key: string; raw: string; draft: CharacterSaveDraft };
+export type BufferedCharacterRecoveryRecord = {
+  key: string;
+  raw: string;
+  reason: 'invalid' | 'unversioned' | 'missing-base' | 'recovery';
+  body?: Record<string, unknown>;
+};
+type StorageUnavailable = { status: 'unavailable' };
+export type BufferedCharacterReadResult =
+  | BufferedCharacterSaveRecord
+  | { status: 'none' }
+  | ({ status: 'invalid' } & BufferedCharacterRecoveryRecord)
+  | StorageUnavailable;
+export type BufferedCharacterWriteResult =
+  | { status: 'stored'; record: BufferedCharacterSaveRecord }
+  | StorageUnavailable;
+export type BufferedCharacterAcknowledgement = { status: 'removed' | 'updated' | 'unchanged' } | StorageUnavailable;
+export type BufferedCharacterLoadResult =
+  | { status: 'loaded'; records: BufferedCharacterSaveRecord[]; retained: BufferedCharacterRecoveryRecord[] }
+  | StorageUnavailable;
+
+/** Account-scoped prefixes include drafts made with campaign editing permission. */
+function accountPrefix(characterId: number, actorId: string): string {
+  return `autosave-character-${characterId}-${actorId}`;
+}
+
+/** Each writer has a separate durable slot so offline tabs cannot replace each other. */
+function bufferKey(characterId: number, actorId: string, writerId: string): string {
+  return `${accountPrefix(characterId, actorId)}:writer:${encodeURIComponent(writerId)}`;
+}
+
+/** Storage may be denied or full; callers must not present an unsuccessful write as durable. */
+function storageUnavailable(action: string, error: unknown): StorageUnavailable {
+  console.error(`Could not ${action} character changes:`, error);
+  return { status: 'unavailable' };
+}
+
+/** Read a recoverable body only when its declared account and character match. */
+function recoverableBody(value: unknown, characterId: number, actorId: string): Record<string, unknown> | undefined {
+  const parsed = z.object({ actorId: z.literal(actorId), body: bodySchema }).safeParse(value);
+  return parsed.success && parsed.data.body.id === characterId ? parsed.data.body : undefined;
+}
+
+/** Parsing never erases an invalid entry; it remains available for explicit recovery. */
+function readRecord(
+  key: string,
+  raw: string,
+  characterId: number,
+  actorId: string
+): BufferedCharacterSaveRecord | ({ status: 'invalid' } & BufferedCharacterRecoveryRecord) {
+  let value: unknown;
+  try {
+    value = JSON.parse(raw);
+  } catch {
+    return { status: 'invalid', reason: 'invalid', key, raw };
+  }
+  const parsed = draftSchema.safeParse(value);
+  if (
+    !parsed.success ||
+    parsed.data.actorId !== actorId ||
+    parsed.data.body.id !== characterId ||
+    (parsed.data.submission && parsed.data.submission.body.id !== characterId) ||
+    key !== bufferKey(characterId, actorId, parsed.data.writerId)
+  ) {
+    return { status: 'invalid', reason: 'invalid', key, raw, body: recoverableBody(value, characterId, actorId) };
+  }
+  return { key, raw, draft: parsed.data };
+}
+
+/** Read only this page's own draft; loading other writers requires explicit restoration. */
+export function getBufferedCharacterSave(
+  characterId: number,
+  actorId: string,
+  writerId = CHARACTER_SAVE_WRITER_ID
+): BufferedCharacterReadResult {
+  try {
+    const key = bufferKey(characterId, actorId, writerId);
+    const raw = localStorage.getItem(key);
+    return raw === null ? { status: 'none' } : readRecord(key, raw, characterId, actorId);
+  } catch (error) {
+    return storageUnavailable('read buffered', error);
+  }
+}
+
+/** Persist inputs synchronously, retaining an uncertain submission through later edits. */
 export function bufferCharacterSave(
   character: Character,
   actorId: string,
   expectedUpdatedAt?: string,
-  options?: { requiresCalculation: boolean; base: Character }
-): void {
-  const body: Record<string, unknown> = { id: character.id };
-  for (const field of SAVED_CHARACTER_FIELDS) body[field] = character[field];
-  if (expectedUpdatedAt) body.expected_updated_at = expectedUpdatedAt;
+  options?: { requiresCalculation: boolean; base: Character; writerId?: string }
+): BufferedCharacterWriteResult {
+  return writeCharacterSave(character, actorId, expectedUpdatedAt, options, false);
+}
+
+/** Share owned storage and historical-copy retention between buffering and reconciliation. */
+function writeCharacterSave(
+  character: Character,
+  actorId: string,
+  expectedUpdatedAt: string | undefined,
+  options: { requiresCalculation: boolean; base: Character; writerId?: string } | undefined,
+  reconciled: boolean
+): BufferedCharacterWriteResult {
   try {
-    const previous = getBufferedCharacterSave(character.id, actorId);
-    if ('draft' in previous && !previous.draft.body.expected_updated_at) preserveRecovery(previous.draft);
-    const base = options
-      ? {
-          id: options.base.id,
-          ...Object.fromEntries(SAVED_CHARACTER_FIELDS.map((field) => [field, options.base[field]])),
-        }
-      : undefined;
-    localStorage.setItem(
-      bufferKey(character.id, actorId),
-      JSON.stringify({
-        version: 1,
-        actorId,
-        body,
-        ...(options ? { requiresCalculation: options.requiresCalculation, base } : {}),
-      })
-    );
+    const writerId = options?.writerId ?? CHARACTER_SAVE_WRITER_ID;
+    const previous = getBufferedCharacterSave(character.id, actorId, writerId);
+    if ('status' in previous && previous.status === 'unavailable') return previous;
+    const key = bufferKey(character.id, actorId, writerId);
+    const body = {
+      id: character.id,
+      ...Object.fromEntries(SAVED_CHARACTER_FIELDS.map((field) => [field, character[field]])),
+      ...(expectedUpdatedAt ? { expected_updated_at: expectedUpdatedAt } : {}),
+    };
+    const draft = draftSchema.parse({
+      version: 2,
+      actorId,
+      writerId,
+      body,
+      ...(options
+        ? {
+            requiresCalculation: options.requiresCalculation,
+            base: {
+              id: options.base.id,
+              ...Object.fromEntries(SAVED_CHARACTER_FIELDS.map((field) => [field, options.base[field]])),
+              updated_at: options.base.updated_at,
+            },
+          }
+        : {}),
+      ...(!reconciled && 'draft' in previous && previous.draft.submission
+        ? { submission: previous.draft.submission }
+        : {}),
+    });
+    const raw = JSON.stringify(draft);
+    if ('raw' in previous && previous.raw === raw) return { status: 'stored', record: { key, raw, draft } };
+    // Keep the first rejected copy separately from this writer's latest editable
+    // draft. Repeated renders or edits cannot fill storage with duplicate backups.
+    if (
+      ('status' in previous && previous.status === 'invalid') ||
+      ('draft' in previous && !previous.draft.body.expected_updated_at)
+    ) {
+      const retainedKey = `${accountPrefix(character.id, actorId)}:retained:${encodeURIComponent(writerId)}`;
+      if (localStorage.getItem(retainedKey) === null) localStorage.setItem(retainedKey, previous.raw);
+    }
+    localStorage.setItem(key, raw);
+    return { status: 'stored', record: { key, raw, draft } };
   } catch (error) {
-    console.error('Could not buffer character changes:', error);
+    return storageUnavailable('buffer', error);
   }
 }
 
-/** Acknowledge only the submitted snapshot, keeping and rebasing any newer queued edit. */
+/** Atomically retain a fully reconciled body and server base without replaying its former submission. */
+export function reconcileBufferedCharacterSave(
+  character: Character,
+  actorId: string,
+  remote: Character,
+  options: { requiresCalculation: boolean; writerId?: string }
+): BufferedCharacterWriteResult | { status: 'removed' } {
+  if (character.id !== remote.id || !remote.updated_at)
+    return storageUnavailable('reconcile', new Error('A matching server version is required'));
+  const stored = writeCharacterSave(character, actorId, remote.updated_at, { ...options, base: remote }, true);
+  if (stored.status === 'unavailable') return stored;
+  if (
+    !options.requiresCalculation &&
+    SAVED_CHARACTER_FIELDS.every((field) => characterSaveValuesEqual(character[field], remote[field]))
+  ) {
+    const acknowledged = acknowledgeBufferedCharacterRecovery(stored.record);
+    if (acknowledged.status === 'unavailable') return acknowledged;
+    if (acknowledged.status === 'removed') return { status: 'removed' };
+  }
+  return stored;
+}
+
+/** Journal the exact attempt before sending it so a lost acknowledgement remains reconcilable. */
+export function journalCharacterSaveSubmission(
+  characterId: number,
+  actorId: string,
+  submitted: Record<string, unknown>,
+  expectedUpdatedAt: string,
+  writerId = CHARACTER_SAVE_WRITER_ID
+): BufferedCharacterWriteResult | { status: 'unchanged' } {
+  try {
+    const stored = getBufferedCharacterSave(characterId, actorId, writerId);
+    if (!('draft' in stored)) return stored.status === 'unavailable' ? stored : { status: 'unchanged' };
+    const draft = draftSchema.parse({
+      ...stored.draft,
+      submission: { body: { ...submitted, id: characterId }, expectedUpdatedAt },
+    });
+    const raw = JSON.stringify(draft);
+    if (localStorage.getItem(stored.key) !== stored.raw) return { status: 'unchanged' };
+    localStorage.setItem(stored.key, raw);
+    return { status: 'stored', record: { key: stored.key, raw, draft } };
+  } catch (error) {
+    return storageUnavailable('journal', error);
+  }
+}
+
+/** Acknowledge only this writer, rebasing its newer intent without touching another tab. */
 export function acknowledgeBufferedCharacterSave(
   characterId: number,
   actorId: string,
   submitted: Record<string, unknown>,
   expectedUpdatedAt: string | undefined,
   updatedAt: string | undefined,
-  calculationComplete = false
-): void {
-  const stored = getBufferedCharacterSave(characterId, actorId);
-  if (!('draft' in stored)) return;
-  if (
-    (!stored.draft.requiresCalculation || calculationComplete) &&
-    SAVED_CHARACTER_FIELDS.every((field) => isEqual(stored.draft.body[field], submitted[field]))
-  ) {
-    if (localStorage.getItem(stored.key) === stored.raw) localStorage.removeItem(stored.key);
-  } else if (updatedAt && stored.draft.body.expected_updated_at === expectedUpdatedAt) {
-    stored.draft.body.expected_updated_at = updatedAt;
-    if (stored.draft.base) {
-      // This accepted snapshot is the new common ancestor for any later merge.
-      const base = bodySchema
-        .extend({ name: z.string(), level: z.number() })
-        .safeParse({ id: characterId, ...submitted });
-      if (base.success) stored.draft.base = base.data;
+  calculationComplete = false,
+  writerId = CHARACTER_SAVE_WRITER_ID
+): BufferedCharacterAcknowledgement {
+  try {
+    const stored = getBufferedCharacterSave(characterId, actorId, writerId);
+    if (!('draft' in stored)) return stored.status === 'unavailable' ? stored : { status: 'unchanged' };
+    if (
+      stored.draft.submission &&
+      (stored.draft.submission.expectedUpdatedAt !== expectedUpdatedAt ||
+        SAVED_CHARACTER_FIELDS.some(
+          (field) => !characterSaveValuesEqual(stored.draft.submission?.body[field], submitted[field])
+        ))
+    )
+      return { status: 'unchanged' };
+    if (
+      (!stored.draft.requiresCalculation || calculationComplete) &&
+      SAVED_CHARACTER_FIELDS.every((field) => characterSaveValuesEqual(stored.draft.body[field], submitted[field]))
+    ) {
+      return acknowledgeBufferedCharacterRecovery(stored);
     }
-    if (localStorage.getItem(stored.key) === stored.raw) localStorage.setItem(stored.key, JSON.stringify(stored.draft));
+    if (!updatedAt || stored.draft.body.expected_updated_at !== expectedUpdatedAt) return { status: 'unchanged' };
+    stored.draft.body.expected_updated_at = updatedAt;
+    const base = baseSchema.safeParse({ ...submitted, id: characterId, updated_at: updatedAt });
+    if (base.success) stored.draft.base = base.data;
+    if (stored.draft.submission?.expectedUpdatedAt === expectedUpdatedAt) delete stored.draft.submission;
+    if (localStorage.getItem(stored.key) !== stored.raw) return { status: 'unchanged' };
+    localStorage.setItem(stored.key, JSON.stringify(stored.draft));
+    return { status: 'updated' };
+  } catch (error) {
+    return storageUnavailable('acknowledge buffered', error);
   }
 }
 
-/** Read the actor claim only to migrate old local drafts; it never authenticates a request. */
+/** Remove a recovered snapshot only after saving it or explicitly choosing to discard it. */
+export function acknowledgeBufferedCharacterRecovery(
+  record: Pick<BufferedCharacterSaveRecord, 'key' | 'raw'>
+): BufferedCharacterAcknowledgement {
+  try {
+    if (!record.key.startsWith('autosave-character-') || localStorage.getItem(record.key) !== record.raw)
+      return { status: 'unchanged' };
+    localStorage.removeItem(record.key);
+    return { status: 'removed' };
+  } catch (error) {
+    return storageUnavailable('acknowledge recovered', error);
+  }
+}
+
+/** An obsolete saved token is used only to identify its local owner, never to authenticate. */
 function legacyActor(token: string): string | null {
   try {
     const payload = token.split('.')[1];
@@ -159,111 +321,103 @@ function legacyActor(token: string): string | null {
   }
 }
 
-/** Locate only this account's draft, safely migrating its obsolete saved bearer token. */
-export function getBufferedCharacterSave(
+/** Move a legacy snapshot into its own slot, removing old credentials only after durable storage. */
+function migrateLegacyRecord(
   characterId: number,
-  actorId: string
-): { key: string; raw: string; draft: CharacterSaveDraft } | BufferedSaveResult {
-  const key = bufferKey(characterId, actorId);
+  actorId: string,
+  key: string,
+  tokenFormat: boolean
+): BufferedCharacterRecoveryRecord | undefined {
   const raw = localStorage.getItem(key);
-  const legacyKey = `autosave-character-${characterId}`;
-  const legacyRaw = raw ? null : localStorage.getItem(legacyKey);
-  if (!raw && !legacyRaw) return { status: 'none' };
+  if (raw === null) return undefined;
+  let value: unknown;
   try {
-    if (raw) {
-      const value: unknown = JSON.parse(raw);
-      const parsed = draftSchema.safeParse(value);
-      if (!parsed.success || parsed.data.body.id !== characterId) {
-        const recoverable = z.object({ actorId: z.literal(actorId), body: bodySchema }).safeParse(value);
-        if (recoverable.success && recoverable.data.body.id === characterId) {
-          preserveRecovery({ version: 1, actorId, body: recoverable.data.body });
-          return { status: 'retained', reason: 'invalid', key, body: recoverable.data.body };
-        }
-        return { status: 'retained', reason: 'invalid', key };
-      }
-      if (parsed.data.actorId !== actorId) return { status: 'retained', reason: 'different-account' };
-      return { key, raw, draft: parsed.data };
+    value = JSON.parse(raw);
+  } catch {
+    return { key, raw, reason: 'invalid' };
+  }
+  let draft: CharacterSaveDraft;
+  if (tokenFormat) {
+    const parsed = legacySchema.safeParse(value);
+    if (!parsed.success) return { key, raw, reason: 'invalid' };
+    if (parsed.data.body.id !== characterId || legacyActor(parsed.data.token) !== actorId) return undefined;
+    draft = { version: 2, actorId, writerId: 'legacy-token', body: parsed.data.body };
+  } else {
+    const parsed = oldDraftSchema.safeParse(value);
+    if (!parsed.success) return { key, raw, reason: 'invalid', body: recoverableBody(value, characterId, actorId) };
+    if (parsed.data.actorId !== actorId || parsed.data.body.id !== characterId) return undefined;
+    draft = { ...parsed.data, version: 2, writerId: 'legacy-account' };
+  }
+  let destination = bufferKey(characterId, actorId, draft.writerId);
+  const existing = localStorage.getItem(destination);
+  if (existing !== null && existing !== JSON.stringify(draft)) {
+    draft.writerId = `${draft.writerId}-${crypto.randomUUID()}`;
+    destination = bufferKey(characterId, actorId, draft.writerId);
+  }
+  localStorage.setItem(destination, JSON.stringify(draft));
+  if (localStorage.getItem(key) === raw) localStorage.removeItem(key);
+  return undefined;
+}
+
+/** Discover every account-owned copy without claiming it or sending any network request. */
+export function loadBufferedCharacterSaves(characterId: number, actorId: string): BufferedCharacterLoadResult {
+  try {
+    const records: BufferedCharacterSaveRecord[] = [];
+    const retained: BufferedCharacterRecoveryRecord[] = [];
+    const prefix = accountPrefix(characterId, actorId);
+    for (const [key, tokenFormat] of [
+      [prefix, false],
+      [`autosave-character-${characterId}`, true],
+    ] as const) {
+      const recovery = migrateLegacyRecord(characterId, actorId, key, tokenFormat);
+      if (recovery) retained.push(recovery);
     }
-    const legacy = legacySchema.safeParse(JSON.parse(legacyRaw!));
-    if (!legacy.success || legacy.data.body.id !== characterId)
-      return { status: 'retained', reason: 'invalid', key: legacyKey };
-    if (legacyActor(legacy.data.token) !== actorId) return { status: 'retained', reason: 'different-account' };
-    const draft: CharacterSaveDraft = { version: 1, actorId, body: legacy.data.body };
-    const migrated = JSON.stringify(draft);
-    localStorage.setItem(key, migrated);
-    if (localStorage.getItem(legacyKey) === legacyRaw) localStorage.removeItem(legacyKey);
-    return { key, raw: migrated, draft };
+    const keys: string[] = [];
+    for (let index = 0; index < localStorage.length; index++) {
+      const key = localStorage.key(index);
+      if (key?.startsWith(`${prefix}:writer:`) || key?.startsWith(`${prefix}:retained:`)) keys.push(key);
+    }
+    keys.sort();
+    for (const key of keys) {
+      const raw = localStorage.getItem(key);
+      if (raw === null) continue;
+      const result = readRecord(key, raw, characterId, actorId);
+      if ('status' in result) {
+        retained.push(result);
+      } else if (!result.draft.body.expected_updated_at) {
+        retained.push({ key, raw, body: result.draft.body, reason: 'unversioned' });
+      } else if (result.draft.base?.id !== characterId) {
+        retained.push({ key, raw, body: result.draft.body, reason: 'missing-base' });
+      } else {
+        records.push(result);
+      }
+    }
+    const recoveryKey = `autosave-character-recovery-${characterId}-${actorId}`;
+    const recoveryRaw = localStorage.getItem(recoveryKey);
+    if (recoveryRaw !== null) {
+      let body: Record<string, unknown> | undefined;
+      try {
+        body = recoverableBody(JSON.parse(recoveryRaw), characterId, actorId);
+      } catch {
+        /* Preserve invalid JSON. */
+      }
+      retained.push({ key: recoveryKey, raw: recoveryRaw, body, reason: 'recovery' });
+    }
+    return { status: 'loaded', records, retained };
   } catch (error) {
-    console.error('Could not read buffered character changes:', error);
-    return { status: 'retained', reason: 'invalid' };
+    return storageUnavailable('load buffered', error);
   }
 }
 
-/** Replay with the current session and retain the draft unless the API returns its saved row. */
-export async function replayBufferedCharacterSave(characterId: number): Promise<BufferedSaveResult> {
+/** Logout removes cached account data while preserving every writer's unsynced work. */
+export function clearSessionDataPreservingDrafts(): { status: 'cleared' } | StorageUnavailable {
   try {
-    const {
-      data: { session },
-    } = await supabase.auth.getSession();
-    if (!session) return { status: 'retained', reason: 'signed-out' };
-    const key = bufferKey(characterId, session.user.id);
-    const existing = replays.get(key);
-    if (existing) return existing;
-    const replay = (async (): Promise<BufferedSaveResult> => {
-      const stored = getBufferedCharacterSave(characterId, session.user.id);
-      if ('status' in stored) return stored;
-      const retained = { status: 'retained' as const, body: stored.draft.body, key: stored.key };
-      // Inputs captured during debouncing/calculation must be recalculated in the
-      // next editor. They are never replayed directly as a full server update.
-      if (stored.draft.requiresCalculation) {
-        if (!stored.draft.body.expected_updated_at) {
-          preserveRecovery(stored.draft);
-          return { ...retained, reason: 'unversioned' };
-        }
-        if (stored.draft.base?.id === characterId)
-          return { status: 'needs-calculation', body: stored.draft.body, base: stored.draft.base };
-        preserveRecovery(stored.draft);
-        return { ...retained, reason: 'invalid' };
-      }
-      // Older buffers omitted the server version. Applying them automatically would
-      // overwrite any changes made on another device while this tab was closed.
-      if (!stored.draft.body.expected_updated_at) {
-        preserveRecovery(stored.draft);
-        return { ...retained, reason: 'unversioned' };
-      }
-      const latest = await supabase.auth.getSession();
-      if (latest.data.session?.user.id !== session.user.id) return { ...retained, reason: 'different-account' };
-      const response = await makeRequest<unknown>('update-character', stored.draft.body, false, {
-        expectedActorId: session.user.id,
-      });
-      const saved = savedRowsSchema.safeParse(response);
-      if (!saved.success || !saved.data.some((row) => row.id === characterId)) {
-        preserveRecovery(stored.draft);
-        return { ...retained, reason: 'rejected' };
-      }
-      // A pagehide event may buffer a newer edit while the old draft is in flight.
-      if (localStorage.getItem(stored.key) === stored.raw) localStorage.removeItem(stored.key);
-      return { status: 'saved' };
-    })().then((result) => {
-      const recovery = getBufferedCharacterRecovery(characterId, session.user.id);
-      return recovery ? { ...result, recovery } : result;
-    });
-    replays.set(key, replay);
-    try {
-      return await replay;
-    } finally {
-      replays.delete(key);
+    for (let index = localStorage.length - 1; index >= 0; index--) {
+      const key = localStorage.key(index);
+      if (key && !key.startsWith('autosave-character-')) localStorage.removeItem(key);
     }
+    return { status: 'cleared' };
   } catch (error) {
-    console.error('Could not replay buffered character changes:', error);
-    return { status: 'retained', reason: 'rejected' };
-  }
-}
-
-/** Logout clears cached account data while retaining each account's unsynced work. */
-export function clearSessionDataPreservingDrafts(): void {
-  for (let index = localStorage.length - 1; index >= 0; index--) {
-    const key = localStorage.key(index);
-    if (key && !key.startsWith('autosave-character-')) localStorage.removeItem(key);
+    return storageUnavailable('clear cached', error);
   }
 }

--- a/frontend/src/utils/use-character.tsx
+++ b/frontend/src/utils/use-character.tsx
@@ -5,23 +5,29 @@ import { Button, Group, Text } from '@mantine/core';
 import { downloadObjectAsJson } from '@export/export-to-json';
 import {
   SAVED_CHARACTER_FIELDS,
+  characterSaveValuesEqual,
   acknowledgeBufferedCharacterSave,
   bufferCharacterSave,
   getBufferedCharacterSave,
-  replayBufferedCharacterSave,
+  loadBufferedCharacterSaves,
+  reconcileBufferedCharacterSave,
+  acknowledgeBufferedCharacterRecovery,
+  journalCharacterSaveSubmission,
+  type BufferedCharacterSaveRecord,
 } from './character-save-buffer';
-import { mergeCharacterOnConflict } from './character-merge';
+import { mergeCharacterSave } from './character-merge';
+import type { CharacterSaveState } from '@common/CharacterSaveStatus';
 import { getCachedPublicUser } from '@auth/user-manager';
 import { applyConditions } from '@conditions/condition-handler';
 import { defineDefaultSources } from '@content/content-store';
 import { saveCustomization } from '@content/customization-cache';
 import { applyEquipmentPenalties } from '@items/inv-utils';
-import { useDebouncedCallback, useDebouncedValue, useDidUpdate } from '@mantine/hooks';
+import { useDebouncedValue, useDidUpdate } from '@mantine/hooks';
 import { hideNotification, showNotification } from '@mantine/notifications';
 import { executeOperations, isOperationCancelled } from '@operations/operations.main';
 import { confirmHealth } from '@pages/character_sheet/entity-handler';
 import { hasSessionExpiredNotice, makeRequest } from '@requests/request-manager';
-import { useQuery, useMutation } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 import { Character, ContentPackage, OperationCharacterResultPackage } from '@schemas/content';
 import { saveCalculatedStats } from '@variables/calculated-stats';
 import { setVariable } from '@variables/variable-manager';
@@ -30,7 +36,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useAtom, useAtomValue } from 'jotai';
 import { SetterOrUpdater } from '@utils/type-fixing';
 import { convertToSetEntity } from './type-fixing';
-import { IconRefresh, IconAlertCircle } from '@tabler/icons-react';
+import { IconRefresh } from '@tabler/icons-react';
 import { hashData } from './numbers';
 import { getDeepDiff } from './objects';
 import { addExtraItems, checkBulkLimit } from '@items/inv-handlers';
@@ -96,6 +102,11 @@ export default function useCharacter(
   operationError: string | null;
   isCalculating: boolean;
   retryOperations: () => void;
+  saveState: CharacterSaveState;
+  draftStored: boolean;
+  retrySave: () => void;
+  loadError: boolean;
+  retryLoad: () => void;
 } {
   const [character, setCharacter] = useAtom(characterState);
   const session = useAtomValue(sessionState);
@@ -105,6 +116,26 @@ export default function useCharacter(
   const loadedActorRef = useRef<string | null>(null);
   const saveScopeRef = useRef(0);
   const needsCalculationRef = useRef(false);
+  const recoveredDraftsRef = useRef<BufferedCharacterSaveRecord[]>([]);
+  const uncertainSaveRef = useRef<{ submitted: Record<string, unknown>; expectedUpdatedAt: string } | null>(null);
+  const [savePhase, setSavePhase] = useState<'idle' | 'saving' | 'failed'>('idle');
+  const [draftStored, setDraftStored] = useState(true);
+  const [isOnline, setIsOnline] = useState(typeof navigator === 'undefined' || navigator.onLine !== false);
+  const [loadError, setLoadError] = useState(false);
+  const [loadAttempt, setLoadAttempt] = useState(0);
+  const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const retryCountRef = useRef(0);
+  const retrySaveRef = useRef<() => void>(() => {});
+
+  /** Only retire recovered snapshots after their merged values are accepted. */
+  const acknowledgeRecoveredDrafts = () => {
+    for (const record of recoveredDraftsRef.current) acknowledgeBufferedCharacterRecovery(record);
+    recoveredDraftsRef.current = [];
+  };
+  const clearSaveRetry = () => {
+    if (retryTimerRef.current !== null) clearTimeout(retryTimerRef.current);
+    retryTimerRef.current = null;
+  };
 
   // Always-current view of the atom (the `character` closure goes stale inside async
   // mutation callbacks), and the last character state we know the server holds — the
@@ -180,6 +211,9 @@ export default function useCharacter(
   const offerConflictResolution = useCallback(
     (local: Character, remote: Character, fields: string[]) => {
       saveConflictRef.current = true;
+      hideNotification('character-save-failed');
+      clearSaveRetry();
+      setSavePhase('idle');
       const scope = saveScopeRef.current;
       const actor = loadedActorRef.current;
       const noticeId = `character-conflict-${characterId}`;
@@ -187,26 +221,25 @@ export default function useCharacter(
         if (scope !== saveScopeRef.current || !actor || actor !== loadedActorRef.current) return;
         const chosen = useLocal ? characterRef.current : remote;
         if (!chosen) return;
-        // An explicit remote choice also discards this matching local draft;
-        // otherwise navigation would restore the very edit the user rejected.
-        // The snapshot comparison preserves any newer draft from another tab.
-        if (!useLocal && characterRef.current) {
-          acknowledgeBufferedCharacterSave(
-            characterId,
-            actor,
-            Object.fromEntries(SAVED_CHARACTER_FIELDS.map((field) => [field, characterRef.current?.[field]])),
-            lastSyncedRef.current?.updated_at,
-            remote.updated_at,
-            true
-          );
+        if (!useLocal) {
+          const owned = getBufferedCharacterSave(characterId, actor);
+          if ('draft' in owned) acknowledgeBufferedCharacterRecovery(owned);
+          acknowledgeRecoveredDrafts();
+        } else {
+          const reconciled = reconcileBufferedCharacterSave(chosen, actor, remote, {
+            requiresCalculation: needsCalculationRef.current || options.type === 'EXECUTE_OPS',
+          });
+          setDraftStored(reconciled.status !== 'unavailable');
         }
+        uncertainSaveRef.current = null;
         lastSyncedRef.current = remote;
         conflictStreakRef.current = 0;
         saveConflictRef.current = false;
-        if (options.type === 'SIMPLE') needsCalculationRef.current = false;
+        if (!useLocal) needsCalculationRef.current = false;
         hideNotification(noticeId);
         characterRef.current = cloneDeep(chosen);
         setCharacter(characterRef.current);
+        setSavePhase('idle');
       };
       showNotification({
         id: noticeId,
@@ -229,7 +262,15 @@ export default function useCharacter(
                 variant='subtle'
                 onClick={() => {
                   if (scope === saveScopeRef.current && actor === loadedActorRef.current)
-                    downloadObjectAsJson(characterRef.current ?? local, `character-${characterId}-conflict-copy`);
+                    downloadObjectAsJson(
+                      recoveredDraftsRef.current.length > 1
+                        ? {
+                            character: characterRef.current ?? local,
+                            copies: recoveredDraftsRef.current.map((record) => record.draft.body),
+                          }
+                        : (characterRef.current ?? local),
+                      `character-${characterId}-conflict-copy`
+                    );
                 }}
               >
                 Download my copy
@@ -245,12 +286,18 @@ export default function useCharacter(
     [characterId, options.type, setCharacter]
   );
 
-  // Replay this account's guarded draft before fetching the authoritative row.
+  // Restore drafts into the editor. This path never writes around its save queue.
   useEffect(() => {
     let active = true;
     const scope = ++saveScopeRef.current;
+    clearSaveRetry();
     loadedActorRef.current = null;
     setLoadedIdentity(null);
+    setLoadError(false);
+    setSavePhase('idle');
+    retryCountRef.current = 0;
+    uncertainSaveRef.current = null;
+    recoveredDraftsRef.current = [];
     needsCalculationRef.current = false;
     lastSyncedRef.current = null;
     readOnlyRef.current = false;
@@ -261,44 +308,71 @@ export default function useCharacter(
     pendingSaveRef.current = null;
     const recoveryNoticeId = `character-recovery-${characterId}`;
     void (async () => {
-      const replay = await replayBufferedCharacterSave(characterId);
+      // A failed request is not an authorization decision. Keep the route and offer retry.
+      const dbCharacter = await makeRequest<Character>('find-character', { id: characterId }, false, {
+        throwOnFailure: true,
+      });
       if (!active) return;
-      const recovery = replay.recovery ?? (replay.status === 'retained' ? replay.body : undefined);
-      if (recovery) {
-        showCharacterRecovery(characterId, recovery);
-      }
-      const dbCharacter = await makeRequest<Character>('find-character', { id: characterId });
-      if (!active) return;
-      loadedActorRef.current = sessionActorId;
-      if (dbCharacter && replay.status === 'needs-calculation') {
-        needsCalculationRef.current = true;
-        const merged = mergeCharacterOnConflict(replay.base, replay.body, dbCharacter);
-        handleFetchedCharacter(dbCharacter, merged.character);
-        if (merged.conflicts.length > 0) {
-          // Retain the common ancestor so navigation cannot silently approve the conflict.
-          lastSyncedRef.current = { ...dbCharacter, ...replay.base };
-          offerConflictResolution(merged.character, dbCharacter, merged.conflicts);
-        }
-      } else {
+      if (!dbCharacter) {
         handleFetchedCharacter(dbCharacter);
+        return;
       }
-      if (dbCharacter) setLoadedIdentity({ id: characterId, actor: sessionActorId });
+      loadedActorRef.current = sessionActorId;
+      const restored = sessionActorId ? loadBufferedCharacterSaves(characterId, sessionActorId) : null;
+      let displayed = dbCharacter;
+      const conflicts: string[] = [];
+      if (restored?.status === 'loaded') {
+        const copies = restored.retained.flatMap((record) => (record.body ? [record.body] : []));
+        if (copies.length) showCharacterRecovery(characterId, copies.length === 1 ? copies[0] : { copies });
+        for (const record of restored.records) {
+          const draft = record.draft;
+          if (!draft.base || !draft.body.expected_updated_at) {
+            showCharacterRecovery(characterId, draft.body);
+            continue;
+          }
+          const merged = mergeCharacterSave(draft.base, draft.body, displayed, draft.submission?.body);
+          displayed = merged.character;
+          conflicts.push(...merged.conflicts);
+          needsCalculationRef.current ||= !!draft.requiresCalculation;
+          recoveredDraftsRef.current.push(record);
+        }
+      } else if (restored?.status === 'unavailable') setDraftStored(false);
+      handleFetchedCharacter(dbCharacter, displayed);
+      if (conflicts.length) {
+        // Original records remain available until the user resolves the conflict.
+        const firstBase = recoveredDraftsRef.current[0]?.draft.base;
+        if (firstBase) lastSyncedRef.current = { ...dbCharacter, ...firstBase };
+        offerConflictResolution(displayed, dbCharacter, [...new Set(conflicts)]);
+      } else if (sessionActorId) {
+        if (recoveredDraftsRef.current.length) {
+          const reconciled = reconcileBufferedCharacterSave(displayed, sessionActorId, dbCharacter, {
+            requiresCalculation: needsCalculationRef.current,
+          });
+          setDraftStored(reconciled.status !== 'unavailable');
+        }
+        if (SAVED_CHARACTER_FIELDS.every((field) => characterSaveValuesEqual(displayed[field], dbCharacter[field])))
+          acknowledgeRecoveredDrafts();
+      }
+      setLoadedIdentity({ id: characterId, actor: sessionActorId });
     })().catch((error: unknown) => {
       if (!active) return;
       console.error('Could not load character:', error);
-      showNotification({
-        id: 'character-load-failed',
-        title: 'Could not load character',
-        message: 'Please reload to try again.',
-        color: 'red',
-      });
+      setLoadError(true);
+      if (options.type === 'EXECUTE_OPS') options.data.onFinishLoading();
     });
+    const retryLoadOnReconnect = () => {
+      if (active && !loadedActorRef.current) setLoadAttempt((attempt) => attempt + 1);
+    };
+    window.addEventListener('online', retryLoadOnReconnect);
     return () => {
       active = false;
       saveScopeRef.current = scope + 1;
+      clearSaveRetry();
+      window.removeEventListener('online', retryLoadOnReconnect);
       hideNotification(recoveryNoticeId);
+      hideNotification('character-save-failed');
     };
-  }, [characterId, sessionActorId, handleFetchedCharacter, offerConflictResolution]);
+  }, [characterId, sessionActorId, loadAttempt, handleFetchedCharacter, offerConflictResolution]);
 
   // Execute operations
   const [operationResults, setOperationResults] = useState<OperationCharacterResultPackage>();
@@ -308,7 +382,6 @@ export default function useCharacter(
   const [operationAttempt, setOperationAttempt] = useState(0);
 
   const [debouncedCharacter] = useDebouncedValue(character, 800);
-  const setCharacterDebounced = useDebouncedCallback(setCharacter, 800);
 
   const getUpdateHash = (c: Character | null | undefined) => {
     return hashData(
@@ -399,9 +472,9 @@ export default function useCharacter(
     if (options.type !== 'EXECUTE_OPS') return;
     if (!debouncedCharacter) return;
     if (signal.aborted) return;
-    // Debounced callbacks must check freshness again when the setter actually runs.
+    // React batches functional updates without discarding earlier completion steps.
     const commitCharacter: SetterOrUpdater<Character | null> = (update) => {
-      setCharacterDebounced((previous) => {
+      setCharacter((previous) => {
         if (signal.aborted || previous?.id !== debouncedCharacter.id) return previous;
         return typeof update === 'function' ? update(previous) : update;
       });
@@ -436,38 +509,26 @@ export default function useCharacter(
     // Apply conditions after everything else
     applyConditions('CHARACTER', debouncedCharacter.details?.conditions ?? []);
 
-    if (debouncedCharacter.meta_data?.reset_hp !== false) {
-      // To reset hp, we need to confirm health
-
-      const handleRestHP = () => {
-        if (signal.aborted) return;
-        const { classHp } = getHealthValueParts('CHARACTER');
-        const maxHealth = getFinalHealthValue('CHARACTER');
-        // Don't clear reset_hp until the character has class HP - otherwise ancestry-only HP
-        // gets locked in before the class is selected, resulting in a too-low starting HP.
-        confirmHealth(
-          `${maxHealth}`,
-          maxHealth,
-          debouncedCharacter,
-          convertToSetEntity(commitCharacter),
-          classHp === 0
-        );
-      };
-
-      // We run it twice for it to break out of the debouncing lock (not a perfect solution, but works)
-      handleRestHP();
-      const hpTimer = setTimeout(handleRestHP, 1000);
-      signal.addEventListener('abort', () => clearTimeout(hpTimer), { once: true });
-    } else {
-      // Because of the drained condition, let's confirm health
+    // Normalize the latest HP inside the functional update. A slow calculation
+    // must not overwrite damage/healing entered after its original snapshot.
+    commitCharacter((previous) => {
+      if (!previous) return previous;
+      const { classHp } = getHealthValueParts('CHARACTER');
       const maxHealth = getFinalHealthValue('CHARACTER');
+      const resetHealth = previous.meta_data?.reset_hp !== false;
+      let normalized: Character | null = previous;
+      const retainHealth: SetterOrUpdater<Character | null> = (update) => {
+        normalized = typeof update === 'function' ? update(previous) : update;
+      };
       confirmHealth(
-        `${debouncedCharacter.hp_current}`,
+        `${resetHealth ? maxHealth : previous.hp_current}`,
         maxHealth,
-        debouncedCharacter,
-        convertToSetEntity(commitCharacter)
+        previous,
+        convertToSetEntity(retainHealth),
+        resetHealth && classHp === 0
       );
-    }
+      return normalized;
+    });
 
     // Save calculated stats
     saveCalculatedStats('CHARACTER', debouncedCharacter, convertToSetEntity(commitCharacter));
@@ -498,22 +559,27 @@ export default function useCharacter(
         executingOperations.current === null &&
         !operationError &&
         !!operationResults &&
-        currentOperationsHash === debouncedOperationsHash &&
+        getUpdateHash(characterRef.current) === debouncedOperationsHash &&
         !!options.data.content);
 
   const canPersistRef = useRef(canPersist);
   canPersistRef.current = canPersist;
 
-  useAutoSave(characterId, () => ({
-    character: characterRef.current,
-    base: lastSyncedRef.current,
-    actorId: loadedActorRef.current,
-    // Retain raw inputs locally through navigation even while their derived state
-    // is waiting or failed. The flag prevents automatic server replay.
-    canBuffer: !readOnlyRef.current && loadedActorRef.current === sessionActorId,
-    requiresCalculation:
-      saveConflictRef.current || (!canPersist() && (needsCalculationRef.current || options.type === 'EXECUTE_OPS')),
-  }));
+  useAutoSave(
+    characterId,
+    () => ({
+      character: characterRef.current,
+      base: lastSyncedRef.current,
+      actorId: loadedActorRef.current,
+      // Retain raw inputs locally through navigation even while their derived state
+      // is waiting or failed. The flag prevents automatic server replay.
+      canBuffer: !readOnlyRef.current && loadedActorRef.current === sessionActorId,
+      forceBuffer: savingRef.current || !!uncertainSaveRef.current,
+      requiresCalculation:
+        saveConflictRef.current || (!canPersist() && (needsCalculationRef.current || options.type === 'EXECUTE_OPS')),
+    }),
+    setDraftStored
+  );
 
   useEffect(() => {
     if (!operationError || !loadedActorRef.current) return;
@@ -531,16 +597,40 @@ export default function useCharacter(
   // A successful calculation can release an edit that was waiting for derived values.
   useDidUpdate(() => {
     if (!debouncedCharacter || !canPersist()) return;
-    if (SAVED_CHARACTER_FIELDS.every((field) => isEqual(debouncedCharacter[field], lastSyncedRef.current?.[field])))
+    if (
+      !savingRef.current &&
+      !uncertainSaveRef.current &&
+      SAVED_CHARACTER_FIELDS.every((field) =>
+        characterSaveValuesEqual(characterRef.current?.[field], lastSyncedRef.current?.[field])
+      )
+    )
       return;
-    mutateCharacter(debouncedCharacter);
+    if (characterRef.current) mutateCharacter(characterRef.current);
   }, [debouncedCharacter, isCalculating, operationError, operationResults, sessionActorId]);
   const { mutate: mutateCharacterRaw } = useMutation({
     mutationFn: async (save: QueuedCharacterSave) => {
       if (!isCurrentSave(save)) throw new Error('Character save scope changed');
+      const uncertain = uncertainSaveRef.current;
+      if (uncertain) {
+        // A timeout can follow a committed write. Read and reconcile before another POST.
+        const remote = await makeRequest<Character>('find-character', { id: save.character.id }, false, {
+          expectedActorId: save.actorId,
+          throwOnFailure: true,
+        });
+        if (!remote) throw new Error('Could not recover character save');
+        return {
+          expected_updated_at: uncertain.expectedUpdatedAt,
+          submitted: uncertain.submitted,
+          forbidden: false,
+          conflict: true,
+          server: remote,
+        };
+      }
       const expected_updated_at = lastSyncedRef.current?.updated_at;
       if (!expected_updated_at) throw new Error('Reload the character to recover its save version');
       const data = Object.fromEntries(SAVED_CHARACTER_FIELDS.map((field) => [field, save.character[field]]));
+      uncertainSaveRef.current = { submitted: data, expectedUpdatedAt: expected_updated_at };
+      journalCharacterSaveSubmission(save.character.id, save.actorId, data, expected_updated_at);
       const resData = await makeRequest(
         'update-character',
         {
@@ -548,7 +638,7 @@ export default function useCharacter(
           ...data,
           ...(expected_updated_at ? { expected_updated_at } : {}),
         },
-        true,
+        false,
         { expectedActorId: save.actorId }
       );
       const request = { expected_updated_at, submitted: data };
@@ -577,10 +667,14 @@ export default function useCharacter(
     },
     onSuccess: (result, save) => {
       if (!result || !isCurrentSave(save)) return;
+      uncertainSaveRef.current = null;
+      clearSaveRetry();
+      setSavePhase('idle');
       if (result.forbidden) {
         // View-only session (e.g. a public sheet). Stop auto-saving entirely —
         // nothing we send will ever be accepted, and retrying just spams the API.
         readOnlyRef.current = true;
+        hideNotification('character-save-failed');
         pendingSaveRef.current = null;
         console.warn('Character is view-only for this session; auto-save disabled.');
         return;
@@ -595,8 +689,8 @@ export default function useCharacter(
         // merging below, so the next save uses the current token).
         const base = lastSyncedRef.current;
         lastSyncedRef.current = remote;
-        conflictStreakRef.current += 1;
-        const merge = mergeCharacterOnConflict(base, characterRef.current, remote);
+        if (remote.updated_at !== result.expected_updated_at) conflictStreakRef.current += 1;
+        const merge = mergeCharacterSave(base, characterRef.current, remote, result.submitted);
         const merged = merge.character;
         if (merge.conflicts.length > 0 || conflictStreakRef.current >= MAX_CONFLICT_STREAK) {
           lastSyncedRef.current = base;
@@ -614,19 +708,24 @@ export default function useCharacter(
         const changed =
           !characterRef.current ||
           SAVED_CHARACTER_FIELDS.some(
-            (field) => !isEqual((merged as any)[field], (characterRef.current as any)[field])
+            (field) => !characterSaveValuesEqual((merged as any)[field], (characterRef.current as any)[field])
           );
-        const needsSave = SAVED_CHARACTER_FIELDS.some((field) => !isEqual(merged[field], remote[field]));
+        const needsSave = SAVED_CHARACTER_FIELDS.some(
+          (field) => !characterSaveValuesEqual(merged[field], remote[field])
+        );
+        const reconciled = reconcileBufferedCharacterSave(merged, save.actorId, remote, {
+          requiresCalculation:
+            options.type === 'EXECUTE_OPS' &&
+            (!canPersistRef.current() || getUpdateHash(merged) !== debouncedOperationsHash),
+        });
+        setDraftStored(reconciled.status !== 'unavailable');
+        characterRef.current = merged;
         if (needsSave) {
           pendingSaveRef.current = { ...save, character: merged };
         } else {
-          acknowledgeBufferedCharacterSave(
-            save.character.id,
-            save.actorId,
-            Object.fromEntries(SAVED_CHARACTER_FIELDS.map((field) => [field, remote[field]])),
-            result.expected_updated_at,
-            remote.updated_at
-          );
+          retryCountRef.current = 0;
+          hideNotification('character-save-failed');
+          acknowledgeRecoveredDrafts();
         }
         if (!changed) return;
         setCharacter(merged);
@@ -639,6 +738,8 @@ export default function useCharacter(
       } else if (result.server) {
         // Record the authoritative post-write state (incl. the new updated_at token).
         conflictStreakRef.current = 0;
+        retryCountRef.current = 0;
+        hideNotification('character-save-failed');
         lastSyncedRef.current = result.server;
         acknowledgeBufferedCharacterSave(
           save.character.id,
@@ -647,6 +748,7 @@ export default function useCharacter(
           result.expected_updated_at,
           result.server.updated_at
         );
+        acknowledgeRecoveredDrafts();
         console.log('> Fetched updated character: #', getUpdateHash(character), 'vs.', getUpdateHash(result.server));
       }
     },
@@ -654,25 +756,43 @@ export default function useCharacter(
       if (!isCurrentSave(save)) return;
       console.error('Character save failed:', error);
       reportClientFailure('save_failed');
-      // If the real cause is a dead session, that persistent notification already
-      // explains it; a generic "check your connection" toast would just confuse.
-      if (hasSessionExpiredNotice()) return;
-      showNotification({
-        id: 'character-save-failed',
-        icon: <IconAlertCircle />,
-        title: 'Failed to save character',
-        message: 'Your changes could not be saved. Please check your connection and try again.',
-        color: 'red',
-        autoClose: 5000,
-      });
+      setSavePhase('failed');
+      if (!hasSessionExpiredNotice() && retryCountRef.current === 0)
+        showNotification({
+          id: 'character-save-failed',
+          title: 'Changes not synced',
+          message: (
+            <Group gap='xs'>
+              <Text size='sm'>Retrying automatically.</Text>
+              <Button size='compact-xs' variant='light' onClick={() => retrySaveRef.current()}>
+                Retry now
+              </Button>
+            </Group>
+          ),
+          color: 'yellow',
+          autoClose: false,
+          withCloseButton: true,
+          closeButtonProps: { 'aria-label': 'Dismiss save notice' },
+        });
+      // The persistent inline state stays visible until an actual acknowledgement.
+      // A bounded backoff also recovers when a flaky network never fires `online`.
+      clearSaveRetry();
+      if (!hasSessionExpiredNotice()) {
+        const delay = Math.min(30000, 2000 * 2 ** Math.min(retryCountRef.current++, 4));
+        retryTimerRef.current = setTimeout(() => {
+          retryTimerRef.current = null;
+          retrySaveRef.current();
+        }, delay);
+      }
     },
     onSettled: (_result, _error, save) => {
       if (!isCurrentSave(save)) return;
       // Once the in-flight save resolves, flush the latest pending snapshot (if any).
       const next = pendingSaveRef.current;
       pendingSaveRef.current = null;
-      if (next && canPersistRef.current()) {
-        mutateCharacterRaw(next);
+      if (!_error && next && canPersistRef.current()) {
+        setSavePhase('saving');
+        mutateCharacterRaw({ ...next, character: characterRef.current ?? next.character });
       } else {
         savingRef.current = false;
       }
@@ -687,39 +807,61 @@ export default function useCharacter(
       pendingSaveRef.current = save;
       return;
     }
+    clearSaveRetry();
     savingRef.current = true;
+    setSavePhase('saving');
     mutateCharacterRaw(save);
   };
 
-  // Poll remote character updates - only if the character hasn't been updated recently
-  const [lDebouncedCharacter] = useDebouncedValue(character, 5000);
-  const notRecentlyUpdated = !!(
-    executingOperations.current === null &&
-    lDebouncedCharacter &&
-    isEqual(lDebouncedCharacter, character) &&
-    isEqual(debouncedCharacter, character)
-  );
-  useQuery({
-    queryKey: [`find-character-polling-updates-${characterId}`],
-    queryFn: async () => {
-      const polledCharacter = await makeRequest<Character>('find-character', {
-        id: characterId,
-      });
+  retrySaveRef.current = () => {
+    const current = characterRef.current;
+    if (!current || savingRef.current || !canPersistRef.current() || hasSessionExpiredNotice()) return;
+    if (
+      !uncertainSaveRef.current &&
+      SAVED_CHARACTER_FIELDS.every((field) => characterSaveValuesEqual(current[field], lastSyncedRef.current?.[field]))
+    )
+      return;
+    mutateCharacter(current);
+  };
+  useEffect(() => {
+    const wake = () => {
+      setIsOnline(typeof navigator === 'undefined' || navigator.onLine !== false);
+      retrySaveRef.current();
+    };
+    const offline = () => setIsOnline(false);
+    const visible = () => {
+      if (document.visibilityState === 'visible') wake();
+    };
+    window.addEventListener('online', wake);
+    window.addEventListener('focus', wake);
+    window.addEventListener('offline', offline);
+    document.addEventListener('visibilitychange', visible);
+    return () => {
+      clearSaveRetry();
+      window.removeEventListener('online', wake);
+      window.removeEventListener('focus', wake);
+      window.removeEventListener('offline', offline);
+      document.removeEventListener('visibilitychange', visible);
+    };
+  }, [characterId, sessionActorId]);
 
-      if (notRecentlyUpdated && Object.keys(getDeepDiff(character, polledCharacter)).length > 0) {
-        showNotification({
-          icon: <IconRefresh />,
-          title: `Updating character...`,
-          message: `Received a remote update`,
-          autoClose: 1500,
-        });
-        setCharacter(polledCharacter);
-      }
-      return polledCharacter;
-    },
-    refetchInterval: 1000,
-    enabled: false, // notRecentlyUpdated, Fix polling on char item update
-  });
+  const hasPendingChanges =
+    !!uncertainSaveRef.current ||
+    !character ||
+    SAVED_CHARACTER_FIELDS.some((field) => !characterSaveValuesEqual(character[field], lastSyncedRef.current?.[field]));
+  const saveState: CharacterSaveState = readOnlyRef.current
+    ? 'read-only'
+    : saveConflictRef.current
+      ? 'conflict'
+      : !isOnline && hasPendingChanges
+        ? 'offline'
+        : savePhase === 'failed'
+          ? 'failed'
+          : savePhase === 'saving'
+            ? 'saving'
+            : hasPendingChanges
+              ? 'pending'
+              : 'saved';
 
   const isFinished =
     hasLoadedCharacter &&
@@ -733,7 +875,12 @@ export default function useCharacter(
   return {
     character,
     setCharacter,
-    isLoading: !isFinished && !operationError,
+    isLoading: !isFinished && !operationError && !loadError,
+    saveState,
+    draftStored,
+    retrySave: () => retrySaveRef.current(),
+    loadError,
+    retryLoad: () => setLoadAttempt((attempt) => attempt + 1),
     results: operationResults ?? null,
     operationError,
     isCalculating,
@@ -746,19 +893,27 @@ type AutoSaveSnapshot = {
   base: Character | null;
   actorId: string | null;
   canBuffer: boolean;
+  forceBuffer: boolean;
   requiresCalculation: boolean;
 };
 
 /** Buffer eligible changes during editing and synchronously on pagehide or navigation. */
-function useAutoSave(characterId: number, getSnapshot: () => AutoSaveSnapshot): void {
+function useAutoSave(
+  characterId: number,
+  getSnapshot: () => AutoSaveSnapshot,
+  onStorage: (stored: boolean) => void
+): void {
   const snapshotRef = useRef(getSnapshot);
   snapshotRef.current = getSnapshot;
 
   const saveImmediately = useCallback(() => {
-    const { character: current, base, actorId, canBuffer, requiresCalculation } = snapshotRef.current();
+    const { character: current, base, actorId, canBuffer, forceBuffer, requiresCalculation } = snapshotRef.current();
     if (!canBuffer || !actorId || !current || current.id !== characterId || base?.id !== characterId) return;
     // Loading the remote row must not replace a retained local recovery copy.
-    if (SAVED_CHARACTER_FIELDS.every((field) => isEqual(current[field], base[field]))) {
+    if (
+      !forceBuffer &&
+      SAVED_CHARACTER_FIELDS.every((field) => characterSaveValuesEqual(current[field], base[field]))
+    ) {
       if (!requiresCalculation) {
         acknowledgeBufferedCharacterSave(
           current.id,
@@ -771,8 +926,9 @@ function useAutoSave(characterId: number, getSnapshot: () => AutoSaveSnapshot): 
       }
       return;
     }
-    bufferCharacterSave(current, actorId, base.updated_at, { requiresCalculation, base });
-  }, [characterId]);
+    const buffered = bufferCharacterSave(current, actorId, base.updated_at, { requiresCalculation, base });
+    onStorage(buffered.status === 'stored');
+  }, [characterId, onStorage]);
 
   // Preserve inputs before auth events or navigation can unmount the editor.
   // Pending derived values stay local until the next successful calculation.


### PR DESCRIPTION
Character saves could stop after a connection failure, lose newer intent after an ambiguous response, or remain pending after the server accepted JSON-normalized data. The editor now retains separate drafts per account and browser page, reconciles uncertain writes through its existing serialized queue, retries after failures/reconnects, and distinguishes server-confirmed saves from local drafts. Initial load failures offer retry. Calculation completion preserves every update and normalizes the latest HP instead of overwriting newer damage or healing.

Skill progression now resolves grants and increases at their earned levels. Earlier increases cannot be counted again after Skill Mastery or later leveling; historical selectors stay usable. Medic's conditional Battle Medicine text observes its rank grant. Removal, repeated selections, level gates and creature stores share the same progression path.

Validation:
- All 18 Cypress scenarios passed against the built app and local Docker API, including dropped writes, a committed response exceeding the 30-second timeout, and prepared spells surviving failed saves and reopening at phone width with 4× CPU throttling.
- 83 rules tests and 84 save/recovery tests passed, including official Rogue/Investigator Skill Mastery and Medic rows, repeated rebuilds, removal/regrant, account/tab isolation, storage exhaustion and HP calculation races.
- Build/typecheck passed; lint has zero errors and 69 warnings. Release tests (8) and local inventory gate passed. Docs have no broken links; the existing OpenAPI configuration warning remains.
- Desktop/mobile screenshots inspected. Browser simulation does not establish behavior during physical iOS/Android process eviction.

This changes the frontend only. Production function/schema compatibility is checked before merging; Render automatically deploys main. Content prerequisite cleanup remains separate from these engine fixes.

Release verification completed for commit `0f4d09dea79abe16ce71e2286d530681377e1b2b`: all 55 deployed functions, 134 schema objects and seven migration-effect checks match. GitHub CI passed, including 54 API tests and all 18 Cypress scenarios in Chrome. Read-only production homepage/search/drawer smoke passed on desktop and phone-width layouts before promotion.
