### PR TITLE
Restore reliable campaign updates and preserve concurrent edits

### DIFF
--- a/docs/api-reference/authentication.mdx
+++ b/docs/api-reference/authentication.mdx
@@ -208,6 +208,15 @@ character page offers **Download saved copy**. Its recovery copy remains availab
 across reloads, even after subsequent edits save successfully. Signed-out viewers and
 sessions identified as read-only do not create buffered writes.
 
+Live character reads run every five seconds while the page is visible, and refresh on
+focus or reconnect. Their account, route, starting server version and write revision
+are checked before applying a response. Reads arriving during an unresolved write are
+ignored; save recovery performs the authoritative reconciliation. A successful incoming
+merge updates the baseline first, so only remaining local edits or changed calculated
+stats can produce a guarded save. Same-field conflicts pause incoming reconciliation
+and writes until the user resolves them. Public viewers can receive updates without
+creating drafts or write attempts.
+
 Inputs changed during a pending or failed calculation remain local with a requirement
 to recalculate. Navigating between builder and sheet restores those inputs using their
 last-synced base and the latest server row, preserving unrelated remote changes. The

--- a/docs/development.mdx
+++ b/docs/development.mdx
@@ -156,7 +156,9 @@ Run request recovery, buffered character saves, and worker lifecycle regressions
 `npm --prefix frontend run test:infra`. These exercise the real request manager, save hook,
 and operation lifecycle with controlled authentication, network, storage, and worker
 boundaries. They require no running database or production credentials. CI runs these
-regression suites before the production build.
+regression suites before the production build. The content selector tests also exercise an
+already typed search while its catalog is still loading, and verify that removed sources
+or filtered choices disappear from search results without another keystroke.
 
 ## Creating a user
 
@@ -282,6 +284,21 @@ through the API as well as the UI. It uses only its own test characters. These s
 simulate flaky transport, constrained CPU and page lifecycle boundaries, not iOS/Android
 process eviction or a measured physical-device performance profile. The save-hook regressions also cover uncertain writes,
 intentional reversions, separate-tab drafts, storage exhaustion, and account changes.
+
+The encounter writer regressions run in `test:infra`. They exercise GM/player races,
+serialized HP edits, lost acknowledgements, narrow guarded writes, retained drafts,
+and failure/conflict responses. The encounter keeps unsynced edits visible and retries
+transport failures. Conflicting edits offer **Review changes**, which opens the sheet's
+existing recovery flow. Navigating away preserves its versioned local draft; the campaign
+does not automatically restore old drafts into encounter controls on a new visit.
+
+`campaigns/encounterSync.cy.ts` creates two confirmed synthetic accounts, joins a real
+campaign through its join-key API, and tests the actual GM HP control while the player
+updates the same character independently. It covers typing during polls, Enter/blur
+deduplication, nested player edits, failed reads/writes, retry, and mobile layout changes.
+Fixture tasks require `SERVICE_ROLE_KEY` in the Cypress Node process and refuse non-local
+HTTP origins. The key is never put in Cypress browser configuration; generated accounts
+send no email, and cleanup verifies their ownership and removal even after a failed run.
 
 The `characters/skillProgression.cy.ts` spec creates an official Fighter/Skill Mastery
 fixture through the local API, runs the real operations worker, and checks master Medicine

--- a/docs/guides/content-data.mdx
+++ b/docs/guides/content-data.mdx
@@ -39,6 +39,18 @@ server confirmation from a locally retained edit; reconnect and retry use one se
 save queue. Each browser page keeps its own recovery copy, so concurrent tabs cannot
 silently overwrite another tab's local draft.
 
+Open character pages check for remote edits every five seconds while visible and on
+reconnect or focus. Incoming edits advance the saved baseline before changing the
+editor, so polling cannot echo the same character back through autosave. A read started
+before a newer save, account change or route change cannot replace the current state.
+Failed reads leave the loaded sheet available. Remote edits use the same merge and
+conflict handling as save recovery.
+
+Incoming conditions and selections invalidate older calculations. If the reconciled
+character needs a different source set, the page loads that exact package before
+calculating or saving. This includes unsynced source choices restored from a draft;
+repeatedly loading the server's older sources would otherwise create a reload loop.
+
 Concurrent character edits merge at nested fields and stable entry IDs. Independent
 changes survive. When both writers change the same value, saving pauses and offers
 **Keep my edits**, **Use saved version**, and **Download my copy**. The local input and
@@ -49,6 +61,8 @@ Calculation completion applies every guarded state update; it does not debounce 
 updates into only the last one. Health normalization reads the latest HP when applying
 the result, so a slow calculation cannot replace newer damage or healing with an older
 clamped value. Input debouncing remains in place before running operations.
+HP initialization clears its reset flag even if the numeric HP already equals the
+maximum, so a later condition recalculation cannot heal newly received damage.
 
 ### Public vs. homebrew
 

--- a/frontend/cypress.config.ts
+++ b/frontend/cypress.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from 'cypress';
+import { registerCampaignFixtures } from './cypress/support/campaign-fixture';
 
 export default defineConfig({
   env: {
@@ -9,7 +10,7 @@ export default defineConfig({
     pageLoadTimeout: 120000,
     // defaultCommandTimeout: 25000,
     setupNodeEvents(on, config) {
-      // implement node event listeners here
+      registerCampaignFixtures(on, config);
     },
   },
 });

--- a/frontend/cypress/e2e/campaigns/encounterSync.cy.ts
+++ b/frontend/cypress/e2e/campaigns/encounterSync.cy.ts
@@ -1,0 +1,115 @@
+/** Independent authenticated GM/player accounts exercise the actual encounter controls and API. */
+type CampaignFixture = {
+  key: string;
+  campaignId: number;
+  characterId: number;
+  gm: { email: string; password: string };
+};
+
+describe('Campaign encounter synchronization', () => {
+  let fixture: CampaignFixture | undefined;
+  let campaignPolls = 0;
+  let failPolls = false;
+
+  beforeEach(() => {
+    fixture = undefined;
+    campaignPolls = 0;
+    failPolls = false;
+    cy.viewport(1280, 900);
+    cy.task<CampaignFixture>('campaignFixture:create', null, { log: false }).then((created) => {
+      fixture = created;
+      cy.login(created.gm.email, created.gm.password);
+      cy.intercept('POST', '**/functions/v1/find-character', (request) => {
+        if (request.body.campaign_id !== created.campaignId) return;
+        campaignPolls += 1;
+        if (failPolls) {
+          request.alias = 'failedCampaignPoll';
+          request.reply({ statusCode: 503, body: { status: 'error', message: 'Simulated weak connection' } });
+        }
+      });
+      cy.visit(`/campaign/${created.campaignId}`);
+      cy.contains('button[role="tab"]', /^Encounters$/, { timeout: 30000 }).click();
+      cy.get('input[placeholder="HP"]', { timeout: 30000 }).should('have.value', '20');
+    });
+  });
+
+  afterEach(() => {
+    if (fixture) cy.task('campaignFixture:cleanup', fixture.key, { log: false });
+  });
+
+  const readPlayer = () => cy.task<any>('campaignFixture:read', fixture!.key, { log: false });
+
+  it('keeps typed HP through fresh player polls, preserves player details, and sends one Enter/blur write', () => {
+    let writes = 0;
+    cy.intercept('POST', '**/functions/v1/update-character', (request) => {
+      if (request.body.id !== fixture!.characterId) return;
+      writes += 1;
+      request.alias = 'gmSave';
+    });
+    cy.get('input[placeholder="HP"]').clear().should('have.value', '').type('18');
+    cy.task('campaignFixture:playerUpdate', { key: fixture!.key, appearance: 'Updated by the player' }, { log: false });
+    cy.then(() => {
+      const previousPolls = campaignPolls;
+      cy.wrap(null, { timeout: 15000 }).should(() => expect(campaignPolls).to.be.greaterThan(previousPolls));
+    });
+    cy.get('input[placeholder="HP"]').should('have.value', '18').type('{enter}');
+    cy.wait('@gmSave').then(({ request, response }) => {
+      expect(response?.body.status).to.eq('success');
+      expect(response?.body.data[0].hp_current).to.eq(18);
+      expect(Object.keys(request.body).sort()).to.deep.equal(['expected_updated_at', 'hp_current', 'id']);
+    });
+    readPlayer().then((character) => {
+      expect(character.hp_current).to.eq(18);
+      expect(character.details.info.appearance).to.eq('Updated by the player');
+    });
+    cy.then(() => {
+      const previousPolls = campaignPolls;
+      cy.wrap(null, { timeout: 15000 }).should(() => expect(campaignPolls).to.be.at.least(previousPolls + 2));
+    });
+    cy.then(() => expect(writes).to.eq(1));
+    cy.get('input[placeholder="HP"]').should('have.value', '18');
+    cy.screenshot('campaign-gm-confirmed-desktop');
+  });
+
+  it('retains unsynced GM HP through failed polls and mobile layout changes, then retries successfully', () => {
+    let disrupted = true;
+    cy.intercept('POST', '**/functions/v1/update-character', (request) => {
+      if (request.body.id !== fixture!.characterId) return;
+      if (disrupted) {
+        request.alias = 'failedGmSave';
+        request.reply({ statusCode: 503, body: { status: 'error', message: 'Simulated weak connection' } });
+      } else request.alias = 'recoveredGmSave';
+    });
+    cy.get('input[placeholder="HP"]').clear().should('have.value', '').type('16{enter}');
+    cy.wait('@failedGmSave');
+    cy.contains('Not synced: retrying automatically', { timeout: 15000 }).should('be.visible');
+    cy.then(() => {
+      failPolls = true;
+    });
+    cy.wait('@failedCampaignPoll', { timeout: 15000 });
+    cy.get('input[placeholder="HP"]').should('have.value', '16');
+    cy.contains('Connection test player').should('be.visible');
+    readPlayer().its('hp_current').should('eq', 20);
+    cy.screenshot('campaign-gm-unsynced-desktop');
+
+    cy.viewport(390, 844);
+    cy.get('button[aria-label="Panel Grid"]').click();
+    cy.contains('button', /^Encounters$/).click();
+    cy.contains('Not synced: retrying automatically', { timeout: 10000 }).should('be.visible');
+    cy.contains('button', 'Retry now').scrollIntoView();
+    cy.document().should((document) => {
+      expect(document.documentElement.scrollWidth).to.be.at.most(document.documentElement.clientWidth);
+    });
+    cy.screenshot('campaign-gm-unsynced-mobile');
+    cy.then(() => {
+      disrupted = false;
+      failPolls = false;
+    });
+    cy.contains('button', 'Retry now').click();
+    cy.wait('@recoveredGmSave', { timeout: 15000 }).its('response.body.status').should('eq', 'success');
+    cy.contains('Not synced: retrying automatically').should('not.exist');
+    readPlayer().its('hp_current').should('eq', 16);
+    cy.viewport(1280, 900);
+    cy.get('input[placeholder="HP"]', { timeout: 10000 }).should('have.value', '16');
+  });
+});

--- a/frontend/cypress/e2e/characters/connectionRecovery.cy.ts
+++ b/frontend/cypress/e2e/characters/connectionRecovery.cy.ts
@@ -122,7 +122,7 @@ describe('Interrupted character saves', () => {
   it('recovers prepared spells after interruption and reopening at phone width', () => {
     cy.get('input[placeholder="Unknown Wanderer"]').type('Mobile wizard recovery');
     cy.get('button[aria-label="Next Page"]').click();
-    cy.contains('Select an ancestry, background, and class to get started.').should('exist');
+    cy.contains('Select an ancestry, background, and class to get started.', { timeout: 30000 }).should('be.visible');
     cy.buildABC('Elf', 'Acolyte', 'Wizard');
     cy.get('button[aria-label="Next Page"]').click();
     cy.location('pathname').should('include', '/sheet');
@@ -145,7 +145,8 @@ describe('Interrupted character saves', () => {
       }
     });
     cy.get('[data-wg-name="prepared-wizard"]').contains('Manage').click();
-    cy.contains('Add Spell').click();
+    // The real catalog may take several seconds under 4x CPU throttling.
+    cy.contains('Add Spell').click({ timeout: 30000 });
     const chooseCharm = () => {
       cy.get('input[placeholder="Search spells"]').last().type('Charm');
       cy.get('input[placeholder="Search spells"]')

--- a/frontend/cypress/e2e/characters/preparedCaster.cy.ts
+++ b/frontend/cypress/e2e/characters/preparedCaster.cy.ts
@@ -17,15 +17,13 @@ describe('Character builder', () => {
 
     cy.get('input[placeholder="Unknown Wanderer"]', { timeout: 30000 }).type('Wizard 1');
     cy.get('button[aria-label="Next Page"]').click();
-    cy.wait(500);
-    cy.contains('Select an ancestry, background, and class to get started.').should('exist');
+    cy.contains('Select an ancestry, background, and class to get started.', { timeout: 30000 }).should('be.visible');
 
     cy.buildABC('Elf', 'Acolyte', 'Wizard');
 
     // Finished!
     cy.get('button[aria-label="Next Page"]').click();
-    cy.wait(500);
-    cy.location('pathname').should('include', '/sheet');
+    cy.location('pathname', { timeout: 30000 }).should('include', '/sheet');
   });
 
   after(() => {
@@ -44,36 +42,31 @@ describe('Character builder', () => {
   it('should cast only one prepared spell', () => {
     cy.contains('Spells').click();
 
-    cy.get('[data-wg-name="prepared-wizard"]').as('preparedSpells');
+    cy.get('[data-wg-name="prepared-wizard"]', { timeout: 30000 }).as('preparedSpells');
     cy.get('@preparedSpells').contains('Manage').click();
 
-    // Add charm to list
-    cy.contains('Add Spell').click();
-    cy.get('div.mantine-Modal-body').get('input[placeholder="Search spells"]').last().type('Charm');
-    cy.wait(300); // Wait to filter
-    cy.get('input[placeholder="Search spells"]')
-      .last()
-      .closest('.mantine-Modal-body')
-      .contains('button', /^Select$/)
-      .click();
+    const chooseCharm = () => {
+      cy.get('input[placeholder="Search spells"]').last().type('Charm');
+      cy.get('input[placeholder="Search spells"]')
+        .last()
+        .closest('.mantine-Modal-body')
+        .contains('p', /^Charm$/, { timeout: 30000 })
+        .parents('.mantine-Group-root')
+        .filter(':has(button)')
+        .first()
+        .contains('button', /^Select$/)
+        .click();
+    };
+
+    // Wait for real content readiness, including a cold catalog download.
+    cy.contains('Add Spell', { timeout: 30000 }).click({ timeout: 30000 });
+    chooseCharm();
 
     // Prepare charm twice
     cy.get('[data-wg-name="rank-1"]').contains('Select Spell').first().click();
-    cy.get('input[placeholder="Search spells"]').last().type('Charm');
-    cy.wait(300); // Wait to filter
-    cy.get('input[placeholder="Search spells"]')
-      .last()
-      .closest('.mantine-Modal-body')
-      .contains('button', /^Select$/)
-      .click();
+    chooseCharm();
     cy.get('[data-wg-name="rank-1"]').contains('Select Spell').first().click();
-    cy.get('input[placeholder="Search spells"]').last().type('Charm');
-    cy.wait(300); // Wait to filter
-    cy.get('input[placeholder="Search spells"]')
-      .last()
-      .closest('.mantine-Modal-body')
-      .contains('button', /^Select$/)
-      .click();
+    chooseCharm();
     cy.get('button.mantine-Modal-close').last().click();
 
     // Cast charm

--- a/frontend/cypress/e2e/characters/remoteUpdates.cy.ts
+++ b/frontend/cypress/e2e/characters/remoteUpdates.cy.ts
@@ -1,0 +1,189 @@
+/** Exercise live reads through the rendered editor, real operations worker, and local API. */
+describe('Incoming character updates', () => {
+  let characterId: number | undefined;
+  let token: string;
+  let actorId: string;
+
+  const request = (endpoint: string, body: Record<string, unknown>) =>
+    cy
+      .request({
+        method: 'POST',
+        url: `${Cypress.env('functions_url')}/${endpoint}`,
+        headers: { Authorization: `Bearer ${token}` },
+        body,
+        log: false,
+      })
+      .then(({ body: result }) => {
+        expect(result.status).to.eq('success');
+        return result.data;
+      });
+  const read = () => request('find-character', { id: characterId });
+
+  beforeEach(() => {
+    characterId = undefined;
+    cy.intercept('POST', '**/auth/v1/token*').as('signIn');
+    cy.login(Cypress.env('TEST_EMAIL'), Cypress.env('TEST_PASSWORD'));
+    cy.wait('@signIn').then(({ response }) => {
+      token = response?.body.access_token;
+      actorId = response?.body.user.id;
+      request('find-class', { id: 20 }).then((playerClass) => {
+        expect(playerClass.name).to.eq('Fighter');
+        request('create-character', {
+          name: 'Incoming update check',
+          level: 1,
+          details: { class: playerClass },
+          content_sources: { enabled: [1] },
+          inventory: { items: [] },
+          hp_current: 10,
+        }).then((created) => {
+          characterId = created.id;
+        });
+      });
+    });
+  });
+
+  afterEach(() => {
+    if (characterId && token) request('delete-content', { id: characterId, type: 'character' });
+  });
+
+  it('receives damage and conditions while open, without an autosave loop', () => {
+    cy.intercept('POST', '**/functions/v1/update-character').as('initialCalculationSave');
+    cy.visit(`/sheet/${characterId}`);
+    cy.contains('Hit Points', { timeout: 30000 }).should('be.visible');
+    cy.wait('@initialCalculationSave', { timeout: 30000 }).its('response.body.status').should('eq', 'success');
+    cy.get('[data-testid="character-save-status"]', { timeout: 30000 }).should('contain', 'Saved');
+    let writes = 0;
+    cy.intercept('POST', '**/functions/v1/update-character', (req) => {
+      writes++;
+      req.continue();
+    });
+    cy.intercept('POST', '**/functions/v1/find-character').as('poll');
+    // cy.request acts as another client; it bypasses browser interception and autosave.
+    read().then((base) =>
+      request('update-character', { id: characterId, expected_updated_at: base.updated_at, hp_current: 7 })
+    );
+    cy.contains('p', /^Hit Points$/)
+      .parent()
+      .contains('p', /^7$/, { timeout: 20000 })
+      .should('be.visible');
+    cy.wait('@poll', { timeout: 15000 });
+    cy.wait('@poll', { timeout: 15000 });
+    cy.then(() => expect(writes, 'incoming HP is already saved').to.eq(0));
+    read().then((base) =>
+      request('update-character', {
+        id: characterId,
+        expected_updated_at: base.updated_at,
+        details: {
+          ...base.details,
+          conditions: [
+            {
+              name: 'Frightened',
+              description: 'Remote condition integration fixture',
+              value: 1,
+              for_object: false,
+              for_creature: true,
+            },
+          ],
+        },
+      })
+    );
+    cy.contains('Frightened', { timeout: 20000 }).should('be.visible');
+    cy.get('[data-testid="character-save-status"]', { timeout: 20000 }).should('contain', 'Saved');
+    // One derived-stat save is allowed after applying the condition; repeated reads must settle.
+    cy.wait('@poll', { timeout: 15000 });
+    cy.wait('@poll', { timeout: 15000 });
+    cy.then(() => expect(writes, 'bounded recalculation after the condition').to.be.at.most(1));
+    cy.viewport(1280, 900);
+    cy.screenshot('incoming-campaign-condition-desktop');
+    cy.viewport(390, 844);
+    cy.screenshot('incoming-campaign-condition-mobile');
+    cy.document().then((doc) => expect(doc.documentElement.scrollWidth).to.be.at.most(doc.documentElement.clientWidth));
+    read().then((saved) => {
+      expect(saved.hp_current).to.eq(7);
+      expect(saved.details.conditions[0].name).to.eq('Frightened');
+    });
+  });
+
+  it('ignores a stale poll arriving after a newer local save', () => {
+    cy.visit(`/builder/${characterId}`);
+    cy.get('input[placeholder="Unknown Wanderer"]', { timeout: 30000 }).should('have.value', 'Incoming update check');
+    cy.get('[data-testid="character-save-status"]', { timeout: 15000 }).should('contain', 'Saved');
+    let held = false;
+    cy.intercept('POST', '**/functions/v1/find-character', (req) => {
+      if (!held) {
+        req.alias = 'staleRead';
+        req.continue((res) => {
+          held = true;
+          res.setDelay(5000);
+        });
+      } else req.continue();
+    });
+    cy.wrap(null, { timeout: 15000 }).should(() => expect(held).to.eq(true));
+    let writes = 0;
+    cy.intercept('POST', '**/functions/v1/update-character', (req) => {
+      writes++;
+      req.continue();
+    }).as('localSave');
+    cy.get('input[placeholder="Unknown Wanderer"]').clear().type('Newer accepted name');
+    cy.wait('@localSave', { timeout: 15000 }).its('response.body.status').should('eq', 'success');
+    cy.wait('@staleRead', { timeout: 15000 });
+    cy.get('input[placeholder="Unknown Wanderer"]').should('have.value', 'Newer accepted name');
+    cy.get('[data-testid="character-save-status"]').should('contain', 'Saved');
+    cy.then(() => expect(writes).to.eq(1));
+    read().its('name').should('eq', 'Newer accepted name');
+  });
+
+  it('reloads matching content after a remote source change and settles', () => {
+    cy.intercept('POST', '**/functions/v1/update-character').as('initialCalculationSave');
+    cy.visit(`/sheet/${characterId}`);
+    cy.contains('Hit Points', { timeout: 30000 }).should('be.visible');
+    cy.wait('@initialCalculationSave', { timeout: 30000 }).its('response.body.status').should('eq', 'success');
+    cy.get('[data-testid="character-save-status"]', { timeout: 30000 }).should('contain', 'Saved');
+    cy.intercept('POST', '**/functions/v1/find-character').as('poll');
+    read().then((base) =>
+      request('update-character', {
+        id: characterId,
+        expected_updated_at: base.updated_at,
+        content_sources: { enabled: [1, 256] },
+      })
+    );
+    cy.wait('@poll', { timeout: 15000 });
+    cy.wait('@poll', { timeout: 15000 });
+    cy.contains('Hit Points', { timeout: 30000 }).should('be.visible');
+    cy.get('[data-testid="character-save-status"]', { timeout: 30000 }).should('contain', 'Saved');
+    read().its('content_sources.enabled').should('deep.eq', [1, 256]);
+    cy.wait('@poll', { timeout: 15000 });
+    cy.contains('Hit Points').should('be.visible');
+    cy.contains("Couldn't calculate this character").should('not.exist');
+  });
+
+  it('reopens unsynced source choices against the older server package without a reload loop', () => {
+    read().then((base) => {
+      cy.intercept('POST', '**/functions/v1/update-character').as('recoveredSources');
+      cy.visit(`/sheet/${characterId}`, {
+        onBeforeLoad(win) {
+          const writerId = 'source-recovery-fixture';
+          win.localStorage.setItem(
+            `autosave-character-${characterId}-${actorId}:writer:${writerId}`,
+            JSON.stringify({
+              version: 2,
+              actorId,
+              writerId,
+              requiresCalculation: true,
+              base,
+              body: { ...base, expected_updated_at: base.updated_at, content_sources: { enabled: [1, 256] } },
+            })
+          );
+        },
+      });
+    });
+    cy.contains('Hit Points', { timeout: 30000 }).should('be.visible');
+    cy.wait('@recoveredSources', { timeout: 30000 }).its('response.body.status').should('eq', 'success');
+    cy.get('[data-testid="character-save-status"]', { timeout: 30000 }).should('contain', 'Saved');
+    read().its('content_sources.enabled').should('deep.eq', [1, 256]);
+    cy.reload();
+    cy.contains('Hit Points', { timeout: 30000 }).should('be.visible');
+    cy.get('[data-testid="character-save-status"]', { timeout: 30000 }).should('contain', 'Saved');
+    cy.contains('Conflicting character edits').should('not.exist');
+  });
+});

--- a/frontend/cypress/e2e/characters/saveRecovery.cy.ts
+++ b/frontend/cypress/e2e/characters/saveRecovery.cy.ts
@@ -71,6 +71,25 @@ describe('Buffered character recovery', () => {
     cy.login(Cypress.env('TEST_EMAIL'), Cypress.env('TEST_PASSWORD'));
     cy.visit(`/builder/${characterId}`);
     cy.get('input[placeholder="Unknown Wanderer"]', { timeout: 30000 }).should('have.value', 'Saved remote name');
+    let saves = 0;
+    let releaseSave: (() => void) | undefined;
+    cy.intercept('POST', '**/functions/v1/update-character', (req) => {
+      saves++;
+      if (saves === 1) {
+        expect(req.body.name).to.eq('My conflicting edit');
+        return new Promise<void>((resolve) => {
+          releaseSave = () => {
+            req.continue();
+            resolve();
+          };
+        });
+      }
+      req.continue();
+    });
+    cy.get('input[placeholder="Unknown Wanderer"]', { timeout: 30000 }).clear().type('My conflicting edit');
+    // Hold the local write while another device commits. Otherwise a live poll can
+    // legitimately receive the remote edit before typing starts, leaving no conflict.
+    cy.wrap(null).should(() => expect(releaseSave).to.be.a('function'));
     cy.request({
       method: 'POST',
       url: `${Cypress.env('functions_url')}/update-character`,
@@ -79,13 +98,8 @@ describe('Buffered character recovery', () => {
       log: false,
     })
       .its('body.status')
-      .should('eq', 'success');
-    let saves = 0;
-    cy.intercept('POST', '**/functions/v1/update-character', (req) => {
-      saves++;
-      req.continue();
-    });
-    cy.get('input[placeholder="Unknown Wanderer"]', { timeout: 30000 }).clear().type('My conflicting edit');
+      .should('eq', 'success')
+      .then(() => releaseSave!());
     cy.contains('Conflicting character edits', { timeout: 30000 }).should('be.visible');
     cy.viewport(1280, 900);
     cy.screenshot('save-conflict-desktop');

--- a/frontend/cypress/support/campaign-fixture.ts
+++ b/frontend/cypress/support/campaign-fixture.ts
@@ -1,0 +1,183 @@
+/** Node-only, localhost-only integration fixtures. No service credential enters the browser. */
+import { createClient } from '@supabase/supabase-js';
+import { randomUUID } from 'node:crypto';
+
+type Fixture = {
+  key: string;
+  users: Array<{ id: string; email: string }>;
+  campaignId?: number;
+  encounterId?: number;
+  characterId?: number;
+  gm?: { email: string; password: string; token: string };
+  playerToken?: string;
+};
+
+/** Register bounded synthetic GM/player setup and verified cleanup for the real API/browser tests. */
+export function registerCampaignFixtures(on: Cypress.PluginEvents, config: Cypress.PluginConfigOptions): void {
+  const fixtures = new Map<string, Fixture>();
+  const base = new URL(String(config.env.functions_url));
+  base.pathname = '/';
+  base.search = '';
+  base.hash = '';
+  const assertLocal = (): void => {
+    if (
+      !['localhost', '127.0.0.1', '[::1]'].includes(base.hostname) ||
+      base.protocol !== 'http:' ||
+      base.username ||
+      base.password
+    )
+      throw new Error('Campaign fixtures require a local HTTP Supabase origin');
+    if (!process.env.SERVICE_ROLE_KEY) throw new Error('Campaign fixtures require Node-only SERVICE_ROLE_KEY');
+  };
+  const admin = () => {
+    assertLocal();
+    return createClient(base.href, process.env.SERVICE_ROLE_KEY!, {
+      auth: { persistSession: false, autoRefreshToken: false },
+    });
+  };
+  const fixtureFor = (key: string): Fixture => {
+    const fixture = fixtures.get(key);
+    if (!fixture) throw new Error('Unknown synthetic campaign fixture');
+    return fixture;
+  };
+  const call = async (token: string, name: string, body: Record<string, unknown>): Promise<any> => {
+    assertLocal();
+    const response = await fetch(new URL(`functions/v1/${name}`, base), {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(30000),
+    });
+    const result = await response.json();
+    if (!response.ok || result.status !== 'success') throw new Error(`Synthetic campaign ${name} failed`);
+    return result.data;
+  };
+  const signIn = async (email: string, password: string): Promise<string> => {
+    assertLocal();
+    const response = await fetch(new URL('auth/v1/token?grant_type=password', base), {
+      method: 'POST',
+      headers: { apikey: process.env.SERVICE_ROLE_KEY!, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password }),
+      signal: AbortSignal.timeout(30000),
+    });
+    const result = await response.json();
+    if (!response.ok || typeof result.access_token !== 'string') throw new Error('Synthetic account login failed');
+    return result.access_token;
+  };
+  const cleanup = async (fixture: Fixture): Promise<void> => {
+    const client = admin();
+    // Verify the exact generated accounts before deleting anything owned by them.
+    for (const user of fixture.users) {
+      const { data, error } = await client.auth.admin.getUserById(user.id);
+      if (error || data.user.email !== user.email || !user.email.startsWith(`wg-campaign-${fixture.key}-`))
+        throw new Error('Synthetic campaign ownership verification failed');
+    }
+    for (const table of ['encounter', 'character', 'campaign']) {
+      const owners = fixture.users.map((user) => user.id);
+      if (!owners.length) continue;
+      // All records owned by these freshly generated accounts belong to this fixture,
+      // including a create response lost before its row ID could be retained.
+      const { error } = await client.from(table).delete().in('user_id', owners);
+      if (error) throw new Error(`Synthetic ${table} cleanup failed`);
+      const { data, error: readError } = await client.from(table).select('id').in('user_id', owners);
+      if (readError || data?.length) throw new Error(`Synthetic ${table} cleanup verification failed`);
+    }
+    for (const user of fixture.users) {
+      const { error } = await client.auth.admin.deleteUser(user.id);
+      if (error) throw new Error('Synthetic account cleanup failed');
+      const { data } = await client.auth.admin.getUserById(user.id);
+      if (data?.user) throw new Error('Synthetic account cleanup verification failed');
+    }
+    fixtures.delete(fixture.key);
+  };
+
+  on('task', {
+    async 'campaignFixture:create'() {
+      const client = admin();
+      const fixture: Fixture = { key: randomUUID(), users: [] };
+      fixtures.set(fixture.key, fixture);
+      try {
+        const password = randomUUID();
+        for (const role of ['gm', 'player']) {
+          const email = `wg-campaign-${fixture.key}-${role}@wanderersguide.test`;
+          const { data, error } = await client.auth.admin.createUser({
+            email,
+            password,
+            email_confirm: true,
+            user_metadata: { display_name: `Campaign ${role}` },
+          });
+          if (error || !data.user) throw new Error('Synthetic campaign account creation failed');
+          fixture.users.push({ id: data.user.id, email });
+          const token = await signIn(email, password);
+          if (role === 'gm') fixture.gm = { email, password, token };
+          else fixture.playerToken = token;
+        }
+        const campaign = await call(fixture.gm!.token, 'create-campaign', { name: 'Connection test campaign' });
+        fixture.campaignId = campaign.id;
+        await call(fixture.playerToken!, 'find-campaign', { join_key: campaign.join_key });
+        const character = await call(fixture.playerToken!, 'create-character', {
+          name: 'Connection test player',
+          level: 1,
+          campaign_id: fixture.campaignId,
+          hp_current: 20,
+          hp_temp: 0,
+          hero_points: 1,
+          stamina_current: 0,
+          resolve_current: 0,
+          details: { conditions: [], info: { appearance: 'Original appearance' } },
+          content_sources: { enabled: [1] },
+          inventory: { items: [], coins: { cp: 0, sp: 0, gp: 0, pp: 0 } },
+          meta_data: { reset_hp: false, calculated_stats: { hp_max: 20, ac: 10, profs: {} } },
+        });
+        fixture.characterId = character.id;
+        if (character.campaign_id !== fixture.campaignId) throw new Error('Synthetic player did not join its campaign');
+        const encounter = await call(fixture.gm!.token, 'create-encounter', {
+          name: 'Connection test encounter',
+          icon: 'combat',
+          color: 'blue',
+          campaign_id: fixture.campaignId,
+          combatants: { list: [{ _id: randomUUID(), type: 'CHARACTER', ally: true, character: fixture.characterId }] },
+          meta_data: { party_level: 1, party_size: 1 },
+        });
+        fixture.encounterId = encounter.id;
+        return {
+          key: fixture.key,
+          campaignId: fixture.campaignId,
+          characterId: fixture.characterId,
+          gm: { email: fixture.gm!.email, password },
+        };
+      } catch (error) {
+        await cleanup(fixture);
+        throw error;
+      }
+    },
+    async 'campaignFixture:playerUpdate'({ key, appearance, hp }: { key: string; appearance?: string; hp?: number }) {
+      const fixture = fixtureFor(key);
+      const character = await call(fixture.playerToken!, 'find-character', { id: fixture.characterId });
+      const result = await call(fixture.playerToken!, 'update-character', {
+        id: fixture.characterId,
+        expected_updated_at: character.updated_at,
+        ...(appearance === undefined
+          ? {}
+          : { details: { ...character.details, info: { ...character.details?.info, appearance } } }),
+        ...(hp === undefined ? {} : { hp_current: hp }),
+      });
+      if (!Array.isArray(result) || result[0]?.id !== fixture.characterId)
+        throw new Error('Synthetic player update was not confirmed');
+      return result[0];
+    },
+    async 'campaignFixture:read'(key: string) {
+      const fixture = fixtureFor(key);
+      return call(fixture.playerToken!, 'find-character', { id: fixture.characterId });
+    },
+    async 'campaignFixture:cleanup'(key: string) {
+      const fixture = fixtures.get(key);
+      if (fixture) await cleanup(fixture);
+      return null;
+    },
+  });
+  // A failed spec hook must not leave the generated accounts or campaign behind.
+  on('after:run', async () => {
+    for (const fixture of fixtures.values()) await cleanup(fixture);
+  });
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,7 @@
     "deploy": "gh-pages -d dist",
     "lint": "eslint src --ext ts,tsx --report-unused-disable-directives",
     "test:rules": "node --test scripts/feat-selection.test.mjs scripts/language-operations.test.mjs scripts/eidolon-runes.test.mjs scripts/item-drawers.test.mjs scripts/inventory-panel.test.mjs scripts/operation-removal.test.mjs scripts/skill-progression.test.mjs",
-    "test:infra": "node --test scripts/operation-lifecycle.test.mjs scripts/session-recovery.test.mjs scripts/character-save-lifecycle.test.mjs scripts/content-cache.test.mjs scripts/browser-recovery.test.mjs",
+    "test:infra": "node --test scripts/operation-lifecycle.test.mjs scripts/session-recovery.test.mjs scripts/character-save-lifecycle.test.mjs scripts/encounter-character-writer.test.mjs scripts/content-cache.test.mjs scripts/content-selection.test.mjs scripts/browser-recovery.test.mjs",
     "preview": "vite preview",
     "start:local": "vite",
     "build:local": "tsc && vite build",

--- a/frontend/scripts/character-save-lifecycle.test.mjs
+++ b/frontend/scripts/character-save-lifecycle.test.mjs
@@ -116,6 +116,23 @@ class HookHost {
       },
     };
   }
+  useQuery(options) {
+    const cell = this.useRef({});
+    this.remoteQuery = { options, cell };
+    return cell.current;
+  }
+  async poll() {
+    assert.ok(this.remoteQuery?.options.enabled, 'the loaded character accepts incoming remote reads');
+    const { options, cell } = this.remoteQuery;
+    try {
+      const data = await options.queryFn();
+      cell.current = { data };
+    } catch (error) {
+      cell.current = { ...cell.current, error };
+    }
+    this.dirty = true;
+    await this.flush();
+  }
   render() {
     harness = this;
     this.cursor = 0;
@@ -167,6 +184,7 @@ globalThis.__saveHooks = {
   useEffect: (fn, deps) => harness.useEffect(fn, deps),
   useDidUpdate: (fn, deps) => harness.useDidUpdate(fn, deps),
   useMutation: (options) => harness.useMutation(options),
+  useQuery: (options) => harness.useQuery(options),
   useAtom: () => [harness.character, harness.setCharacter],
   useAtomValue: () => harness.session,
   makeRequest: async (type, body, _notify, options) => {
@@ -195,7 +213,8 @@ const boundaries = {
   jotai: 'export const {useAtom,useAtomValue} = globalThis.__saveHooks;',
   '@mantine/hooks':
     'export const {useDidUpdate} = globalThis.__saveHooks; export const useDebouncedValue = value => [globalThis.__saveHooks.debounce(value)]; export const useDebouncedCallback = globalThis.__saveHooks.debounceCallback;',
-  '@tanstack/react-query': 'export const {useMutation} = globalThis.__saveHooks; export const useQuery = () => {};',
+  '@tanstack/react-query': 'export const {useMutation,useQuery} = globalThis.__saveHooks;',
+  '@constants/data': 'export const COMMON_CORE_ID = 3;',
   '@requests/request-manager':
     'export const {makeRequest} = globalThis.__saveHooks; export const hasSessionExpiredNotice = () => false;',
   '@mantine/notifications':
@@ -883,5 +902,246 @@ test('JSON-normalized save acknowledgements clear the draft and show Saved', asy
   await harness.flush();
   assert.equal(harness.value.saveState, 'saved');
   assert.equal(getBufferedCharacterSave(1, 'owner').status, 'none');
+  harness.unmount();
+});
+
+test('incoming campaign HP updates advance the server base without echoing a write', async () => {
+  let remote = { ...row(), hp_current: 20 };
+  harness.request = async (type) => {
+    assert.equal(type, 'find-character', 'receiving remote data must not send it back');
+    return structuredClone(remote);
+  };
+  harness.render();
+  await harness.flush();
+  remote = { ...remote, hp_current: 12, updated_at: 'version-2' };
+  await harness.poll();
+  assert.equal(harness.character.hp_current, 12);
+  for (let i = 0; i < 4; i++) await harness.poll();
+  assert.equal(harness.requests.filter(({ type }) => type === 'update-character').length, 0);
+  assert.equal(harness.value.saveState, 'saved');
+  harness.unmount();
+});
+
+test('a remote HP change merges with unsaved local notes and the single save uses the new version', async () => {
+  let remote = { ...row(), hp_current: 20, notes: { pages: [] } };
+  harness.request = async (type, body) => {
+    if (type === 'find-character') return structuredClone(remote);
+    assert.equal(body.expected_updated_at, 'version-2');
+    remote = { ...remote, ...body, updated_at: 'version-3' };
+    return [structuredClone(remote)];
+  };
+  harness.render();
+  await harness.flush();
+  harness.debouncedCharacter = harness.character;
+  harness.edit({ notes: { pages: [{ id: 'note', title: 'My local note' }] } });
+  await harness.flush();
+  remote = { ...remote, hp_current: 12, updated_at: 'version-2' };
+  await harness.poll();
+  assert.equal(harness.character.hp_current, 12);
+  assert.equal(harness.character.notes.pages[0].title, 'My local note');
+  harness.debouncedCharacter = harness.character;
+  harness.render();
+  await harness.flush();
+  for (let i = 0; i < 4; i++) await harness.poll();
+  assert.equal(harness.requests.filter(({ type }) => type === 'update-character').length, 1);
+  assert.equal(remote.hp_current, 12);
+  assert.equal(remote.notes.pages[0].title, 'My local note');
+  harness.unmount();
+});
+
+test('a delayed remote read cannot roll back a save accepted while that read was in flight', async () => {
+  harness.render();
+  await harness.flush();
+  const stale = deferred();
+  harness.request = async (type, body) =>
+    type === 'find-character' ? stale.promise : [{ ...row(), ...body, updated_at: 'version-3' }];
+  const polling = harness.poll();
+  await harness.flush();
+  harness.edit({ name: 'Newer saved name' });
+  await harness.flush();
+  stale.resolve({ ...row(), name: 'Older remote name', updated_at: 'version-2' });
+  await polling;
+  assert.equal(harness.character.name, 'Newer saved name');
+  assert.equal(harness.value.saveState, 'saved');
+  assert.equal(harness.requests.filter(({ type }) => type === 'update-character').length, 1);
+  harness.unmount();
+});
+
+test('incoming same-field conflicts preserve the draft and pause writes until a choice', async () => {
+  harness.render();
+  await harness.flush();
+  harness.debouncedCharacter = harness.character;
+  harness.edit({ name: 'My unsaved name' });
+  await harness.flush();
+  harness.request = async () => ({ ...row(), name: 'GM changed name', updated_at: 'version-2' });
+  await harness.poll();
+  assert.equal(harness.character.name, 'My unsaved name');
+  assert.equal(harness.value.saveState, 'conflict');
+  assert.equal(harness.requests.filter(({ type }) => type === 'update-character').length, 0);
+  assert.equal(getBufferedCharacterSave(1, 'owner').draft.body.name, 'My unsaved name');
+  assert.ok(harness.notices.some(({ id }) => id === 'character-conflict-1'));
+  harness.unmount();
+});
+
+test('failed incoming reads retain the current sheet and never redirect or write', async () => {
+  harness.render();
+  await harness.flush();
+  harness.request = async () => {
+    throw new Error('Connection unavailable');
+  };
+  await harness.poll();
+  assert.equal(harness.character.name, 'Character 1');
+  assert.equal(harness.value.loadError, false);
+  assert.equal(window.location.href, '');
+  assert.equal(harness.requests.filter(({ type }) => type === 'update-character').length, 0);
+  harness.unmount();
+});
+
+test('late remote reads cannot update a different account or character after navigation', async () => {
+  harness.render();
+  await harness.flush();
+  const stale = deferred();
+  harness.request = async (type, body) => (body.id === 1 ? stale.promise : row(body.id));
+  const polling = harness.poll();
+  await harness.flush();
+  harness.characterId = 2;
+  harness.session = { user: { id: 'next-owner' } };
+  harness.render();
+  await harness.flush();
+  stale.resolve({ ...row(), name: 'Wrong scope', updated_at: 'version-2' });
+  await polling;
+  assert.equal(harness.character.id, 2);
+  assert.equal(harness.character.name, 'Character 2');
+  assert.equal(harness.requests.filter(({ type }) => type === 'update-character').length, 0);
+  harness.unmount();
+});
+
+test('incoming conditions invalidate a slow calculation and settle without echoing the remote row', async () => {
+  let remote = row();
+  const calculations = [];
+  harness.options = {
+    type: 'EXECUTE_OPS',
+    data: { content: { items: [] }, context: 'CHARACTER-SHEET', onFinishLoading() {} },
+  };
+  harness.calculate = () => {
+    const pending = deferred();
+    calculations.push(pending);
+    return pending.promise;
+  };
+  harness.request = async (type) => {
+    assert.equal(type, 'find-character');
+    return structuredClone(remote);
+  };
+  harness.render();
+  await harness.flush();
+  assert.equal(calculations.length, 1);
+  remote = { ...remote, details: { conditions: [{ name: 'Frightened', value: 1 }] }, updated_at: 'version-2' };
+  await harness.poll();
+  assert.equal(calculations.length, 2);
+  calculations[0].resolve({ old: true });
+  await harness.flush();
+  assert.equal(harness.value.results, null);
+  calculations[1].resolve({ current: true });
+  await harness.flush();
+  for (let i = 0; i < 3; i++) await harness.poll();
+  assert.deepEqual(harness.value.results, { current: true });
+  assert.equal(harness.value.saveState, 'saved');
+  assert.equal(harness.requests.filter(({ type }) => type === 'update-character').length, 0);
+  harness.unmount();
+});
+
+test('initial HP already at maximum clears the reset flag so remote damage survives later conditions', async () => {
+  let remote = { ...row(), hp_current: 10, meta_data: {} };
+  let revision = 1;
+  harness.options = {
+    type: 'EXECUTE_OPS',
+    data: {
+      content: { items: [] },
+      context: 'CHARACTER-SHEET',
+      onFinishLoading() {},
+    },
+  };
+  harness.calculate = async () => ({});
+  harness.confirmHealth = actualConfirmHealth;
+  harness.request = async (type, body) => {
+    if (type === 'find-character') return structuredClone(remote);
+    remote = { ...remote, ...body, updated_at: `version-${++revision}` };
+    return [structuredClone(remote)];
+  };
+  harness.render();
+  await harness.flush();
+  assert.equal(remote.meta_data.reset_hp, false, 'initialization must finish even when HP needs no numeric change');
+  remote = { ...remote, hp_current: 7, updated_at: `version-${++revision}` };
+  await harness.poll();
+  remote = {
+    ...remote,
+    details: { ...remote.details, conditions: [{ name: 'Frightened', value: 1 }] },
+    updated_at: `version-${++revision}`,
+  };
+  await harness.poll();
+  assert.equal(harness.character.hp_current, 7, 'a later calculation must not heal remotely applied damage');
+  assert.equal(remote.hp_current, 7);
+  harness.unmount();
+});
+
+test('remote source changes pause calculations until the page reloads matching content', async () => {
+  let remote = { ...row(), content_sources: { enabled: [1] } };
+  let calculations = 0;
+  const sourceRequests = [];
+  harness.options = {
+    type: 'EXECUTE_OPS',
+    data: {
+      content: { items: [], defaultSources: { PAGE: [1, 3] } },
+      context: 'CHARACTER-SHEET',
+      onFinishLoading() {},
+      onSourcesChange(sources) {
+        sourceRequests.push(sources);
+      },
+    },
+  };
+  harness.calculate = async () => {
+    calculations++;
+    return {};
+  };
+  harness.request = async (type) => {
+    assert.equal(type, 'find-character');
+    return structuredClone(remote);
+  };
+  harness.render();
+  await harness.flush();
+  assert.equal(calculations, 1);
+  remote = { ...remote, content_sources: { enabled: [1, 256] }, updated_at: 'version-2' };
+  await harness.poll();
+  assert.equal(calculations, 1, 'the old content package must not recalculate the changed character');
+  assert.deepEqual(sourceRequests, [[1, 256]]);
+  assert.equal(getBufferedCharacterSave(1, 'owner').draft.requiresCalculation, true);
+  harness.options = {
+    ...harness.options,
+    data: { ...harness.options.data, content: { items: [], defaultSources: { PAGE: [1, 3, 256] } } },
+  };
+  harness.render();
+  await harness.flush();
+  assert.equal(calculations, 2);
+  assert.equal(harness.requests.filter(({ type }) => type === 'update-character').length, 0);
+  harness.unmount();
+});
+
+test('a public viewer receives remote changes without turning calculated local values into a conflict', async () => {
+  harness.session = null;
+  let remote = { ...row(), hp_current: 20 };
+  harness.request = async (type) => {
+    assert.equal(type, 'find-character');
+    return structuredClone(remote);
+  };
+  harness.render();
+  await harness.flush();
+  harness.edit({ hp_current: 19 });
+  await harness.flush();
+  remote = { ...remote, hp_current: 12, updated_at: 'version-2' };
+  await harness.poll();
+  assert.equal(harness.character.hp_current, 12);
+  assert.equal(harness.value.saveState, 'saved');
+  assert.equal(harness.notices.length, 0);
+  assert.equal(harness.requests.filter(({ type }) => type === 'update-character').length, 0);
   harness.unmount();
 });

--- a/frontend/scripts/content-selection.test.mjs
+++ b/frontend/scripts/content-selection.test.mjs
@@ -1,0 +1,181 @@
+/** Run the real picker render logic with delayed query data and the real search index. */
+import assert from 'node:assert/strict';
+import { after, test } from 'node:test';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { createRequire } from 'node:module';
+const root = fileURLToPath(new URL('../', import.meta.url));
+const require = createRequire(`${root}/package.json`);
+const { build } = require('esbuild');
+const directory = await mkdtemp(join(tmpdir(), 'wg-content-selection-'));
+after(() => rm(directory, { recursive: true, force: true }));
+let host;
+class RenderHost {
+  constructor() {
+    this.data = undefined;
+    this.slots = [];
+    this.effects = [];
+  }
+  render(component, props) {
+    host = this;
+    this.cursor = 0;
+    this.effects = [];
+    const result = component(props);
+    for (const effect of this.effects) effect();
+    return result;
+  }
+  memo(callback, deps) {
+    const index = this.cursor++;
+    const prior = this.slots[index];
+    if (!prior || deps.some((value, i) => !Object.is(value, prior.deps[i])))
+      this.slots[index] = { deps, value: callback() };
+    return this.slots[index].value;
+  }
+  ref(value) {
+    const index = this.cursor++;
+    return (this.slots[index] ??= { current: value });
+  }
+}
+globalThis.__selectionHooks = {
+  useRef: (value) => host.ref(value),
+  useMemo: (callback, deps) => host.memo(callback, deps),
+  useEffect: (callback) => {
+    host.effects.push(callback);
+  },
+  useState: (value) => [host.searchQuery ?? (typeof value === 'function' ? value() : value), () => {}],
+  useQuery: () => ({ data: host.data, isFetching: host.data === undefined }),
+};
+const special = {
+  useAtom: '() => [null, () => {}]',
+  useAtomValue: '() => null',
+  collectEntitySpellcasting: '(id, entity) => entity.spells',
+  isSpellVisible: '() => true',
+  isNormalSpell: '() => true',
+  isRitual: '() => false',
+  isTruthy: 'value => !!value',
+  getVariable: '() => undefined',
+  useMantineTheme: '() => ({colors:{dark:[],guide:[]}})',
+  useMantineColorScheme: '() => ({colorScheme:"dark"})',
+  getDefaultSources: '() => [1]',
+  getDefaultSourcesKey: '() => "1"',
+};
+const imports = new Map();
+const paths = ['src/common/select/SelectContent.tsx', 'src/modals/ManageSpellsModal.tsx'];
+for (const path of paths) {
+  const source = await readFile(join(root, path), 'utf8');
+  for (const match of source.matchAll(/import\s+([\s\S]*?)\s+from\s+['"]([^'"]+)['"];?/g)) {
+    if (['react', 'js-search', 'lodash-es', '@tanstack/react-query'].includes(match[2])) continue;
+    const names = imports.get(match[2]) ?? new Set();
+    const inside = match[1].match(/\{([\s\S]*?)\}/)?.[1];
+    if (inside)
+      for (const name of inside
+        .split(',')
+        .map((value) => value.trim())
+        .filter(Boolean))
+        names.add(name);
+    if (!match[1].trim().startsWith('{')) names.add('default');
+    imports.set(match[2], names);
+  }
+}
+const output = join(directory, 'selection.mjs');
+await build({
+  absWorkingDir: root,
+  stdin: {
+    contents: `export {SelectionOptions} from './src/common/select/SelectContent'; export {default as ManageSpellsModal} from './src/modals/ManageSpellsModal';`,
+    resolveDir: root,
+  },
+  bundle: true,
+  platform: 'node',
+  format: 'esm',
+  outfile: output,
+  jsx: 'automatic',
+  plugins: [
+    {
+      name: 'selection-render-boundaries',
+      setup(b) {
+        b.onResolve({ filter: /.*/ }, (args) => {
+          if (
+            args.path === 'react' ||
+            args.path === 'react/jsx-runtime' ||
+            args.path === '@tanstack/react-query' ||
+            imports.has(args.path)
+          )
+            return { path: args.path, namespace: 'boundary' };
+        });
+        b.onLoad({ filter: /SelectContent\.tsx$/ }, async (args) => ({
+          contents: `${await readFile(args.path, 'utf8')}\nexport {SelectionOptions};`,
+          loader: 'tsx',
+        }));
+        b.onLoad({ filter: /.*/, namespace: 'boundary' }, (args) => {
+          if (args.path === 'react')
+            return { contents: 'export const {useRef,useMemo,useEffect,useState}=globalThis.__selectionHooks;' };
+          if (args.path === '@tanstack/react-query')
+            return { contents: 'export const {useQuery}=globalThis.__selectionHooks;' };
+          if (args.path === 'react/jsx-runtime')
+            return {
+              contents:
+                'export const jsx=(type,props)=>({type,props}); export const jsxs=jsx; export const Fragment="fragment";',
+            };
+          let contents = '';
+          for (const name of imports.get(args.path)) {
+            const value =
+              special[name] ?? (name === 'default' || /^[A-Z]/.test(name) ? JSON.stringify(name) : '() => undefined');
+            contents += name === 'default' ? `export default ${value};\n` : `export const ${name} = ${value};\n`;
+          }
+          return { contents };
+        });
+      },
+    },
+  ],
+});
+const { SelectionOptions, ManageSpellsModal } = await import(pathToFileURL(output).href);
+const charm = { id: 1, name: 'Charm', rank: 1 };
+const command = { id: 2, name: 'Command', rank: 1 };
+const picker = { type: 'spell', searchQuery: 'Charm', limitSelectedOptions: false };
+test('an already typed search displays content in the same render that its delayed query resolves', () => {
+  const host = new RenderHost();
+  assert.deepEqual(host.render(SelectionOptions, picker).props.options, []);
+  host.data = [charm, command];
+  assert.deepEqual(host.render(SelectionOptions, picker).props.options, [charm]);
+});
+test('search never offers an option removed by the current filter or override list', () => {
+  const host = new RenderHost();
+  host.data = [charm, command];
+  host.render(SelectionOptions, picker);
+  assert.deepEqual(host.render(SelectionOptions, picker).props.options, [charm]);
+  assert.deepEqual(
+    host.render(SelectionOptions, { ...picker, filterFn: (spell) => spell.id !== charm.id }).props.options,
+    []
+  );
+  assert.deepEqual(host.render(SelectionOptions, { ...picker, overrideOptions: [command] }).props.options, []);
+});
+
+function findChild(node, componentName) {
+  if (!node || typeof node !== 'object') return undefined;
+  if (node.type?.name === componentName) return node;
+  for (const child of [node.props?.children].flat(Infinity)) {
+    const found = findChild(child, componentName);
+    if (found) return found;
+  }
+}
+test('manage spells updates an active search when its catalog arrives or a source is removed', () => {
+  const host = new RenderHost();
+  host.searchQuery = 'Charm';
+  const props = {
+    id: 'CHARACTER',
+    entity: { id: 1, spells: { list: [{ spell_id: 1, source: 'Wizard', rank: 1 }], slots: [] } },
+    source: 'Wizard',
+    type: 'LIST-ONLY',
+    opened: true,
+    onClose: () => {},
+    setEntity: () => {},
+  };
+  const list = () => findChild(host.render(ManageSpellsModal, props), 'ListSection').props.spells;
+  assert.deepEqual(list(), []);
+  host.data = [charm, command];
+  assert.deepEqual(list(), [charm]);
+  host.data = [command];
+  assert.deepEqual(list(), []);
+});

--- a/frontend/scripts/encounter-character-writer.test.mjs
+++ b/frontend/scripts/encounter-character-writer.test.mjs
@@ -1,0 +1,384 @@
+/** Exercise the real encounter queue, merge rules, response schemas and durable recovery. */
+import assert from 'node:assert/strict';
+import { after, test } from 'node:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { createRequire } from 'node:module';
+const root = resolve(import.meta.dirname, '..');
+const require = createRequire(`${root}/package.json`);
+const { build } = require('esbuild');
+const folder = mkdtempSync(join(tmpdir(), 'wg-encounter-save-'));
+after(() => rmSync(folder, { recursive: true, force: true }));
+await build({
+  stdin: {
+    contents: `export * from './src/utils/encounter-character-writer'; export * from './src/utils/character-version';`,
+    resolveDir: root,
+  },
+  absWorkingDir: root,
+  bundle: true,
+  platform: 'node',
+  format: 'esm',
+  outfile: `${folder}/writer.mjs`,
+});
+const { createEncounterCharacterWriter, compareCharacterVersions } = await import(`${folder}/writer.mjs`);
+const storage = new Map();
+globalThis.localStorage = {
+  getItem: (key) => storage.get(key) ?? null,
+  setItem: (key, value) => storage.set(key, value),
+  removeItem: (key) => storage.delete(key),
+};
+const row = () => ({
+  id: 1,
+  name: 'Campaign player',
+  user_id: 'player',
+  created_at: '',
+  updated_at: '2026-09-06T12:00:00.000Z',
+  campaign_id: 1,
+  level: 1,
+  experience: 0,
+  hp_current: 20,
+  hp_temp: 0,
+  hero_points: 1,
+  stamina_current: 0,
+  resolve_current: 0,
+  details: { conditions: [], info: { appearance: 'Original' } },
+  meta_data: { reset_hp: false },
+  notes: null,
+  roll_history: null,
+  spells: null,
+  operation_data: null,
+  inventory: null,
+  custom_operations: null,
+  options: null,
+  variants: null,
+  content_sources: null,
+  companions: null,
+});
+const deferred = () => {
+  let resolve;
+  const promise = new Promise((r) => (resolve = r));
+  return { promise, resolve };
+};
+async function until(predicate) {
+  for (let i = 0; i < 100; i++) {
+    if (predicate()) return;
+    await new Promise((r) => setTimeout(r, 2));
+  }
+  assert.fail('Queue did not reach the expected state');
+}
+function setup(t, initial = row(), override) {
+  storage.clear();
+  let server = structuredClone(initial),
+    version = 0;
+  const requests = [];
+  const commit = (body) => {
+    const { expected_updated_at, id, ...changes } = body;
+    if (expected_updated_at !== server.updated_at) return { __conflict: true, character: structuredClone(server) };
+    server = { ...server, ...changes, updated_at: `2026-09-06T12:00:${String(++version).padStart(2, '0')}.000Z` };
+    return [structuredClone(server)];
+  };
+  const writer = createEncounterCharacterWriter({
+    actorId: 'gm',
+    changed() {},
+    request: async (type, body) => {
+      requests.push({ type, body: structuredClone(body) });
+      return override
+        ? override({
+            type,
+            body,
+            commit,
+            get server() {
+              return server;
+            },
+            set server(value) {
+              server = value;
+            },
+          })
+        : type === 'find-character'
+          ? structuredClone(server)
+          : commit(body);
+    },
+  });
+  t.after(() => writer.dispose());
+  return {
+    writer,
+    requests,
+    get server() {
+      return server;
+    },
+    set server(value) {
+      server = value;
+    },
+  };
+}
+
+test('GM HP writes merge newer player details and omit untouched combat/inventory/spell fields', async (t) => {
+  const original = row();
+  const state = setup(t);
+  state.server = {
+    ...original,
+    hero_points: 2,
+    details: { ...original.details, info: { appearance: 'Player edit' }, extension: { retained: true } },
+    meta_data: { reset_hp: false, extension: { retained: true } },
+    updated_at: '2026-09-06T12:00:00.100Z',
+  };
+  state.writer.update(original, { ...original, hp_current: 15 });
+  await until(() => state.writer.status(1)?.phase === 'saved');
+  const body = state.requests.find((r) => r.type === 'update-character').body;
+  assert.deepEqual(Object.keys(body).sort(), ['expected_updated_at', 'hp_current', 'id']);
+  assert.equal(state.server.hero_points, 2);
+  assert.equal(state.server.details.info.appearance, 'Player edit');
+  assert.deepEqual(state.server.details.extension, { retained: true });
+  assert.equal(state.server.hp_current, 15);
+  assert.equal(storage.size, 0);
+});
+
+test('JSON column patches preserve unknown sibling data while adding a condition', async (t) => {
+  const original = row();
+  const state = setup(t);
+  state.server = {
+    ...original,
+    details: { ...original.details, extension: { retained: true } },
+    meta_data: { reset_hp: false, extension: { retained: true } },
+    updated_at: '2026-09-06T12:00:00.100Z',
+  };
+  state.writer.update(original, {
+    ...original,
+    details: {
+      ...original.details,
+      conditions: [
+        { name: 'Frightened', description: 'Test condition', value: 1, for_object: false, for_creature: true },
+      ],
+    },
+    meta_data: { reset_hp: true },
+  });
+  await until(() => state.writer.status(1)?.phase === 'saved');
+  assert.deepEqual(state.server.meta_data.extension, { retained: true });
+  assert.equal(state.server.meta_data.reset_hp, true);
+  assert.deepEqual(state.server.details.extension, { retained: true });
+  assert.equal(state.server.details.conditions[0].name, 'Frightened');
+  assert.equal(state.requests.filter((r) => r.type === 'update-character').length, 1);
+});
+
+test('simultaneous changes to HP pause with a recoverable draft and no overwrite', async (t) => {
+  const original = row();
+  const state = setup(t);
+  state.server = { ...original, hp_current: 12, updated_at: '2026-09-06T12:00:00.100Z' };
+  state.writer.update(original, { ...original, hp_current: 15 });
+  await until(() => state.writer.status(1)?.phase === 'conflict');
+  assert.equal(state.server.hp_current, 12);
+  assert.deepEqual(state.writer.status(1).conflicts, ['hp_current']);
+  assert.equal(state.requests.filter((r) => r.type === 'update-character').length, 0);
+  assert.equal(JSON.parse([...storage.values()][0]).body.hp_current, 15);
+});
+
+test('pending changes serialize and a later deliberate return to old HP survives ACK', async (t) => {
+  const waiting = deferred();
+  let writes = 0;
+  const state = setup(t, row(), async (request) => {
+    if (request.type === 'find-character') return structuredClone(request.server);
+    writes++;
+    const result = request.commit(request.body);
+    if (writes === 1) await waiting.promise;
+    return result;
+  });
+  const original = row();
+  state.writer.update(original, { ...original, hp_current: 15 });
+  await until(() => writes === 1);
+  const pending = state.writer.display(original);
+  state.writer.update(pending, { ...pending, hp_current: 20 });
+  assert.equal(writes, 1);
+  waiting.resolve();
+  await until(() => state.writer.status(1)?.phase === 'saved');
+  assert.equal(state.server.hp_current, 20);
+  assert.equal(writes, 2);
+  assert.equal(storage.size, 0);
+});
+
+test('lost ACK retries by reading; it does not repeat a committed HP write', async (t) => {
+  let writes = 0;
+  const state = setup(t, row(), async (request) => {
+    if (request.type === 'find-character') return structuredClone(request.server);
+    writes++;
+    request.commit(request.body);
+    return null;
+  });
+  state.writer.update(row(), { ...row(), hp_current: 15 });
+  await until(() => state.writer.status(1)?.phase === 'failed');
+  assert.ok(JSON.parse([...storage.values()][0]).submission);
+  state.writer.retry(1);
+  await until(() => state.writer.status(1)?.phase === 'saved');
+  assert.equal(writes, 1);
+  assert.equal(storage.size, 0);
+});
+
+test('guard conflicts merge unrelated writes made between GET and POST', async (t) => {
+  let writes = 0;
+  const state = setup(t, row(), (request) => {
+    if (request.type === 'find-character') return structuredClone(request.server);
+    if (++writes === 1) request.server = { ...request.server, hero_points: 2, updated_at: '2026-09-06T12:00:00.100Z' };
+    return request.commit(request.body);
+  });
+  state.writer.update(row(), { ...row(), hp_current: 15 });
+  await until(() => state.writer.status(1)?.phase === 'saved');
+  assert.equal(writes, 2);
+  assert.equal(state.server.hero_points, 2);
+  assert.equal(state.server.hp_current, 15);
+});
+
+test('forbidden and empty results never claim the change was saved', async (t) => {
+  for (const response of [{ __forbidden: true }, []]) {
+    const state = setup(t, row(), (request) => (request.type === 'find-character' ? request.server : response));
+    state.writer.update(row(), { ...row(), hp_current: 15 });
+    await until(() => ['failed', 'forbidden'].includes(state.writer.status(1)?.phase));
+    assert.equal(state.server.hp_current, 20);
+    assert.equal(storage.size, 1);
+    state.writer.dispose();
+  }
+});
+
+test('acknowledged overlay prevents stale polling from reverting HP, then follows newer reads', async (t) => {
+  const state = setup(t);
+  state.writer.update(row(), { ...row(), hp_current: 15 });
+  await until(() => state.writer.status(1)?.phase === 'saved');
+  assert.equal(state.writer.display(row()).hp_current, 15);
+  const newer = { ...state.server, hp_current: 10, updated_at: '2026-09-06T12:00:20.000Z' };
+  assert.equal(state.writer.display(newer).hp_current, 10);
+  state.server = newer;
+  state.writer.update(newer, { ...newer, hp_current: 15 });
+  await until(() => state.writer.status(1)?.phase === 'saved');
+  assert.equal(state.server.hp_current, 15);
+});
+
+test('no-op blur submits nothing and disposing retains only unsynced recovery data', async (t) => {
+  const waiting = deferred();
+  const state = setup(t, row(), () => waiting.promise);
+  state.writer.update(row(), row());
+  assert.equal(state.requests.length, 0);
+  state.writer.update(row(), { ...row(), hp_current: 15 });
+  state.writer.dispose();
+  waiting.resolve(row());
+  await new Promise((r) => setTimeout(r, 10));
+  assert.equal(state.requests.filter((r) => r.type === 'update-character').length, 0);
+  assert.equal(storage.size, 1);
+});
+
+test('reconnecting preserves a later intentional revert after an uncertain committed write', async (t) => {
+  let writes = 0;
+  const state = setup(t, row(), (request) => {
+    if (request.type === 'find-character') return structuredClone(request.server);
+    const result = request.commit(request.body);
+    return ++writes === 1 ? null : result;
+  });
+  state.writer.update(row(), { ...row(), hp_current: 15 });
+  await until(() => state.writer.status(1)?.phase === 'failed');
+  const pending = state.writer.display(row());
+  state.writer.update(pending, { ...pending, hp_current: 20 });
+  await until(() => state.writer.status(1)?.phase === 'saved');
+  assert.equal(state.server.hp_current, 20);
+  assert.equal(writes, 2);
+  assert.equal(storage.size, 0);
+});
+
+test("simultaneous condition-array changes pause instead of dropping either writer's choice", async (t) => {
+  const condition = (name) => ({ name, description: 'Test condition', for_creature: true, for_object: false });
+  const state = setup(t);
+  state.server = { ...row(), details: { conditions: [condition('Clumsy')] }, updated_at: '2026-09-06T12:00:00.100Z' };
+  state.writer.update(row(), { ...row(), details: { conditions: [condition('Frightened')] } });
+  await until(() => state.writer.status(1)?.phase === 'conflict');
+  assert.deepEqual(state.writer.status(1).conflicts, ['details.conditions']);
+  assert.equal(state.server.details.conditions[0].name, 'Clumsy');
+  assert.equal(state.writer.display(row()).details.conditions[0].name, 'Frightened');
+});
+
+test('storage exhaustion is reported without discarding the in-memory pending edit', async (t) => {
+  const waiting = deferred();
+  const state = setup(t, row(), () => waiting.promise);
+  const previous = globalThis.localStorage;
+  globalThis.localStorage = {
+    ...previous,
+    setItem() {
+      throw new Error('Quota exceeded');
+    },
+  };
+  t.after(() => {
+    globalThis.localStorage = previous;
+  });
+  state.writer.update(row(), { ...row(), hp_current: 15 });
+  assert.equal(state.writer.status(1).stored, false);
+  assert.equal(state.writer.display(row()).hp_current, 15);
+  state.writer.dispose();
+  waiting.resolve(row());
+});
+
+test('development effect cleanup/reattachment leaves the writer usable', async (t) => {
+  const state = setup(t);
+  state.writer.dispose();
+  state.writer.activate();
+  state.writer.update(row(), { ...row(), hp_current: 15 });
+  await until(() => state.writer.status(1)?.phase === 'saved');
+  assert.equal(state.server.hp_current, 15);
+});
+
+test('character versions preserve microseconds and equivalent timezone/precision representations', () => {
+  assert.equal(compareCharacterVersions('2026-09-06T12:00:00.123456+00:00', '2026-09-06T12:00:00.123455Z'), 1);
+  assert.equal(compareCharacterVersions('2026-09-06T12:00:00.123454Z', '2026-09-06T12:00:00.123455Z'), -1);
+  assert.equal(compareCharacterVersions('2026-09-06T08:00:00.123400-04:00', '2026-09-06T12:00:00.1234Z'), 0);
+  assert.equal(compareCharacterVersions('2026-09-06T12:00:00Z', '2026-09-06T12:00:00.000000Z'), 0);
+  assert.equal(compareCharacterVersions('2026-09-06T12:00:01.000001Z', '2026-09-06T12:00:00.999999Z'), 1);
+  assert.equal(compareCharacterVersions('version-2', 'version-1'), null);
+  assert.equal(compareCharacterVersions(undefined, '2026-09-06T12:00:00Z'), null);
+});
+
+test('pending GM HP displays unrelated fresh player changes and ignores older polls', async (t) => {
+  const waiting = deferred();
+  const initial = { ...row(), updated_at: '2026-09-06T12:00:00.123455Z' };
+  const state = setup(t, initial, () => waiting.promise);
+  state.writer.update(initial, { ...initial, hp_current: 15 });
+  const fresh = {
+    ...initial,
+    details: { ...initial.details, info: { appearance: 'Fresh player detail' } },
+    updated_at: '2026-09-06T12:00:00.123456Z',
+  };
+  const displayed = state.writer.display(fresh);
+  assert.equal(displayed.hp_current, 15);
+  assert.equal(displayed.details.info.appearance, 'Fresh player detail');
+  assert.equal(state.writer.display({ ...row(), hp_current: 3 }).hp_current, 15);
+  state.writer.dispose();
+  waiting.resolve(initial);
+});
+
+test('reattachment recovers an acknowledgement ignored while unmounted without repeating the write', async (t) => {
+  const waiting = deferred();
+  let writes = 0;
+  const state = setup(t, row(), async (request) => {
+    if (request.type === 'find-character') return structuredClone(request.server);
+    writes++;
+    const committed = request.commit(request.body);
+    await waiting.promise;
+    return committed;
+  });
+  state.writer.update(row(), { ...row(), hp_current: 15 });
+  await until(() => writes === 1);
+  state.writer.dispose();
+  waiting.resolve();
+  await new Promise((resolve) => setTimeout(resolve, 5));
+  assert.equal(state.writer.status(1).phase, 'saving');
+  state.writer.activate();
+  await until(() => state.writer.status(1)?.phase === 'saved');
+  assert.equal(writes, 1);
+  assert.equal(storage.size, 0);
+});
+
+test('legacy partial inventory and extension JSON do not block a safe HP update', async (t) => {
+  const original = { ...row(), inventory: { items: [], legacy: { keep: true } }, spells: { legacy: ['unchanged'] } };
+  const state = setup(t, original);
+  state.writer.update(original, { ...original, hp_current: 15 });
+  await until(() => state.writer.status(1)?.phase === 'saved');
+  assert.deepEqual(state.server.inventory, original.inventory);
+  assert.deepEqual(state.server.spells, original.spells);
+  const body = state.requests.find((request) => request.type === 'update-character').body;
+  assert.equal('inventory' in body, false);
+  assert.equal('spells' in body, false);
+});

--- a/frontend/src/common/select/SelectContent.tsx
+++ b/frontend/src/common/select/SelectContent.tsx
@@ -804,17 +804,15 @@ function SelectionOptions(props: {
     options = options.filter((option) => !languageIds.includes(option.id));
   }
 
-  // Filter options based on search query
-  const search = useRef(new JsSearch.Search('id'));
-  useEffect(() => {
-    if (!options) return;
-    search.current.addIndex('name');
-    //search.current.addIndex('description');
-    search.current.addDocuments(options);
-  }, [options]);
-  let filteredOptions = props.searchQuery
-    ? (search.current.search(props.searchQuery) as Record<string, any>[])
-    : options;
+  // Build from this render's eligible options. An effect leaves an already typed
+  // query empty when content arrives, and an accumulating index retains removed choices.
+  const filteredOptions = useMemo(() => {
+    if (!props.searchQuery) return [...options];
+    const search = new JsSearch.Search('id');
+    search.addIndex('name');
+    search.addDocuments(options);
+    return search.search(props.searchQuery) as Record<string, any>[];
+  }, [options, props.searchQuery]);
 
   // Pre-compute the prereq-met rank per option once (rather than re-running
   // `meetsPrerequisites` on every comparator call). Lower rank = better fit:
@@ -833,7 +831,7 @@ function SelectionOptions(props: {
   }
 
   // Sort by level/rank, then prereqs-met (when enabled for feats), then name
-  filteredOptions = filteredOptions.sort((a, b) => {
+  filteredOptions.sort((a, b) => {
     if (a.level !== undefined && b.level !== undefined) {
       if (a.level !== b.level) {
         // Sort greatest first if it's overrideOptions

--- a/frontend/src/modals/ManageSpellsModal.tsx
+++ b/frontend/src/modals/ManageSpellsModal.tsx
@@ -31,7 +31,7 @@ import { isTruthy } from '@utils/type-fixing';
 import useRefresh from '@utils/use-refresh';
 import * as JsSearch from 'js-search';
 import { groupBy } from 'lodash-es';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useAtom } from 'jotai';
 import { SetterOrUpdater } from '@utils/type-fixing';
 
@@ -68,21 +68,26 @@ export default function ManageSpellsModal(props: {
     },
   });
 
-  // Filter options based on search query
-  const search = useRef(new JsSearch.Search('id'));
-  useEffect(() => {
-    if (!allRawSpells) return;
-    search.current.addIndex('name');
-    search.current.addIndex('description');
-    search.current.addIndex('duration');
-    search.current.addIndex('targets');
-    search.current.addIndex('area');
-    search.current.addIndex('range');
-    search.current.addIndex('requirements');
-    search.current.addIndex('trigger');
-    search.current.addIndex('cost');
-    search.current.addIndex('defense');
-    search.current.addDocuments(allRawSpells);
+  // Rebuild before rendering results so late content and removed sources are
+  // reflected immediately, including when the user has already typed a search.
+  const search = useMemo(() => {
+    const index = new JsSearch.Search('id');
+    for (const field of [
+      'name',
+      'description',
+      'duration',
+      'targets',
+      'area',
+      'range',
+      'requirements',
+      'trigger',
+      'cost',
+      'defense',
+    ]) {
+      index.addIndex(field);
+    }
+    index.addDocuments(allRawSpells ?? []);
+    return index;
   }, [allRawSpells]);
 
   const charData = useMemo(() => {
@@ -91,8 +96,7 @@ export default function ManageSpellsModal(props: {
   }, [props.entity]);
 
   const allFilteredSpells =
-    (searchQuery.trim() ? (search.current?.search(searchQuery.trim()) as Spell[] | undefined) : (allRawSpells ?? [])) ??
-    [];
+    (searchQuery.trim() ? (search.search(searchQuery.trim()) as Spell[] | undefined) : (allRawSpells ?? [])) ?? [];
 
   const spells = useMemo(() => {
     const filteredSpells = charData?.list

--- a/frontend/src/pages/campaign/CampaignDrawer.tsx
+++ b/frontend/src/pages/campaign/CampaignDrawer.tsx
@@ -29,9 +29,13 @@ import RichTextInput from '@common/rich_text_input/RichTextInput';
 import { JSONContent } from '@tiptap/react';
 import { useSwipeGesture } from '@utils/use-swipe-gesture';
 import { IMPRINT_BG_COLOR } from '@constants/data';
+import { campaignCharactersQuery } from '@utils/campaign-characters-query';
+import { sessionState } from '@atoms/supabaseAtoms';
+import { useAtomValue } from 'jotai';
 
 export default function CampaignDrawer(props: { opened: boolean; onClose: () => void; campaignId: number }) {
   const theme = useMantineTheme();
+  const session = useAtomValue(sessionState);
   const isTablet = useMediaQuery(tabletQuery());
   const isWideDesktop = useMediaQuery(wideDesktopQuery());
 
@@ -47,15 +51,7 @@ export default function CampaignDrawer(props: { opened: boolean; onClose: () => 
     refetchOnWindowFocus: false,
   });
 
-  const { data: characters } = useQuery({
-    queryKey: [`find-campaign-characters`],
-    queryFn: async () => {
-      return await makeRequest<Character[]>('find-character', {
-        campaign_id: props.campaignId,
-      });
-    },
-    refetchInterval: 400,
-  });
+  const { data: characters } = useQuery(campaignCharactersQuery(props.campaignId, session?.user.id));
 
   const swipeHandlers = useSwipeGesture({ onSwipeLeft: props.onClose });
 

--- a/frontend/src/pages/campaign/CampaignOverviewPage.tsx
+++ b/frontend/src/pages/campaign/CampaignOverviewPage.tsx
@@ -41,7 +41,7 @@ import { Campaign, Character, Encounter } from '@schemas/content';
 import { setPageTitle } from '@utils/document-change';
 import { isPhoneSized, tabletQuery } from '@utils/mobile-responsive';
 import { cloneDeep, truncate } from 'lodash-es';
-import { Suspense, useEffect, useState } from 'react';
+import { Suspense, useEffect, useMemo, useState } from 'react';
 import { GiRollingDices } from '@common/game-icons-inline';
 import { useLoaderData } from 'react-router-dom';
 import classes from '@css/UserInfoIcons.module.css';
@@ -59,6 +59,8 @@ import BlurButton from '@common/BlurButton';
 import BlurActionIcon from '@common/BlurActionIcon';
 import { getAnchorStyles } from '@utils/anchor';
 import ImprintButton from '@common/ImprintButton';
+import { campaignCharactersQuery } from '@utils/campaign-characters-query';
+import { createEncounterCharacterWriter } from '@utils/encounter-character-writer';
 
 export function Component() {
   const theme = useMantineTheme();
@@ -157,15 +159,7 @@ export function CampaignInner(props: { campaignId: number; onFinishLoading: () =
     })();
   }, [debouncedCampaign]);
 
-  const { data: characters, isLoading } = useQuery({
-    queryKey: [`find-campaign-characters`, { campaign_id: props.campaignId }],
-    queryFn: async () => {
-      return await makeRequest<Character[]>('find-character', {
-        campaign_id: props.campaignId,
-      });
-    },
-    refetchInterval: 400,
-  });
+  const { data: characters, isLoading } = useQuery(campaignCharactersQuery(props.campaignId, session?.user.id));
 
   const isLoaded = !isLoading && !isFetching;
 
@@ -401,6 +395,28 @@ function SectionPanels(props: {
   panelHeight: number;
   panelWidth: number;
 }) {
+  const session = useAtomValue(sessionState);
+  const [, refreshCharacterSaves] = useState(0);
+  const characterWriter = useMemo(
+    () =>
+      session?.user.id && props.campaign?.id
+        ? createEncounterCharacterWriter({
+            actorId: session.user.id,
+            request: (type, body) => makeRequest(type, body, false, { expectedActorId: session.user.id }),
+            changed: () => refreshCharacterSaves((value) => value + 1),
+          })
+        : undefined,
+    [session?.user.id, props.campaign?.id]
+  );
+  useEffect(() => {
+    characterWriter?.activate();
+    const retry = () => characterWriter?.retry();
+    window.addEventListener('online', retry);
+    return () => {
+      window.removeEventListener('online', retry);
+      characterWriter?.dispose();
+    };
+  }, [characterWriter]);
   const theme = useMantineTheme();
   const isPhone = isPhoneSized(props.panelWidth);
 
@@ -453,6 +469,7 @@ function SectionPanels(props: {
 
             {activeTab === 'encounters' && (
               <EncountersPanel
+                characterWriter={characterWriter}
                 campaign={{
                   data: props.campaign,
                   players: props.players,
@@ -665,6 +682,7 @@ function SectionPanels(props: {
 
             <Tabs.Panel value='encounters'>
               <EncountersPanel
+                characterWriter={characterWriter}
                 panelHeight={props.panelHeight}
                 panelWidth={props.panelWidth}
                 campaign={{

--- a/frontend/src/pages/campaign/panels/EncountersPanel.tsx
+++ b/frontend/src/pages/campaign/panels/EncountersPanel.tsx
@@ -66,10 +66,13 @@ import { GiDiceTwentyFacesTwenty } from '@common/game-icons-inline';
 import { useAtom, useAtomValue } from 'jotai';
 import BlurBox from '@common/BlurBox';
 import ImprintButton from '@common/ImprintButton';
+import { CharacterSaveStatus } from '@common/CharacterSaveStatus';
+import { createEncounterCharacterWriter, type EncounterCharacterSave } from '@utils/encounter-character-writer';
 
 export default function EncountersPanel(props: {
   panelHeight: number;
   panelWidth: number;
+  characterWriter?: ReturnType<typeof createEncounterCharacterWriter>;
   campaign?: {
     data: Campaign;
     players: Character[];
@@ -90,12 +93,7 @@ export default function EncountersPanel(props: {
         user_id: session?.user.id,
       });
 
-      // Prefetch content package for creature calculations
-
-      const sv = defineDefaultSources('PAGE', 'ALL-USER-ACCESSIBLE');
-      // We could await fetch content for a more seemless experience but it takes a bit too long imo - Quzzar
-      // Opportunistic prefetch; actual creature calculation awaits its own package.
-      void fetchContentPackage(sv, { fetchSources: false, fetchCreatures: false }).catch(() => undefined);
+      defineDefaultSources('PAGE', 'ALL-USER-ACCESSIBLE');
 
       return result ?? [];
     },
@@ -196,6 +194,7 @@ export default function EncountersPanel(props: {
     return (
       <ScrollArea h={props.panelHeight} scrollbars='y'>
         <EncounterView
+          characterWriter={props.characterWriter}
           encounter={encounter}
           setEncounter={(e) => {
             const newEncounters = cloneDeep(encounters);
@@ -464,6 +463,7 @@ export default function EncountersPanel(props: {
 export type PopulatedCombatant = Omit<Combatant, 'data'> & Required<Pick<Combatant, 'data'>>;
 
 function EncounterView(props: {
+  characterWriter?: ReturnType<typeof createEncounterCharacterWriter>;
   encounter: Encounter;
   setEncounter: (encounter: Encounter) => void;
   players?: Character[];
@@ -549,7 +549,8 @@ function EncounterView(props: {
   const populateCombatants = (combatants: Combatant[]): PopulatedCombatant[] => {
     const getCombatantData = (combatant: Combatant): LivingEntity | undefined => {
       if (combatant.type === 'CHARACTER') {
-        return props.players?.find((p) => p.id === combatant.character);
+        const player = props.players?.find((p) => p.id === combatant.character);
+        return player ? (props.characterWriter?.display(player) ?? player) : undefined;
       } else {
         return combatant.creature;
       }
@@ -787,6 +788,8 @@ function EncounterView(props: {
                   key={combatant._id}
                   combatant={combatant}
                   computed={getComputedData(combatant)}
+                  save={combatant.character ? props.characterWriter?.status(combatant.character) : undefined}
+                  retrySave={() => props.characterWriter?.retry(combatant.character)}
                   // Returning updated populated entity data, will trigger update of the combatant
                   updateEntity={(input) => {
                     let entity = cloneDeep(input);
@@ -812,24 +815,9 @@ function EncounterView(props: {
                     }
 
                     if (combatant.type === 'CHARACTER') {
-                      // Send remote update to change character.
-                      //
-                      // Only send the combat fields the encounter panel actually edits.
-                      // combatant.data is a clone of an up-to-400ms-stale poll snapshot of
-                      // the FULL player character, so spreading it would full-replace the
-                      // player's live inventory/spells/etc. with the GM's stale copy and
-                      // silently destroy anything the player changed since the last poll.
-                      const c = entity as Character;
-                      makeRequest('update-character', {
-                        id: combatant.character!,
-                        hp_current: c.hp_current,
-                        hp_temp: c.hp_temp,
-                        stamina_current: c.stamina_current,
-                        resolve_current: c.resolve_current,
-                        hero_points: c.hero_points,
-                        details: c.details,
-                        meta_data: c.meta_data,
-                      });
+                      // Preserve player edits and pending GM changes through the same
+                      // versioned merge/recovery format used by character sheets.
+                      props.characterWriter?.update(combatant.data as Character, entity as Character);
                     } else if (combatant.type === 'CREATURE') {
                       updateCombatant({
                         ...combatant,
@@ -886,6 +874,8 @@ function EncounterView(props: {
 }
 
 function CombatantCard(props: {
+  save?: EncounterCharacterSave;
+  retrySave: () => void;
   combatant: PopulatedCombatant;
   computed?: {
     id: number;
@@ -928,17 +918,24 @@ function CombatantCard(props: {
 
   const [health, setHealth] = useState<string | undefined>();
   const healthRef = useRef<HTMLInputElement>(null);
+  const healthEditingRef = useRef(false);
+  const submittedHealthRef = useRef<string | null>(null);
+  const currentHp = props.combatant.data.hp_current;
+  const maximumHp = props.computed?.maxHp;
 
   useEffect(() => {
-    if (props.combatant.data) {
-      const currentHealth =
-        props.combatant.data.hp_current === undefined ? (props.computed?.maxHp ?? 0) : props.combatant.data.hp_current;
-      setHealth(`${currentHealth}` === 'null' ? `${props.computed?.maxHp ?? ''}` : `${currentHealth}`);
+    if (!healthEditingRef.current) {
+      const currentHealth = currentHp === undefined ? (maximumHp ?? 0) : currentHp;
+      setHealth(`${currentHealth}` === 'null' ? `${maximumHp ?? ''}` : `${currentHealth}`);
     }
-  }, [props.combatant, props.computed]);
+  }, [currentHp, maximumHp]);
 
   const handleHealthSubmit = () => {
     const inputHealth = health ?? '0';
+    healthEditingRef.current = false;
+    // Enter causes blur too. Commit that user action once, including under latency.
+    if (submittedHealthRef.current === inputHealth) return;
+    submittedHealthRef.current = inputHealth;
     let result = -1;
     try {
       result = evaluate(inputHealth);
@@ -977,13 +974,6 @@ function CombatantCard(props: {
         value={initiative ?? undefined}
         onChange={(val) => {
           setInitiative(parseInt(`${val}`));
-        }}
-        onFocus={(e) => {
-          const length = e.target.value.length;
-          // Move cursor to end
-          requestAnimationFrame(() => {
-            e.target.setSelectionRange(length, length);
-          });
         }}
         onBlur={handleInitiativeSubmit}
         onKeyDown={getHotkeyHandler([
@@ -1067,6 +1057,21 @@ function CombatantCard(props: {
             )}
           </Group>
 
+          {props.save && props.save.phase !== 'saved' && (
+            <Box onClick={(event) => event.stopPropagation()}>
+              <CharacterSaveStatus
+                state={props.save.phase === 'forbidden' ? 'read-only' : props.save.phase}
+                draftStored={props.save.stored}
+                onRetry={props.retrySave}
+              />
+              {(props.save.phase === 'conflict' || props.save.phase === 'forbidden') && (
+                <Button component='a' href={`/sheet/${props.combatant.character}`} variant='subtle' size='compact-xs'>
+                  Review changes
+                </Button>
+              )}
+            </Box>
+          )}
+
           {props.computed && (
             <Group gap={5} wrap='nowrap'>
               <Text fz='xs' c='gray.6'>
@@ -1098,14 +1103,9 @@ function CombatantCard(props: {
           autoComplete='nope'
           value={health}
           onChange={(e) => {
+            healthEditingRef.current = true;
+            submittedHealthRef.current = null;
             setHealth(e.target.value);
-          }}
-          onFocus={(e) => {
-            const length = e.target.value.length;
-            // Move cursor to end
-            requestAnimationFrame(() => {
-              e.target.setSelectionRange(length, length);
-            });
           }}
           onBlur={handleHealthSubmit}
           onKeyDown={getHotkeyHandler([
@@ -1119,6 +1119,7 @@ function CombatantCard(props: {
             </Group>
           }
           rightSectionWidth={60}
+          rightSectionPointerEvents='none'
           styles={{
             input: {
               backgroundColor: IMPRINT_BG_COLOR,
@@ -1205,7 +1206,11 @@ function CombatantCard(props: {
 }
 
 async function computeCombatants(combatants: PopulatedCombatant[]) {
-  const content = await fetchContentPackage(getDefaultSources('PAGE'), { fetchSources: false, fetchCreatures: false });
+  // Player rows already contain their calculated stats. Only creatures need the
+  // content package; share that lazy request when several creatures are present.
+  let contentPromise: ReturnType<typeof fetchContentPackage> | undefined;
+  const getCreatureContent = () =>
+    (contentPromise ??= fetchContentPackage(getDefaultSources('PAGE'), { fetchSources: false, fetchCreatures: false }));
 
   async function computeCombatant(combatant: PopulatedCombatant): Promise<{
     _id: string;
@@ -1239,7 +1244,7 @@ async function computeCombatants(combatants: PopulatedCombatant[]) {
         data: {
           id: STORE_ID,
           creature,
-          content,
+          content: await getCreatureContent(),
         },
       });
       // Apply conditions after everything else

--- a/frontend/src/pages/character_builder/CharBuilderCreation.tsx
+++ b/frontend/src/pages/character_builder/CharBuilderCreation.tsx
@@ -2,6 +2,7 @@ import { CharacterSaveStatus } from '@common/CharacterSaveStatus';
 import { CharacterLoadError } from '@common/CharacterLoadError';
 import D20Loader from '@assets/images/D20Loader';
 import { characterState } from '@atoms/characterAtoms';
+import { sessionState } from '@atoms/supabaseAtoms';
 import { drawerState } from '@atoms/navAtoms';
 import { CharacterInfo } from '@common/CharacterInfo';
 import { OperationError } from '@common/OperationError';
@@ -11,10 +12,10 @@ import { SelectContentButton, selectContent } from '@common/select/SelectContent
 import { IMPRINT_BG_COLOR, IMPRINT_BG_COLOR_HOVER, IMPRINT_BORDER_COLOR } from '@constants/data';
 import {
   fetchContent,
+  defineDefaultSources,
   fetchContentPackage,
   fetchContentSources,
   getDefaultSources,
-  getDefaultSourcesKey,
 } from '@content/content-store';
 import { getIconFromContentType } from '@content/content-utils';
 import classes from '@css/FaqSimple.module.css';
@@ -43,6 +44,7 @@ import { ObjectWithUUID, convertKeyToBasePrefix, hasOperationSelection } from '@
 import { removeParentSelections } from '@operations/selection-tree';
 import { IconId, IconPuzzle } from '@tabler/icons-react';
 import { useQuery } from '@tanstack/react-query';
+import { makeRequest } from '@requests/request-manager';
 import {
   AbilityBlock,
   Ancestry,
@@ -75,7 +77,12 @@ const CHOICE_COUNT_INTERVAL = 1500;
 
 export default function CharBuilderCreation(props: { characterId: number; pageHeight: number }) {
   const theme = useMantineTheme();
+  const actorId = useAtomValue(sessionState)?.user.id ?? null;
   const [doneLoading, setDoneLoading] = useState(false);
+  const [sourceRequest, setSourceRequest] = useState<{ id: number; actor: string | null; sources: number[] }>();
+  const requestedSources =
+    sourceRequest?.id === props.characterId && sourceRequest.actor === actorId ? sourceRequest.sources : undefined;
+  useEffect(() => setDoneLoading(false), [props.characterId, actorId]);
 
   const {
     data: content,
@@ -85,13 +92,18 @@ export default function CharBuilderCreation(props: { characterId: number; pageHe
   } = useQuery({
     queryKey: [
       `find-content-${props.characterId}-for-char-builder-creation`,
-      { characterId: props.characterId, sources: getDefaultSourcesKey('PAGE') },
+      { characterId: props.characterId, actor: actorId, sources: requestedSources ?? null },
     ],
     queryFn: async () => {
+      const character = await makeRequest<Character>('find-character', { id: props.characterId }, false, {
+        throwOnFailure: true,
+        ...(actorId ? { expectedActorId: actorId } : {}),
+      });
+      const sources = defineDefaultSources('PAGE', requestedSources ?? character?.content_sources?.enabled ?? []);
       // Prefetch content sources (to avoid multiple requests)
-      await fetchContentSources(getDefaultSources('PAGE'));
+      await fetchContentSources(sources);
 
-      const content = await fetchContentPackage(getDefaultSources('PAGE'), {
+      const content = await fetchContentPackage(sources, {
         fetchSources: true,
         fetchCreatures: false,
       });
@@ -156,6 +168,10 @@ export default function CharBuilderCreation(props: { characterId: number; pageHe
             key={props.characterId}
             characterId={props.characterId}
             content={content}
+            onSourcesChange={(sources) => {
+              setDoneLoading(false);
+              setSourceRequest({ id: props.characterId, actor: actorId, sources });
+            }}
             pageHeight={props.pageHeight}
             onFinishLoading={() => {
               interval.stop();
@@ -173,6 +189,7 @@ export function CharBuilderCreationInner(props: {
   content: ContentPackage;
   pageHeight: number;
   onFinishLoading: () => void;
+  onSourcesChange: (sources: number[]) => void;
 }) {
   const isMobile = isCharacterBuilderMobile();
   const isPhone = useMediaQuery(phoneQuery());
@@ -198,6 +215,7 @@ export function CharBuilderCreationInner(props: {
       content: props.content,
       context: 'CHARACTER-BUILDER',
       onFinishLoading: props.onFinishLoading,
+      onSourcesChange: props.onSourcesChange,
     },
   });
 

--- a/frontend/src/pages/character_sheet/CharacterSheetPage.tsx
+++ b/frontend/src/pages/character_sheet/CharacterSheetPage.tsx
@@ -1,5 +1,7 @@
 import { CharacterSaveStatus } from '@common/CharacterSaveStatus';
 import { CharacterLoadError } from '@common/CharacterLoadError';
+import { sessionState } from '@atoms/supabaseAtoms';
+import { useAtomValue } from 'jotai';
 import D20Loader from '@assets/images/D20Loader';
 import { glassStyle } from '@utils/colors';
 import BlurBox from '@common/BlurBox';
@@ -92,7 +94,12 @@ export function Component(props: {}) {
   };
 
   const theme = useMantineTheme();
+  const actorId = useAtomValue(sessionState)?.user.id ?? null;
   const [doneLoading, setDoneLoading] = useState(false);
+  const [sourceRequest, setSourceRequest] = useState<{ id: string; actor: string | null; sources: number[] }>();
+  const requestedSources =
+    sourceRequest?.id === characterId && sourceRequest.actor === actorId ? sourceRequest.sources : undefined;
+  useEffect(() => setDoneLoading(false), [characterId, actorId]);
 
   const {
     data: content,
@@ -100,7 +107,7 @@ export function Component(props: {}) {
     isError,
     refetch,
   } = useQuery({
-    queryKey: [`find-content-${characterId}`],
+    queryKey: [`find-content-${characterId}`, { actor: actorId, sources: requestedSources ?? null }],
     queryFn: async () => {
       // Set default sources
       const character = await makeRequest<Character>(
@@ -109,9 +116,9 @@ export function Component(props: {}) {
           id: characterId,
         },
         false,
-        { throwOnFailure: true }
+        { throwOnFailure: true, ...(actorId ? { expectedActorId: actorId } : {}) }
       );
-      const sv = defineDefaultSources('PAGE', character?.content_sources?.enabled ?? []);
+      const sv = defineDefaultSources('PAGE', requestedSources ?? character?.content_sources?.enabled ?? []);
 
       // Prefetch content sources (to avoid multiple requests)
       await fetchContentSources(sv);
@@ -190,6 +197,10 @@ export function Component(props: {}) {
           <CharacterSheetInner
             key={characterId}
             content={content}
+            onSourcesChange={(sources) => {
+              setDoneLoading(false);
+              setSourceRequest({ id: characterId, actor: actorId, sources });
+            }}
             characterId={parseInt(characterId)}
             onFinishLoading={() => {
               interval.stop();
@@ -207,7 +218,12 @@ export function Component(props: {}) {
  * tabbed panel area. Also owns the floating action buttons anchored to the
  * bottom-left corner (modes, campaign, dice roller).
  */
-function CharacterSheetInner(props: { content: ContentPackage; characterId: number; onFinishLoading: () => void }) {
+function CharacterSheetInner(props: {
+  content: ContentPackage;
+  characterId: number;
+  onFinishLoading: () => void;
+  onSourcesChange: (sources: number[]) => void;
+}) {
   const isTablet = useMediaQuery(tabletQuery());
   const isPhone = useMediaQuery(phoneQuery());
   const { ref, width, height } = useElementSize();
@@ -237,6 +253,7 @@ function CharacterSheetInner(props: { content: ContentPackage; characterId: numb
       content: props.content,
       context: 'CHARACTER-SHEET',
       onFinishLoading: props.onFinishLoading,
+      onSourcesChange: props.onSourcesChange,
     },
   });
 

--- a/frontend/src/pages/character_sheet/entity-handler.ts
+++ b/frontend/src/pages/character_sheet/entity-handler.ts
@@ -32,7 +32,9 @@ export function confirmHealth(
   if (result < 0) result = 0;
   if (result > maxHealth) result = maxHealth;
 
-  if (result === entity.hp_current) return;
+  // Completing initialization must clear reset_hp even when HP already equals
+  // the maximum. Otherwise a later condition calculation can erase new damage.
+  if (result === entity.hp_current && (keepResetHp || entity.meta_data?.reset_hp === false)) return;
 
   if (maxHealth === 0) return;
 
@@ -115,7 +117,11 @@ export function confirmPool(
  * Take a Breather (stamina variant, 10-min activity): spend 1 resolve point to restore
  * all stamina points. No-op if the entity has no resolve left.
  */
-export function handleTakeBreather(id: StoreID, entity: LivingEntity, setEntity?: SetterOrUpdater<LivingEntity | null>) {
+export function handleTakeBreather(
+  id: StoreID,
+  entity: LivingEntity,
+  setEntity?: SetterOrUpdater<LivingEntity | null>
+) {
   const maxResolve = getFinalResolveValue(id);
   // Negative pool values are the "uninitialized / full" sentinel
   const currentResolve = entity.resolve_current < 0 ? maxResolve : entity.resolve_current;

--- a/frontend/src/utils/campaign-characters-query.ts
+++ b/frontend/src/utils/campaign-characters-query.ts
@@ -1,0 +1,26 @@
+import type { Character } from '@schemas/content';
+import { makeRequest } from '@requests/request-manager';
+import { queryOptions } from '@tanstack/react-query';
+import { EncounterCharacterSchema } from './encounter-character-schema';
+
+/** Share campaign reads across the overview/drawer without clearing good data on an outage. */
+export function campaignCharactersQuery(campaignId: number, actorId?: string) {
+  return queryOptions({
+    queryKey: ['find-campaign-characters', { campaign_id: campaignId, actor: actorId ?? null }],
+    queryFn: async (): Promise<Character[]> => {
+      const characters = await makeRequest<Character[]>('find-character', { campaign_id: campaignId }, false, {
+        throwOnFailure: true,
+        ...(actorId ? { expectedActorId: actorId } : {}),
+      });
+      if (!EncounterCharacterSchema.array().safeParse(characters).success || !characters)
+        throw new Error('Campaign characters returned an invalid response');
+      // Validate without stripping extension fields in nested character JSON columns.
+      return characters;
+    },
+    refetchInterval: 5000,
+    refetchOnWindowFocus: 'always',
+    refetchOnReconnect: 'always',
+    // makeRequest already retries a transient read once; the interval is the next attempt.
+    retry: false,
+  });
+}

--- a/frontend/src/utils/character-version.ts
+++ b/frontend/src/utils/character-version.ts
@@ -1,0 +1,19 @@
+/**
+ * Compare server timestamps without losing PostgreSQL's sub-millisecond precision.
+ * Unknown/opaque tokens are unordered; equality guards still use their original text.
+ */
+export function compareCharacterVersions(left?: string, right?: string): -1 | 0 | 1 | null {
+  const parse = (value?: string): { milliseconds: number; remainder: string } | null => {
+    if (!value) return null;
+    const match = /^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.(\d{1,9}))?(?:Z|[+-]\d{2}:?\d{2})$/i.exec(value);
+    const milliseconds = Date.parse(value);
+    if (!match || !Number.isFinite(milliseconds)) return null;
+    return { milliseconds, remainder: (match[1] ?? '').padEnd(9, '0').slice(3) };
+  };
+  const first = parse(left);
+  const second = parse(right);
+  if (!first || !second) return null;
+  if (first.milliseconds !== second.milliseconds) return first.milliseconds < second.milliseconds ? -1 : 1;
+  if (first.remainder === second.remainder) return 0;
+  return first.remainder < second.remainder ? -1 : 1;
+}

--- a/frontend/src/utils/encounter-character-schema.ts
+++ b/frontend/src/utils/encounter-character-schema.ts
@@ -1,0 +1,35 @@
+import { CharacterSchema, ConditionSchema } from '@schemas/content';
+import { z } from 'zod';
+
+/**
+ * Validate fields consumed by encounter controls. Unrelated legacy/extension JSON is
+ * opaque here: editing HP must not depend on the shape of an old inventory or spell list.
+ */
+export const EncounterCharacterSchema = CharacterSchema.pick({
+  id: true,
+  name: true,
+  level: true,
+  hp_current: true,
+})
+  .extend({
+    updated_at: z.string().min(1),
+    details: z
+      .object({ conditions: z.array(ConditionSchema).optional(), image_url: z.string().optional() })
+      .passthrough()
+      .nullable(),
+    meta_data: z
+      .object({
+        reset_hp: z.boolean().optional(),
+        calculated_stats: z
+          .object({
+            hp_max: z.number().optional(),
+            ac: z.number().optional(),
+            profs: z.record(z.string(), z.object({ total: z.number() }).passthrough()).optional(),
+          })
+          .passthrough()
+          .optional(),
+      })
+      .passthrough()
+      .nullable(),
+  })
+  .passthrough();

--- a/frontend/src/utils/encounter-character-writer.ts
+++ b/frontend/src/utils/encounter-character-writer.ts
@@ -1,0 +1,222 @@
+import type { Character } from '@schemas/content';
+import { cloneDeep } from 'lodash-es';
+import { z } from 'zod';
+import { mergeCharacterSave } from './character-merge';
+import { compareCharacterVersions } from './character-version';
+import { EncounterCharacterSchema } from './encounter-character-schema';
+import {
+  bufferCharacterSave,
+  characterSaveValuesEqual,
+  journalCharacterSaveSubmission,
+  reconcileBufferedCharacterSave,
+  SAVED_CHARACTER_FIELDS,
+} from './character-save-buffer';
+
+export type EncounterCharacterSave = {
+  character: Character;
+  phase: 'saving' | 'saved' | 'failed' | 'conflict' | 'forbidden';
+  stored: boolean;
+  conflicts: string[];
+};
+type Entry = EncounterCharacterSave & {
+  base: Character;
+  running: boolean;
+  uncertain?: Character;
+  retries: number;
+  timer?: ReturnType<typeof setTimeout>;
+};
+type Request = (type: 'find-character' | 'update-character', body: Record<string, unknown>) => Promise<unknown>;
+const conflictSchema = z.object({ __conflict: z.literal(true), character: EncounterCharacterSchema });
+const forbiddenSchema = z.object({ __forbidden: z.literal(true) });
+
+/**
+ * Serialize encounter edits per character using the editor's existing merge and durable
+ * recovery format. Reads never write back unchanged rows; every write has a server token.
+ */
+export function createEncounterCharacterWriter(options: { actorId: string; request: Request; changed: () => void }) {
+  const entries = new Map<number, Entry>();
+  const writerId = `encounter:${crypto.randomUUID()}`;
+  let disposed = false;
+
+  const same = (left: Character, right: Character): boolean =>
+    SAVED_CHARACTER_FIELDS.every((field) => characterSaveValuesEqual(left[field], right[field]));
+  const publish = (): void => {
+    if (!disposed) options.changed();
+  };
+  const retain = (entry: Entry): void => {
+    entry.stored =
+      bufferCharacterSave(entry.character, options.actorId, entry.base.updated_at, {
+        requiresCalculation: true,
+        base: entry.base,
+        writerId,
+      }).status !== 'unavailable';
+  };
+  const reconcile = (entry: Entry, remote: Character): void => {
+    entry.base = cloneDeep(remote);
+    entry.uncertain = undefined;
+    entry.stored =
+      reconcileBufferedCharacterSave(entry.character, options.actorId, remote, {
+        requiresCalculation: !same(entry.character, remote),
+        writerId,
+      }).status !== 'unavailable';
+  };
+  const parseRow = (value: unknown, id: number): Character => {
+    const result = EncounterCharacterSchema.safeParse(value);
+    if (!result.success || result.data.id !== id || !result.data.updated_at)
+      throw new Error('Encounter update did not return a versioned character');
+    // Validate known fields without stripping newer/extension JSON properties: those
+    // siblings must survive when the API replaces a details or meta_data column.
+    return value as Character;
+  };
+
+  /** Re-read before retries, including an ambiguous write whose response was lost. */
+  const run = async (entry: Entry): Promise<void> => {
+    if (disposed || entry.running || entry.phase === 'conflict' || entry.phase === 'forbidden') return;
+    if (entry.timer) clearTimeout(entry.timer);
+    entry.timer = undefined;
+    entry.running = true;
+    entry.phase = 'saving';
+    publish();
+    try {
+      let remote = parseRow(await options.request('find-character', { id: entry.character.id }), entry.character.id);
+      let conflicts = 0;
+      while (!disposed) {
+        const merge = mergeCharacterSave(entry.base, entry.character, remote, entry.uncertain);
+        if (merge.conflicts.length || conflicts >= 3) {
+          entry.phase = 'conflict';
+          entry.conflicts = merge.conflicts.length ? merge.conflicts : ['Repeated remote changes'];
+          retain(entry);
+          break;
+        }
+        entry.character = merge.character;
+        reconcile(entry, remote);
+        if (same(entry.character, remote)) {
+          entry.phase = 'saved';
+          entry.retries = 0;
+          break;
+        }
+        const submitted = cloneDeep(entry.character);
+        // JSON columns are replaced by the API. Their unchanged children were preserved
+        // by the three-way merge above, and the guard catches changes after our read.
+        const changes = Object.fromEntries(
+          SAVED_CHARACTER_FIELDS.filter((field) => !characterSaveValuesEqual(submitted[field], remote[field])).map(
+            (field) => [field, submitted[field]]
+          )
+        );
+        entry.uncertain = submitted;
+        if (
+          journalCharacterSaveSubmission(submitted.id, options.actorId, submitted, remote.updated_at!, writerId)
+            .status === 'unavailable'
+        )
+          entry.stored = false;
+        const result = await options.request('update-character', {
+          id: submitted.id,
+          expected_updated_at: remote.updated_at,
+          ...changes,
+        });
+        if (disposed) return;
+        if (forbiddenSchema.safeParse(result).success) {
+          entry.phase = 'forbidden';
+          break;
+        }
+        const raced = conflictSchema.safeParse(result);
+        if (raced.success) {
+          remote = parseRow((result as { character: unknown }).character, submitted.id);
+          conflicts += 1;
+          continue;
+        }
+        remote = parseRow(Array.isArray(result) && result.length === 1 ? result[0] : null, submitted.id);
+        // Later local edits have the submitted body as their ancestor, not the old
+        // database row. A deliberate return to the original HP must survive this ACK.
+        const latest = mergeCharacterSave(submitted, entry.character, remote);
+        entry.character = latest.character;
+        reconcile(entry, remote);
+        entry.retries = 0;
+        if (latest.conflicts.length) {
+          entry.phase = 'conflict';
+          entry.conflicts = latest.conflicts;
+          retain(entry);
+          break;
+        }
+      }
+    } catch (error) {
+      if (disposed) return;
+      console.error('Encounter character save failed:', error);
+      entry.phase = 'failed';
+      retain(entry);
+      entry.timer = setTimeout(() => void run(entry), Math.min(30000, 2000 * 2 ** Math.min(entry.retries++, 4)));
+    } finally {
+      entry.running = false;
+      publish();
+    }
+  };
+
+  return {
+    /** React development mode reattaches effects once to verify cleanup. */
+    activate(): void {
+      disposed = false;
+      for (const entry of entries.values())
+        if (!entry.running && (entry.phase === 'saving' || entry.phase === 'failed')) void run(entry);
+    },
+    /** Accept only the HP/condition fields edited by the encounter controls. */
+    update(base: Character, edited: Character): void {
+      if (disposed) return;
+      const desired: Character = {
+        ...cloneDeep(base),
+        hp_current: edited.hp_current,
+      };
+      if (!characterSaveValuesEqual(base.details?.conditions, edited.details?.conditions))
+        desired.details = { ...cloneDeep(base.details), conditions: cloneDeep(edited.details?.conditions) };
+      if (!characterSaveValuesEqual(base.meta_data?.reset_hp, edited.meta_data?.reset_hp))
+        desired.meta_data = { ...cloneDeep(base.meta_data), reset_hp: edited.meta_data?.reset_hp };
+      if (same(base, desired)) return;
+      let entry = entries.get(base.id);
+      if (!entry || entry.phase === 'saved') {
+        entry = {
+          character: desired,
+          base: cloneDeep(base),
+          phase: 'saving',
+          stored: true,
+          conflicts: [],
+          running: false,
+          retries: 0,
+        };
+        entries.set(base.id, entry);
+      } else {
+        // The view includes queued edits. Apply only this new user action if a poll
+        // or acknowledgement arrived between rendering the control and submitting it.
+        entry.character = mergeCharacterSave(base, desired, entry.character).character;
+      }
+      retain(entry);
+      publish();
+      void run(entry);
+    },
+    /** Retain the acknowledged row until polling catches up, avoiding a visible revert. */
+    display(remote: Character): Character {
+      const entry = entries.get(remote.id);
+      if (!entry) return remote;
+      if (
+        entry.phase === 'saved' &&
+        (remote.updated_at === entry.base.updated_at ||
+          compareCharacterVersions(remote.updated_at, entry.base.updated_at) === 1)
+      )
+        return remote;
+      if (entry.phase !== 'saved' && compareCharacterVersions(remote.updated_at, entry.base.updated_at) !== -1)
+        return mergeCharacterSave(entry.base, entry.character, remote, entry.uncertain).character;
+      return entry.character;
+    },
+    status(id: number): EncounterCharacterSave | undefined {
+      return entries.get(id);
+    },
+    retry(id?: number): void {
+      for (const [characterId, entry] of entries) {
+        if ((id === undefined || id === characterId) && entry.phase === 'failed') void run(entry);
+      }
+    },
+    /** Unmount/account switches stop retries; versioned drafts remain for sheet recovery. */
+    dispose(): void {
+      disposed = true;
+      for (const entry of entries.values()) if (entry.timer) clearTimeout(entry.timer);
+    },
+  };
+}

--- a/frontend/src/utils/use-character.tsx
+++ b/frontend/src/utils/use-character.tsx
@@ -20,6 +20,8 @@ import type { CharacterSaveState } from '@common/CharacterSaveStatus';
 import { getCachedPublicUser } from '@auth/user-manager';
 import { applyConditions } from '@conditions/condition-handler';
 import { defineDefaultSources } from '@content/content-store';
+import { COMMON_CORE_ID } from '@constants/data';
+import { compareCharacterVersions } from './character-version';
 import { saveCustomization } from '@content/customization-cache';
 import { applyEquipmentPenalties } from '@items/inv-utils';
 import { useDebouncedValue, useDidUpdate } from '@mantine/hooks';
@@ -27,8 +29,8 @@ import { hideNotification, showNotification } from '@mantine/notifications';
 import { executeOperations, isOperationCancelled } from '@operations/operations.main';
 import { confirmHealth } from '@pages/character_sheet/entity-handler';
 import { hasSessionExpiredNotice, makeRequest } from '@requests/request-manager';
-import { useMutation } from '@tanstack/react-query';
-import { Character, ContentPackage, OperationCharacterResultPackage } from '@schemas/content';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { Character, CharacterSchema, ContentPackage, OperationCharacterResultPackage } from '@schemas/content';
 import { saveCalculatedStats } from '@variables/calculated-stats';
 import { setVariable } from '@variables/variable-manager';
 import { isEqual, isArray, cloneDeep } from 'lodash-es';
@@ -53,6 +55,7 @@ interface CharStateOptionsExecuteOps extends CharStateOptionsGeneric {
     content: ContentPackage;
     context: 'CHARACTER-SHEET' | 'CHARACTER-BUILDER';
     onFinishLoading: () => void;
+    onSourcesChange: (sources: number[]) => void;
   };
 }
 
@@ -64,6 +67,10 @@ interface CharStateOptionsSimple extends CharStateOptionsGeneric {
 type CharStateOptions = CharStateOptionsExecuteOps | CharStateOptionsSimple;
 
 type QueuedCharacterSave = { character: Character; actorId: string; scope: number };
+
+// Validate the concurrency envelope while retaining the complete authoritative row.
+const remoteCharacterVersionSchema = CharacterSchema.pick({ id: true, updated_at: true });
+const REMOTE_CHARACTER_INTERVAL = 5000;
 
 /** Offer the preserved input copy without automatically overwriting remote changes. */
 function showCharacterRecovery(characterId: number, recovery: Record<string, unknown>): void {
@@ -145,6 +152,7 @@ export default function useCharacter(
     characterRef.current = character;
   }, [character]);
   const lastSyncedRef = useRef<Character | null>(null);
+  const writeRevisionRef = useRef(0);
 
   // Latched when the server reports this session can read but not write the
   // character (RLS: e.g. anyone viewing a public sheet, incl. logged-out users).
@@ -420,10 +428,24 @@ export default function useCharacter(
   const debouncedOperationsHash = useMemo(() => getUpdateHash(debouncedCharacter), [debouncedCharacter]);
   const operationContent = options.type === 'EXECUTE_OPS' ? options.data.content : undefined;
   const operationContext = options.type === 'EXECUTE_OPS' ? options.data.context : undefined;
+  const onSourcesChangeRef = useRef<((sources: number[]) => void) | undefined>(undefined);
+  onSourcesChangeRef.current = options.type === 'EXECUTE_OPS' ? options.data.onSourcesChange : undefined;
+  const sourceKey = (ids: number[]) => [...new Set([COMMON_CORE_ID, ...ids])].sort((a, b) => a - b).join(',');
+  const characterSourcesKey = sourceKey(character?.content_sources?.enabled ?? []);
+  const loadedSources = operationContent?.defaultSources?.PAGE;
+  const contentSourcesMatch = !Array.isArray(loadedSources) || sourceKey(loadedSources) === characterSourcesKey;
+
+  useEffect(() => {
+    if (!hasLoadedCharacter || !operationContext || contentSourcesMatch) return;
+    // Reload the page's package for the reconciled inputs, including unsynced local
+    // source choices. Re-reading server sources here could create a reload loop.
+    onSourcesChangeRef.current?.(characterRef.current?.content_sources?.enabled ?? []);
+  }, [hasLoadedCharacter, contentSourcesMatch, characterSourcesKey, characterId, operationContext]);
 
   useEffect(() => {
     if (
       !hasLoadedCharacter ||
+      !contentSourcesMatch ||
       options.type !== 'EXECUTE_OPS' ||
       !debouncedCharacter ||
       debouncedCharacter.id !== characterId
@@ -466,6 +488,7 @@ export default function useCharacter(
     operationContext,
     operationAttempt,
     hasLoadedCharacter,
+    contentSourcesMatch,
   ]);
 
   const handleOperationResults = (results: OperationCharacterResultPackage, signal: AbortSignal) => {
@@ -556,6 +579,7 @@ export default function useCharacter(
     (options.type !== 'EXECUTE_OPS'
       ? !needsCalculationRef.current
       : !isCalculating &&
+        contentSourcesMatch &&
         executingOperations.current === null &&
         !operationError &&
         !!operationResults &&
@@ -594,6 +618,54 @@ export default function useCharacter(
     loadedActorRef.current === save.actorId &&
     sessionActorId === save.actorId;
 
+  /** Incoming reads and rejected saves share one merge, draft and conflict-resolution path. */
+  const receiveRemoteCharacter = (remote: Character, submitted?: Record<string, unknown>, repeatedConflict = false) => {
+    const base = lastSyncedRef.current;
+    const merge =
+      readOnlyRef.current || !loadedActorRef.current
+        ? { character: cloneDeep(remote), conflicts: [] }
+        : mergeCharacterSave(base, characterRef.current, remote, submitted);
+    const merged = merge.character;
+    pendingSaveRef.current = null;
+    if (merge.conflicts.length || repeatedConflict) {
+      characterRef.current = merged;
+      setCharacter(merged);
+      offerConflictResolution(
+        merged,
+        remote,
+        merge.conflicts.length ? merge.conflicts : ['Repeated changes from another session']
+      );
+      return null;
+    }
+    const changed = SAVED_CHARACTER_FIELDS.some(
+      (field) => !characterSaveValuesEqual(merged[field], characterRef.current?.[field])
+    );
+    const needsSave = SAVED_CHARACTER_FIELDS.some((field) => !characterSaveValuesEqual(merged[field], remote[field]));
+    // Advance the authoritative baseline BEFORE publishing incoming state. A clean
+    // remote edit is already saved; autosave must not echo it back to the server.
+    lastSyncedRef.current = remote;
+    const actor = loadedActorRef.current;
+    if (actor && !readOnlyRef.current) {
+      const reconciled = reconcileBufferedCharacterSave(merged, actor, remote, {
+        requiresCalculation:
+          needsCalculationRef.current ||
+          (options.type === 'EXECUTE_OPS' &&
+            (!canPersistRef.current() || getUpdateHash(merged) !== debouncedOperationsHash)),
+      });
+      setDraftStored(reconciled.status !== 'unavailable');
+    }
+    characterRef.current = merged;
+    if (!needsSave) {
+      retryCountRef.current = 0;
+      hideNotification('character-save-failed');
+      acknowledgeRecoveredDrafts();
+    }
+    if (changed) setCharacter(merged);
+    return { changed, needsSave };
+  };
+  const receiveRemoteRef = useRef(receiveRemoteCharacter);
+  receiveRemoteRef.current = receiveRemoteCharacter;
+
   // A successful calculation can release an edit that was waiting for derived values.
   useDidUpdate(() => {
     if (!debouncedCharacter || !canPersist()) return;
@@ -629,6 +701,7 @@ export default function useCharacter(
       const expected_updated_at = lastSyncedRef.current?.updated_at;
       if (!expected_updated_at) throw new Error('Reload the character to recover its save version');
       const data = Object.fromEntries(SAVED_CHARACTER_FIELDS.map((field) => [field, save.character[field]]));
+      writeRevisionRef.current += 1;
       uncertainSaveRef.current = { submitted: data, expectedUpdatedAt: expected_updated_at };
       journalCharacterSaveSubmission(save.character.id, save.actorId, data, expected_updated_at);
       const resData = await makeRequest(
@@ -682,53 +755,17 @@ export default function useCharacter(
       if (result.conflict) {
         const remote = result.server;
         if (!remote) return;
-        // Drop any stale queued snapshot — the merge produces the correct next save.
-        pendingSaveRef.current = null;
-        // The three-way merge needs the PREVIOUS synced state as its base; adopt the
-        // fresh concurrency token only after capturing it (and even when we skip
-        // merging below, so the next save uses the current token).
-        const base = lastSyncedRef.current;
-        lastSyncedRef.current = remote;
         if (remote.updated_at !== result.expected_updated_at) conflictStreakRef.current += 1;
-        const merge = mergeCharacterSave(base, characterRef.current, remote, result.submitted);
-        const merged = merge.character;
-        if (merge.conflicts.length > 0 || conflictStreakRef.current >= MAX_CONFLICT_STREAK) {
-          lastSyncedRef.current = base;
-          setCharacter(merged);
-          offerConflictResolution(
-            merged,
-            remote,
-            merge.conflicts.length ? merge.conflicts : ['Repeated changes from another session']
-          );
-          return;
-        }
-        // Only apply + notify when the merge actually changes local data. Equal on
-        // every saved field means the server row already matches what we have
-        // (pure token skew) — updating state anyway would fire a pointless save.
-        const changed =
-          !characterRef.current ||
-          SAVED_CHARACTER_FIELDS.some(
-            (field) => !characterSaveValuesEqual((merged as any)[field], (characterRef.current as any)[field])
-          );
-        const needsSave = SAVED_CHARACTER_FIELDS.some(
-          (field) => !characterSaveValuesEqual(merged[field], remote[field])
+        const received = receiveRemoteRef.current(
+          remote,
+          result.submitted,
+          conflictStreakRef.current >= MAX_CONFLICT_STREAK
         );
-        const reconciled = reconcileBufferedCharacterSave(merged, save.actorId, remote, {
-          requiresCalculation:
-            options.type === 'EXECUTE_OPS' &&
-            (!canPersistRef.current() || getUpdateHash(merged) !== debouncedOperationsHash),
-        });
-        setDraftStored(reconciled.status !== 'unavailable');
-        characterRef.current = merged;
-        if (needsSave) {
-          pendingSaveRef.current = { ...save, character: merged };
-        } else {
-          retryCountRef.current = 0;
-          hideNotification('character-save-failed');
-          acknowledgeRecoveredDrafts();
+        if (!received) return;
+        if (received.needsSave && characterRef.current) {
+          pendingSaveRef.current = { ...save, character: characterRef.current };
         }
-        if (!changed) return;
-        setCharacter(merged);
+        if (!received.changed) return;
         showNotification({
           icon: <IconRefresh />,
           title: 'Merged a remote update',
@@ -812,6 +849,59 @@ export default function useCharacter(
     setSavePhase('saving');
     mutateCharacterRaw(save);
   };
+
+  // React Query owns polling, visibility/reconnect behavior and request deduplication.
+  // Read snapshots carry their starting version so delayed reads cannot undo newer saves.
+  const { data: remoteSnapshot } = useQuery({
+    queryKey: ['character-remote-updates', characterId, sessionActorId],
+    queryFn: async () => {
+      const context = {
+        scope: saveScopeRef.current,
+        actor: loadedActorRef.current,
+        baseVersion: lastSyncedRef.current?.updated_at,
+        writeRevision: writeRevisionRef.current,
+      };
+      const remote = await makeRequest<Character>('find-character', { id: characterId }, false, {
+        ...(context.actor ? { expectedActorId: context.actor } : {}),
+        throwOnFailure: true,
+      });
+      if (!remote) return { ...context, character: null };
+      const version = remoteCharacterVersionSchema.safeParse(remote);
+      if (!version.success || version.data.id !== characterId || !version.data.updated_at) {
+        console.warn('Ignoring an invalid remote character version');
+        throw new Error('Remote character version is unavailable');
+      }
+      return { ...context, character: remote };
+    },
+    enabled: hasLoadedCharacter && isOnline && !loadError && !saveConflictRef.current,
+    refetchInterval: REMOTE_CHARACTER_INTERVAL,
+    refetchIntervalInBackground: false,
+    refetchOnWindowFocus: 'always',
+    refetchOnReconnect: 'always',
+    retry: false,
+  });
+
+  useEffect(() => {
+    if (
+      !hasLoadedCharacter ||
+      !remoteSnapshot?.character ||
+      remoteSnapshot.scope !== saveScopeRef.current ||
+      remoteSnapshot.actor !== loadedActorRef.current ||
+      remoteSnapshot.actor !== sessionActorId ||
+      remoteSnapshot.baseVersion !== lastSyncedRef.current?.updated_at ||
+      remoteSnapshot.writeRevision !== writeRevisionRef.current ||
+      savingRef.current ||
+      uncertainSaveRef.current ||
+      saveConflictRef.current
+    )
+      return;
+    const remote = remoteSnapshot.character;
+    const base = lastSyncedRef.current;
+    if (remote.id !== characterId || !base?.updated_at || !remote.updated_at || remote.updated_at === base.updated_at)
+      return;
+    if (compareCharacterVersions(remote.updated_at, base.updated_at) === -1) return;
+    receiveRemoteRef.current(remote);
+  }, [remoteSnapshot, hasLoadedCharacter, characterId, sessionActorId]);
 
   retrySaveRef.current = () => {
     const current = characterRef.current;


### PR DESCRIPTION
Open character sheets previously ignored live campaign changes. This restores visible-page refreshes every five seconds and on reconnect/focus, reconciles incoming rows against the saved baseline before publishing them, and rejects delayed reads that predate a newer write or account/route change. Local edits keep the existing guarded save, draft recovery, and explicit conflict flow. Changed sources reload the reconciled content package before operations can calculate or persist.

GM encounter edits now use versioned, serialized writes that preserve unrelated player fields. Pending HP survives polling and responsive layout changes, failed saves retain a recoverable copy and retry, and Enter/blur submits once. Both campaign surfaces share a scoped five-second reader that retains good data through outages. The HP input also accepts pointer events correctly, and player-only encounters skip the unnecessary content-package fetch.

Initializing HP already at maximum now clears its reset flag, preventing a later condition calculation from erasing incoming damage. Picker search indexes update when the catalog arrives or eligible options change, fixing empty search results after typing during loading. Deferred cursor rewrites no longer interfere with clearing combat inputs.

Validation: 114 focused save/recovery/selector tests, 83 rules tests, TypeScript/build, lint (zero errors; existing warnings), release checks, and documentation links. All 12 targeted local browser scenarios pass across the final focused runs. Real local API/browser scenarios cover incoming damage/conditions, stale reads, source recovery, two authenticated GM/player identities, delayed/lost saves, prepared spells, skill progression, and phone-width layout changes. Final-revision CI passes, including all 24 browser scenarios and 54 API tests; the production compatibility gate passes for the exact reviewed commit. Production API preflight also passed all 26 checks with verified temporary-account cleanup. Phone-width/CPU simulation does not constitute physical iOS/Android process-eviction testing.
