### PR TITLE
Fix homebrew operation ordering and delayed content loading

### DIFF
--- a/docs/development.mdx
+++ b/docs/development.mdx
@@ -152,6 +152,23 @@ These bundle the actual operation engine and drawer components against explicit 
 selected rules content comes from the checked-in sanitized data dump. They need no running
 database or authentication account.
 
+The broad PF2e matrix is part of `test:rules`: **1,211 comparisons across 469 engine
+calculations**, grouped into 49 named scenarios and a coverage guard. It loads four
+official sources from the checked-in dump, uses fixed content identities, and freezes
+fixtures so one calculation cannot change later inputs. A discrepancy fails the command
+and CI. It requires no ignored audit exports or local database. To run only that matrix:
+
+```bash
+node --test frontend/scripts/pf2e-matrix.test.mjs
+```
+
+These are correlated comparisons, not 1,211 independent user journeys. They cover
+Fighter, Wizard, Rogue and Monk at selected levels, controlled attributes, condition
+combinations, armor thresholds, variants, replay and selected skill progression. They
+do not certify complete legal builds, every class/archetype, every property rune or
+arbitrary homebrew. Absolute rule examples and condition deltas have separate oracles;
+a baseline comparison alone cannot establish the correctness of that baseline.
+
 The rules suite includes the retained PF2e stress cases for combined typed modifiers,
 attack attributes, armor potency, speed penalties, deterministic condition derivation,
 and explicit Drained/Dying/Wounded transitions. The infrastructure suite verifies
@@ -159,6 +176,11 @@ coupled HP/condition conflicts, including companion levels and lost acknowledgem
 The Cypress `conditionMath.cy.ts` and `encounterSync.cy.ts` specs exercise these edits
 through actual sheet and GM controls, local API saves, mobile viewports, reloading,
 and simulated connection failures. They create and clean up synthetic characters.
+The sheet spec also holds a required content response, verifies no partial save occurs,
+then checks nested homebrew variables and binding chains through level changes and
+reopening. A cyclic homebrew graph must show calculation recovery without persisting
+partial math. The fast homebrew tests cover conditional custom Lore, binding order,
+self-links, repeated assignments, long chains, and companion isolation.
 
 Run request recovery, buffered character saves, and worker lifecycle regressions with
 `npm --prefix frontend run test:infra`. These exercise the real request manager, save hook,
@@ -167,6 +189,15 @@ boundaries. They require no running database or production credentials. CI runs 
 regression suites before the production build. The content selector tests also exercise an
 already typed search while its catalog is still loading, and verify that removed sources
 or filtered choices disappear from search results without another keystroke.
+
+Timing failures belong in the correctness suite when they can change results. Cache
+tests hold IndexedDB reads, writes and deletion independently: fresh downloads must
+continue, and a late cache cannot resurrect content a completed download says is absent.
+Worker tests include the production four-worker pool, queued companions, rapid owner
+changes, reversed completions and a worker failure. These are deterministic integration
+tests with controlled I/O boundaries; Cypress adds the actual browser, worker and API.
+A passing run is evidence for these behaviors, not a universal clean bill of health or
+a physical iPhone/Android performance benchmark.
 
 ## Creating a user
 

--- a/docs/guides/content-data.mdx
+++ b/docs/guides/content-data.mdx
@@ -32,6 +32,14 @@ Browser caches follow the signed-in account and resolved source set, and resets 
 late requests and hydration from the previous cache generation. Content cache cleanup
 preserves unsynced character drafts.
 
+Optional browser-cache work cannot block authoritative content loading. Homebrew
+invalidation clears the current in-memory generation immediately and queues persistent
+deletion in order with other storage writes. Cache hydration has a 2.5-second deadline;
+after that deadline its late result cannot publish rows, even after a delayed source
+version check. A successful empty download therefore stays empty. If browser storage
+itself remains stalled, fresh content still loads but persistence waits for that storage
+operation to finish.
+
 The builder waits for the current character's authoritative save context before
 exposing editable controls. A cached route row cannot make the form ready early.
 A failed load leaves the character route available for retry. Save status distinguishes

--- a/docs/guides/operations.mdx
+++ b/docs/guides/operations.mdx
@@ -67,6 +67,10 @@ Introduce a new named variable on the character. Used for variables that aren’
 ```
 
 If the variable already exists, this is a no-op.
+An active conditional branch can create its own variables. The selected branch's
+declarations run before its proficiency guards and other effects; inactive branches
+create nothing. Recalculating after a level or selection change removes variables
+whose creating branch no longer runs.
 
 ### `setValue`
 
@@ -210,6 +214,13 @@ Bind one variable to another’s source so the bound value follows the original.
 ```
 
 `storeId` is `'CHARACTER'` for the active character; companion stores use their own IDs.
+Bindings resolve after ordinary operations and explicit language overrides. A chain
+reads each source's final bound value regardless of authoring order. Multiple bindings
+to one target retain their authored assignment order and the variable's existing setter
+rules: ordinary numeric values use the last assignment, while speeds and class HP per
+level retain the highest value. Self-copies do nothing. A dependency cycle between
+distinct variables fails the calculation with its variable path; the sheet retains
+its last completed state until the graph is corrected.
 
 ---
 

--- a/frontend/cypress/e2e/characters/conditionMath.cy.ts
+++ b/frontend/cypress/e2e/characters/conditionMath.cy.ts
@@ -293,6 +293,17 @@ describe('Condition math and recovery through the real sheet', () => {
   });
 
   it('waits for delayed content before saving nested homebrew effects and preserves them through level changes', () => {
+    // Level changes can save HP normalization before the calculated-stat update.
+    // Read the API again until it confirms the expected result, rather than
+    // assuming the first intercepted save was the final calculation.
+    const savedMaximum = (expected: number, retries = 40): Cypress.Chainable<unknown> =>
+      read().then((saved) => {
+        if (saved.meta_data.calculated_stats.hp_max === expected || retries === 0) {
+          expect(saved.meta_data.calculated_stats.hp_max).to.eq(expected);
+          return;
+        }
+        return cy.wait(250, { log: false }).then(() => savedMaximum(expected, retries - 1));
+      });
     read().then((base) =>
       request('update-character', {
         id: characterId,
@@ -360,7 +371,7 @@ describe('Condition math and recovery through the real sheet', () => {
     cy.wait('@homebrewSave', { timeout: 30000 });
     settled();
     cy.contains('Hit Points', { timeout: 30000 }).parent().find('a').should('have.text', '53');
-    read().its('meta_data.calculated_stats.hp_max').should('eq', 53);
+    savedMaximum(53);
     cy.screenshot('homebrew-conditional-bindings-mobile');
     for (const [level, maximum] of [
       [1, 17],
@@ -373,7 +384,7 @@ describe('Condition math and recovery through the real sheet', () => {
       cy.wait('@homebrewSave', { timeout: 30000 });
       settled();
       cy.contains('Hit Points', { timeout: 30000 }).parent().find('a').should('have.text', String(maximum));
-      read().its('meta_data.calculated_stats.hp_max').should('eq', maximum);
+      savedMaximum(maximum);
     }
     cy.reload();
     cy.contains('Hit Points', { timeout: 30000 }).parent().find('a').should('have.text', '53');

--- a/frontend/cypress/e2e/characters/conditionMath.cy.ts
+++ b/frontend/cypress/e2e/characters/conditionMath.cy.ts
@@ -2,6 +2,7 @@
 describe('Condition math and recovery through the real sheet', () => {
   let characterId: number;
   let token: string;
+  let releaseContent: (() => void) | undefined;
   const request = (endpoint: string, body: Record<string, unknown>) =>
     cy
       .request({
@@ -61,6 +62,7 @@ describe('Condition math and recovery through the real sheet', () => {
       .then((text) => parseInt(text));
   beforeEach(() => {
     characterId = 0;
+    releaseContent = undefined;
     cy.viewport(1280, 900);
     cy.intercept('POST', '**/auth/v1/token*').as('signIn');
     cy.login(Cypress.env('TEST_EMAIL'), Cypress.env('TEST_PASSWORD'));
@@ -94,6 +96,7 @@ describe('Condition math and recovery through the real sheet', () => {
     });
   });
   afterEach(() => {
+    releaseContent?.();
     if (characterId && token)
       request('delete-content', { id: characterId, type: 'character' }).then(() =>
         request('find-character', { id: [characterId] }).should('deep.equal', [])
@@ -287,5 +290,147 @@ describe('Condition math and recovery through the real sheet', () => {
       }
     });
     cy.screenshot('drained-lost-ack-recovered-mobile');
+  });
+
+  it('waits for delayed content before saving nested homebrew effects and preserves them through level changes', () => {
+    read().then((base) =>
+      request('update-character', {
+        id: characterId,
+        expected_updated_at: base.updated_at,
+        custom_operations: [
+          ...base.custom_operations,
+          {
+            id: 'homebrew-conditional',
+            type: 'conditional',
+            data: {
+              conditions: [
+                { id: 'homebrew-level', name: 'LEVEL', type: 'num', operator: 'GREATER_THAN_OR_EQUALS', value: '5' },
+              ],
+              trueOperations: [
+                {
+                  id: 'homebrew-counter',
+                  type: 'createValue',
+                  data: { variable: 'BREW_COUNTER', type: 'num', value: 2 },
+                },
+                { id: 'homebrew-adjust', type: 'adjValue', data: { variable: 'BREW_COUNTER', value: 3 } },
+                { id: 'homebrew-link', type: 'createValue', data: { variable: 'BREW_LINK', type: 'num', value: 0 } },
+                {
+                  id: 'homebrew-hp',
+                  type: 'bindValue',
+                  data: { variable: 'MAX_HEALTH_BONUS', value: { storeId: 'CHARACTER', variable: 'BREW_LINK' } },
+                },
+                {
+                  id: 'homebrew-final',
+                  type: 'bindValue',
+                  data: { variable: 'BREW_LINK', value: { storeId: 'CHARACTER', variable: 'BREW_COUNTER' } },
+                },
+              ],
+              falseOperations: [
+                { id: 'homebrew-low-level', type: 'setValue', data: { variable: 'MAX_HEALTH_BONUS', value: 1 } },
+              ],
+            },
+          },
+        ],
+      })
+    );
+    let saves = 0;
+    let contentRequests = 0;
+    const gate = new Promise<void>((resolve) => {
+      releaseContent = resolve;
+    });
+    cy.intercept('POST', '**/functions/v1/update-character', (req) => {
+      saves++;
+      req.continue();
+    }).as('homebrewSave');
+    cy.intercept('POST', '**/functions/v1/get-content-versions', { body: { status: 'success', data: [] } });
+    cy.intercept('POST', '**/functions/v1/find-ability-block', (req) => {
+      contentRequests++;
+      return gate.then(() => {
+        req.continue();
+      });
+    });
+    cy.viewport(390, 844);
+    cy.visit(`/sheet/${characterId}`);
+    cy.wrap(null).should(() => expect(contentRequests, 'the required table is held').to.be.greaterThan(0));
+    cy.contains('Hit Points').should('not.exist');
+    cy.then(() => {
+      expect(saves, 'no partial calculation can save').to.eq(0);
+      releaseContent?.();
+    });
+    cy.wait('@homebrewSave', { timeout: 30000 });
+    settled();
+    cy.contains('Hit Points', { timeout: 30000 }).parent().find('a').should('have.text', '53');
+    read().its('meta_data.calculated_stats.hp_max').should('eq', 53);
+    cy.screenshot('homebrew-conditional-bindings-mobile');
+    for (const [level, maximum] of [
+      [1, 17],
+      [5, 53],
+    ]) {
+      read().then((base) =>
+        request('update-character', { id: characterId, expected_updated_at: base.updated_at, level })
+      );
+      cy.reload();
+      cy.wait('@homebrewSave', { timeout: 30000 });
+      settled();
+      cy.contains('Hit Points', { timeout: 30000 }).parent().find('a').should('have.text', String(maximum));
+      read().its('meta_data.calculated_stats.hp_max').should('eq', maximum);
+    }
+    cy.reload();
+    cy.contains('Hit Points', { timeout: 30000 }).parent().find('a').should('have.text', '53');
+    settled();
+  });
+
+  it('shows a cyclic homebrew calculation error without saving partial math and recovers after correction', () => {
+    cy.intercept('POST', '**/functions/v1/update-character').as('baselineHomebrewSave');
+    cy.visit(`/sheet/${characterId}`);
+    cy.wait('@baselineHomebrewSave', { timeout: 30000 });
+    settled();
+    read().then((base) =>
+      request('update-character', {
+        id: characterId,
+        expected_updated_at: base.updated_at,
+        custom_operations: [
+          ...base.custom_operations,
+          { id: 'cycle-a', type: 'createValue', data: { variable: 'BREW_A', type: 'num', value: 1 } },
+          { id: 'cycle-b', type: 'createValue', data: { variable: 'BREW_B', type: 'num', value: 2 } },
+          {
+            id: 'cycle-first',
+            type: 'bindValue',
+            data: { variable: 'BREW_A', value: { storeId: 'CHARACTER', variable: 'BREW_B' } },
+          },
+          {
+            id: 'cycle-second',
+            type: 'bindValue',
+            data: { variable: 'BREW_B', value: { storeId: 'CHARACTER', variable: 'BREW_A' } },
+          },
+        ],
+      })
+    );
+    let saves = 0;
+    cy.intercept('POST', '**/functions/v1/update-character', (req) => {
+      saves++;
+      req.continue();
+    });
+    cy.viewport(390, 844);
+    cy.reload();
+    cy.contains("Couldn't calculate this character", { timeout: 30000 }).should('be.visible');
+    cy.contains('button', 'Retry calculation').should('be.enabled');
+    cy.then(() => expect(saves, 'failed homebrew cannot save derived state').to.eq(0));
+    read().its('meta_data.calculated_stats.hp_max').should('eq', 48);
+    cy.screenshot('homebrew-cycle-paused-mobile');
+    read().then((base) =>
+      request('update-character', {
+        id: characterId,
+        expected_updated_at: base.updated_at,
+        custom_operations: base.custom_operations.filter(
+          (operation: { id: string }) => !operation.id.startsWith('cycle-')
+        ),
+      })
+    );
+    cy.reload();
+    cy.contains('Hit Points', { timeout: 30000 }).should('be.visible');
+    cy.contains("Couldn't calculate this character").should('not.exist');
+    settled();
+    read().its('meta_data.calculated_stats.hp_max').should('eq', 48);
   });
 });

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,7 @@
     "predeploy": "tsc && vite build",
     "deploy": "gh-pages -d dist",
     "lint": "eslint src --ext ts,tsx --report-unused-disable-directives",
-    "test:rules": "node --test scripts/feat-selection.test.mjs scripts/language-operations.test.mjs scripts/eidolon-runes.test.mjs scripts/item-drawers.test.mjs scripts/inventory-panel.test.mjs scripts/operation-removal.test.mjs scripts/skill-progression.test.mjs scripts/pf2e-stress-audit.mjs scripts/condition-compilation.test.mjs scripts/health-transitions.test.mjs scripts/modifier-math.test.mjs",
+    "test:rules": "node --test scripts/feat-selection.test.mjs scripts/language-operations.test.mjs scripts/eidolon-runes.test.mjs scripts/item-drawers.test.mjs scripts/inventory-panel.test.mjs scripts/operation-removal.test.mjs scripts/skill-progression.test.mjs scripts/pf2e-stress-audit.mjs scripts/condition-compilation.test.mjs scripts/health-transitions.test.mjs scripts/modifier-math.test.mjs scripts/pf2e-matrix.test.mjs scripts/homebrew-operations.test.mjs",
     "test:infra": "node --test scripts/operation-lifecycle.test.mjs scripts/session-recovery.test.mjs scripts/character-save-lifecycle.test.mjs scripts/encounter-character-writer.test.mjs scripts/content-cache.test.mjs scripts/content-selection.test.mjs scripts/browser-recovery.test.mjs scripts/character-health-merge.test.mjs",
     "preview": "vite preview",
     "start:local": "vite",

--- a/frontend/scripts/content-cache.test.mjs
+++ b/frontend/scripts/content-cache.test.mjs
@@ -15,13 +15,19 @@ const deferred = () => {
 };
 
 /** Exercise real cache logic with explicit session, network and IndexedDB boundaries. */
-test('content packages and cache respect failures, sources, actors and generations', async () => {
+test('content packages and cache respect failures, sources, actors and generations', async (t) => {
   const directory = await mkdtemp(join(tmpdir(), 'wg-content-cache-'));
   const state = (globalThis.__contentCacheTest = {
     actor: 'A',
     records: new Map(),
     requests: [],
     read: async (key) => state.records.get(key),
+    write: async (key, value) => {
+      state.records.set(key, structuredClone(value));
+    },
+    delete: async (key) => {
+      state.records.delete(key);
+    },
     request: async () => [],
     session: async () => ({ data: { session: { user: { id: state.actor } } } }),
   });
@@ -30,7 +36,7 @@ test('content packages and cache respect failures, sources, actors and generatio
     'supabase-client': `export const supabase = {auth:{getSession:()=>globalThis.__contentCacheTest.session()}};`,
     '@requests/request-manager': `export const makeRequest = async (...args) => { globalThis.__contentCacheTest.requests.push(args); return globalThis.__contentCacheTest.request(...args); };`,
     '@utils/images': `export const preloadImage = async () => {};`,
-    'content-cache-db': `export const idbGet = key => globalThis.__contentCacheTest.read(key); export const idbSet = async (key,value) => {globalThis.__contentCacheTest.records.set(key,structuredClone(value));}; export const idbDelete = async key => {globalThis.__contentCacheTest.records.delete(key);};`,
+    'content-cache-db': `export const idbGet = key => globalThis.__contentCacheTest.read(key); export const idbSet = (key,value) => globalThis.__contentCacheTest.write(key,value); export const idbDelete = key => globalThis.__contentCacheTest.delete(key);`,
   };
   let store;
   try {
@@ -174,6 +180,128 @@ test('content packages and cache respect failures, sources, actors and generatio
       /content-source/,
       'failed source resolution cannot masquerade as an empty source set'
     );
+    await t.test('a stalled optional cache deletion cannot block fresh homebrew content', async () => {
+      const deleting = deferred();
+      state.delete = () => deleting.promise;
+      state.request = async () => [row];
+      store.resetContentStore(false, true);
+      const pending = store.fetchContent('language', query);
+      let timeout;
+      try {
+        const result = await Promise.race([
+          pending,
+          new Promise((resolve) => {
+            timeout = setTimeout(() => resolve('blocked'), 3000);
+          }),
+        ]);
+        assert.notEqual(result, 'blocked', 'optional storage must not prevent a healthy network read');
+        assert.equal(result[0].id, row.id);
+      } finally {
+        clearTimeout(timeout);
+        deleting.resolve();
+        await pending;
+        state.delete = async (key) => {
+          state.records.delete(key);
+        };
+      }
+    });
+    await t.test('late hydration cannot resurrect rows absent from a fresh source download', async () => {
+      const reading = deferred();
+      state.read = () => reading.promise;
+      state.request = async () => [];
+      store.resetContentStore(false);
+      try {
+        assert.deepEqual(await store.fetchContent('language', { content_sources: [81000] }), []);
+        reading.resolve({
+          version: 4,
+          actorId: state.actor,
+          savedAt: Date.now(),
+          idStore: new Map([['language', new Map([[row.id, row]])]]),
+          contentStore: new Map(),
+        });
+        await new Promise((resolve) => setImmediate(resolve));
+        assert.deepEqual(store.getCachedContent('language'), [], 'late cache rows must not reappear in selectors');
+        assert.deepEqual(await store.fetchContent('language', query), [], 'ID lookups must respect the fresh download');
+      } finally {
+        reading.resolve(null);
+        state.read = async (key) => state.records.get(key);
+        store.resetContentStore(false, true);
+      }
+    });
+    await t.test('fresh content stays usable and survives deletion queued behind an old write', async (t) => {
+      store.resetContentStore(false, true);
+      await new Promise((resolve) => setImmediate(resolve));
+      t.mock.timers.enable({ apis: ['setTimeout'] });
+      const writing = deferred();
+      const started = deferred();
+      let fresh;
+      state.write = async (key, value) => {
+        if (value.idStore.get('language')?.get(row.id)?.name === 'Before homebrew edit') {
+          started.resolve();
+          await writing.promise;
+        }
+        state.records.set(key, structuredClone(value));
+      };
+      try {
+        state.request = async () => [{ ...row, name: 'Before homebrew edit' }];
+        await store.fetchContent('language', query);
+        t.mock.timers.tick(10000);
+        await started.promise;
+        store.resetContentStore(false, true);
+        state.request = async () => [{ ...row, name: 'After homebrew edit' }];
+        let displayed;
+        fresh = store.fetchContent('language', query).then((rows) => {
+          displayed = rows;
+          return rows;
+        });
+        await new Promise((resolve) => setImmediate(resolve));
+        assert.equal(displayed?.[0].name, 'After homebrew edit', 'a stuck old write must not block fresh content');
+        t.mock.timers.tick(10000);
+        writing.resolve();
+        await new Promise((resolve) => setImmediate(resolve));
+        const saved = state.records.get(`content-store:${state.actor}`);
+        assert.equal(saved.idStore.get('language').get(row.id).name, 'After homebrew edit');
+        store.resetContentStore(false);
+        state.request = async () => {
+          throw new Error('The fresh persisted copy should satisfy this read');
+        };
+        assert.equal((await store.fetchContent('language', query))[0].name, 'After homebrew edit');
+      } finally {
+        writing.resolve();
+        await fresh;
+        state.write = async (key, value) => {
+          state.records.set(key, structuredClone(value));
+        };
+        store.resetContentStore(false, true);
+      }
+    });
+    await t.test('a late source-version response cannot publish its timed-out snapshot', async () => {
+      const checking = deferred();
+      const snapshot = {
+        version: 4,
+        actorId: state.actor,
+        savedAt: Date.now(),
+        idStore: new Map([
+          ['content-source', new Map([[81000, { id: 81000, updated_at: 'old-source-token' }]])],
+          ['language', new Map([[row.id, row]])],
+        ]),
+        contentStore: new Map(),
+      };
+      state.read = async () => snapshot;
+      state.request = async (type) => (type === 'get-content-versions' ? checking.promise : []);
+      store.resetContentStore(false);
+      try {
+        assert.deepEqual(await store.fetchContent('language', { content_sources: [81000] }), []);
+        checking.resolve([{ id: 81000, updated_at: 'old-source-token' }]);
+        await new Promise((resolve) => setImmediate(resolve));
+        assert.deepEqual(store.getCachedContent('language'), []);
+        assert.deepEqual(await store.fetchContent('language', query), []);
+      } finally {
+        checking.resolve(null);
+        state.read = async (key) => state.records.get(key);
+        store.resetContentStore(false, true);
+      }
+    });
   } finally {
     store?.resetContentStore(true, true);
     await rm(directory, { recursive: true, force: true });

--- a/frontend/scripts/homebrew-operations.test.mjs
+++ b/frontend/scripts/homebrew-operations.test.mjs
@@ -210,3 +210,72 @@ test('nested skill guards can read a variable created earlier in their active br
   ]);
   assert.equal(packet.store.variables.SKILL_LORE_BREW.value.value, 'E');
 });
+
+test('all proficiency assignments preserve attribute metadata before downstream copies', async () => {
+  const packet = await calculate([
+    op('create-first-prof', 'createValue', {
+      variable: 'BREW_FIRST_PROF',
+      type: 'prof',
+      value: { value: 'T', attribute: 'ATTRIBUTE_STR' },
+    }),
+    op('create-second-prof', 'createValue', { variable: 'BREW_SECOND_PROF', type: 'prof', value: { value: 'E' } }),
+    bind('SAVE_FORT', 'SAVE_REFLEX', 'downstream-reflex'),
+    bind('SAVE_REFLEX', 'BREW_FIRST_PROF', 'initial-proficiency'),
+    bind('SAVE_REFLEX', 'BREW_SECOND_PROF', 'final-proficiency'),
+  ]);
+  assert.equal(packet.store.variables.SAVE_REFLEX.value.value, 'E');
+  assert.equal(packet.store.variables.SAVE_REFLEX.value.attribute, 'ATTRIBUTE_STR');
+  assert.equal(packet.store.variables.SAVE_FORT.value.value, 'E');
+  assert.equal(packet.store.variables.SAVE_FORT.value.attribute, 'ATTRIBUTE_STR');
+});
+
+test('removed cyclic grants do not enter the remaining binding graph', async () => {
+  const feat = {
+    id: 92001,
+    name: 'Removed cyclic grant',
+    type: 'feat',
+    level: 1,
+    operations: [bind('BREW_A', 'BREW_B', 'removed-forward'), bind('BREW_B', 'BREW_A', 'removed-backward')],
+  };
+  engine.setFixtures([{ table: 'ability_block', row: feat }]);
+  try {
+    const packet = await calculate([
+      create('BREW_A', 3),
+      create('BREW_B', 7),
+      op('give-cyclic-feat', 'giveAbilityBlock', { type: 'feat', abilityBlockId: 92001 }),
+      op('remove-cyclic-feat', 'removeAbilityBlock', { type: 'feat', abilityBlockId: 92001 }),
+      bind('MAX_HEALTH_BONUS', 'BREW_A'),
+      bind('BREW_A', 'BREW_B', 'remaining-link'),
+    ]);
+    assert.equal(packet.store.variables.BREW_A.value, 7);
+    assert.equal(packet.store.variables.MAX_HEALTH_BONUS.value, 7);
+  } finally {
+    engine.setFixtures([]);
+  }
+});
+
+test('removing a later assignment preserves an independent earlier binding', async () => {
+  const feat = {
+    id: 92002,
+    name: 'Removed later binding',
+    type: 'feat',
+    level: 1,
+    operations: [bind('BREW_A', 'BREW_SECOND', 'removed-assignment')],
+  };
+  engine.setFixtures([{ table: 'ability_block', row: feat }]);
+  try {
+    const packet = await calculate([
+      create('BREW_A'),
+      create('BREW_FIRST', 3),
+      create('BREW_SECOND', 7),
+      bind('MAX_HEALTH_BONUS', 'BREW_A'),
+      bind('BREW_A', 'BREW_FIRST', 'independent-assignment'),
+      op('give-later-assignment', 'giveAbilityBlock', { type: 'feat', abilityBlockId: 92002 }),
+      op('remove-later-assignment', 'removeAbilityBlock', { type: 'feat', abilityBlockId: 92002 }),
+    ]);
+    assert.equal(packet.store.variables.BREW_A.value, 3);
+    assert.equal(packet.store.variables.MAX_HEALTH_BONUS.value, 3);
+  } finally {
+    engine.setFixtures([]);
+  }
+});

--- a/frontend/scripts/homebrew-operations.test.mjs
+++ b/frontend/scripts/homebrew-operations.test.mjs
@@ -1,0 +1,212 @@
+/** Run authored homebrew graphs through the same controller used by the worker. */
+import assert from 'node:assert/strict';
+import { after, before, test } from 'node:test';
+import { createOperationEngine } from './operation-test-harness.mjs';
+
+let engine;
+const content = {
+  abilityBlocks: [],
+  items: [],
+  classes: [],
+  traits: [],
+  ancestries: [],
+  backgrounds: [],
+  languages: [],
+  spells: [],
+  archetypes: [],
+  versatileHeritages: [],
+  classArchetypes: [],
+  sources: [],
+  defaultSources: { PAGE: [], INFO: [] },
+};
+const op = (id, type, data) => ({ id, type, data });
+const create = (variable, value = 0) => op(`create-${variable}`, 'createValue', { variable, type: 'num', value });
+const bind = (variable, source, id = `bind-${variable}`) =>
+  op(id, 'bindValue', { variable, value: { storeId: 'CHARACTER', variable: source } });
+const set = (variable, value) => op(`set-${variable}`, 'setValue', { variable, value });
+const adjust = (variable, value) => op(`adjust-${variable}`, 'adjValue', { variable, value });
+const character = (operations, level = 5) => ({
+  id: 1,
+  level,
+  details: {},
+  inventory: { items: [] },
+  operation_data: { selections: {} },
+  options: { custom_operations: true },
+  custom_operations: operations,
+});
+const calculate = (operations, level) =>
+  engine._executeCharacterOperations({ character: character(operations, level), content, context: 'CHARACTER-SHEET' });
+
+before(async () => {
+  engine = await createOperationEngine();
+});
+after(async () => {
+  await engine?.cleanup();
+});
+
+test('an active conditional creates its custom counter before its adjustments and final HP binding', async () => {
+  const packet = await calculate([
+    op('active-branch', 'conditional', {
+      conditions: [],
+      trueOperations: [create('BREW_COUNTER', 2), adjust('BREW_COUNTER', 3), bind('MAX_HEALTH_BONUS', 'BREW_COUNTER')],
+    }),
+  ]);
+  assert.deepEqual(packet.errors, []);
+  assert.equal(packet.store.variables.BREW_COUNTER?.value, 5);
+  assert.equal(packet.store.variables.MAX_HEALTH_BONUS.value, 5);
+});
+
+test('a binding chain follows the final source value in either authoring order', async () => {
+  const linkOperations = [bind('MAX_HEALTH_BONUS', 'BREW_COUNTER'), bind('BREW_COUNTER', 'SPEED')];
+  for (const links of [linkOperations, [...linkOperations].reverse()]) {
+    const packet = await calculate([create('BREW_COUNTER'), set('SPEED', 25), ...links]);
+    assert.deepEqual(packet.errors, []);
+    assert.equal(packet.store.variables.BREW_COUNTER.value, 25);
+    assert.equal(packet.store.variables.MAX_HEALTH_BONUS.value, 25);
+  }
+});
+
+test('switching a level-gated branch removes its custom variable and permits a clean regrant', async () => {
+  const operations = [
+    op('level-branch', 'conditional', {
+      conditions: [{ id: 'level-five', name: 'LEVEL', type: 'num', operator: 'GREATER_THAN_OR_EQUALS', value: '5' }],
+      trueOperations: [create('BREW_COUNTER', 2), adjust('BREW_COUNTER', 3), bind('MAX_HEALTH_BONUS', 'BREW_COUNTER')],
+      falseOperations: [set('MAX_HEALTH_BONUS', 1)],
+    }),
+  ];
+  for (const [level, expected] of [
+    [5, 5],
+    [1, 1],
+    [5, 5],
+  ]) {
+    const packet = await calculate(operations, level);
+    assert.equal(packet.store.variables.MAX_HEALTH_BONUS.value, expected);
+    assert.equal(packet.store.variables.BREW_COUNTER?.value, level === 5 ? 5 : undefined);
+  }
+});
+
+test('the last applicable binding wins and downstream bindings see that value', async () => {
+  const packet = await calculate([
+    create('BREW_COUNTER'),
+    create('BREW_FIRST', 3),
+    create('BREW_SECOND', 7),
+    bind('MAX_HEALTH_BONUS', 'BREW_COUNTER'),
+    bind('BREW_COUNTER', 'BREW_FIRST', 'earlier-binding'),
+    bind('BREW_COUNTER', 'BREW_SECOND', 'later-binding'),
+    bind('BREW_COUNTER', 'MISSING_OPTIONAL_SOURCE', 'missing-binding'),
+  ]);
+  assert.equal(packet.store.variables.BREW_COUNTER.value, 7);
+  assert.equal(packet.store.variables.MAX_HEALTH_BONUS.value, 7);
+});
+
+test('cyclic bindings reject without replacing the committed sheet and a corrected graph can retry', async () => {
+  const previousWindow = globalThis.window;
+  globalThis.window = {};
+  const execute = (operations) =>
+    engine.executeOperations(
+      { type: 'CHARACTER', data: { character: character(operations), content, context: 'CHARACTER-SHEET' } },
+      { directExecution: true }
+    );
+  try {
+    await execute([set('MAX_HEALTH_BONUS', 17)]);
+    const cycle = [create('BREW_A', 1), create('BREW_B', 2), bind('BREW_A', 'BREW_B'), bind('BREW_B', 'BREW_A')];
+    await assert.rejects(
+      execute(cycle),
+      /Cyclic variable binding: CHARACTER.BREW_A -> CHARACTER.BREW_B -> CHARACTER.BREW_A/
+    );
+    assert.equal(engine.getVariable('CHARACTER', 'MAX_HEALTH_BONUS').value, 17);
+    await execute([
+      create('BREW_A', 1),
+      create('BREW_B', 2),
+      bind('MAX_HEALTH_BONUS', 'BREW_A'),
+      bind('BREW_A', 'BREW_B'),
+    ]);
+    assert.equal(engine.getVariable('CHARACTER', 'MAX_HEALTH_BONUS').value, 2);
+  } finally {
+    globalThis.window = previousWindow;
+  }
+});
+
+test('self-bindings preserve the final value and do not make dependent bindings cyclic', async () => {
+  const packet = await calculate([set('SPEED', 25), bind('MAX_HEALTH_BONUS', 'SPEED'), bind('SPEED', 'SPEED')]);
+  assert.equal(packet.store.variables.MAX_HEALTH_BONUS.value, 25);
+  assert.equal(packet.store.variables.SPEED.value, 25);
+});
+
+test('long homebrew binding chains resolve without depending on recursive call-stack depth', async () => {
+  const variables = Array.from({ length: 256 }, (_, index) => `BREW_${index}`);
+  const links = variables.map((variable, index) => bind(variable, variables[index + 1] ?? 'SPEED'));
+  const packet = await calculate([...variables.map((variable) => create(variable)), set('SPEED', 31), ...links]);
+  for (const variable of variables) assert.equal(packet.store.variables[variable].value, 31, variable);
+});
+
+test('companion binding chains read their current owner without changing the owner store', async () => {
+  const parent = await calculate([set('SPEED', 25)]);
+  const parentSnapshot = structuredClone(parent.store);
+  const packet = await engine._executeCreatureOperations({
+    id: 'brew-companion',
+    creature: {
+      name: 'Homebrew companion',
+      level: 1,
+      inventory: { items: [] },
+      operations: [
+        create('BREW_COUNTER'),
+        op('child-target', 'bindValue', {
+          variable: 'MAX_HEALTH_BONUS',
+          value: { storeId: 'brew-companion', variable: 'BREW_COUNTER' },
+        }),
+        bind('BREW_COUNTER', 'SPEED'),
+      ],
+    },
+    content,
+    charStore: parent.store,
+  });
+  assert.equal(packet.store.variables.BREW_COUNTER.value, 25);
+  assert.equal(packet.store.variables.MAX_HEALTH_BONUS.value, 25);
+  assert.deepEqual(parent.store, parentSnapshot);
+});
+
+test('duplicate speed bindings preserve the existing strongest-speed rule', async () => {
+  const packet = await calculate([
+    create('BREW_FAST', 40),
+    create('BREW_SLOW', 15),
+    set('SPEED', 25),
+    bind('MAX_HEALTH_BONUS', 'SPEED'),
+    bind('SPEED', 'BREW_FAST', 'bind-fast'),
+    bind('SPEED', 'BREW_SLOW', 'bind-slow'),
+  ]);
+  assert.equal(packet.store.variables.SPEED.value, 40);
+  assert.equal(packet.store.variables.MAX_HEALTH_BONUS.value, 40);
+});
+
+test('trailing self-binding cannot erase an earlier applicable binding', async () => {
+  const packet = await calculate([
+    create('BREW_A', 1),
+    create('BREW_B', 7),
+    bind('BREW_A', 'BREW_B', 'bind-other'),
+    bind('BREW_A', 'BREW_A', 'bind-self'),
+    bind('MAX_HEALTH_BONUS', 'BREW_A'),
+  ]);
+  assert.equal(packet.store.variables.BREW_A.value, 7);
+  assert.equal(packet.store.variables.MAX_HEALTH_BONUS.value, 7);
+});
+
+test('nested skill guards can read a variable created earlier in their active branch', async () => {
+  const packet = await calculate([
+    op('outer-branch', 'conditional', {
+      conditions: [],
+      trueOperations: [
+        op('create-lore', 'createValue', {
+          variable: 'SKILL_LORE_BREW',
+          type: 'prof',
+          value: { value: 'T', increases: 0, attribute: 'ATTRIBUTE_INT' },
+        }),
+        op('self-guarded-rank', 'conditional', {
+          conditions: [{ id: 'rank-check', name: 'SKILL_LORE_BREW', type: 'prof', operator: 'LESS_THAN', value: 'E' }],
+          trueOperations: [op('expert-lore', 'adjValue', { variable: 'SKILL_LORE_BREW', value: { value: 'E' } })],
+        }),
+      ],
+    }),
+  ]);
+  assert.equal(packet.store.variables.SKILL_LORE_BREW.value.value, 'E');
+});

--- a/frontend/scripts/operation-lifecycle.test.mjs
+++ b/frontend/scripts/operation-lifecycle.test.mjs
@@ -369,3 +369,70 @@ test('a direct companion cannot restore over a newer worker character commit', a
   await Promise.all([companion, current]);
   assert.equal(level(), 9);
 });
+
+test('four busy workers and queued companions converge on the newest parent despite reordered replies and one failure', async () => {
+  Object.defineProperty(globalThis, 'navigator', { configurable: true, value: { hardwareConcurrency: 8 } });
+  const ids = ['parallel-a', 'parallel-b', 'parallel-c', 'parallel-d', 'queued-e', 'queued-f'];
+  const outcomes = new Map(
+    ids.map((id) => [
+      id,
+      engine.executeOperations(creature(id)).then(
+        () => 'success',
+        (error) => error
+      ),
+    ])
+  );
+  assert.equal(workers.length, 4, 'the production pool runs four jobs and queues the remainder');
+  const staleChildren = workers.slice();
+  const firstParent = engine.executeOperations(execution(1));
+  const superseded = assert.rejects(firstParent, { name: 'AbortError' });
+  const staleParent = workers.at(-1);
+  const finalParent = engine.executeOperations(execution(9));
+  for (const worker of staleChildren) {
+    assert.equal(worker.terminated, true);
+    worker.reply(creatureResults[0]);
+  }
+  staleParent.reply(results[0]);
+  workers.at(-1).reply(results[1]);
+  await Promise.all([superseded, finalParent]);
+  const seen = new Set();
+  let failedId;
+  for (let round = 0; round < 20 && seen.size < ids.length; round++) {
+    await flush();
+    const active = workers
+      .filter(
+        (worker) =>
+          !worker.terminated &&
+          worker.requests.at(-1)?.execution.type === 'CREATURE' &&
+          !seen.has(worker.requests.at(-1).id)
+      )
+      .reverse();
+    for (const worker of active) {
+      const request = worker.requests.at(-1);
+      assert.equal(request.charStore.variables.LEVEL.value, 9, 'every retried companion uses the final parent');
+      seen.add(request.id);
+      if (!failedId) {
+        failedId = request.execution.data.id;
+        worker.onerror({ preventDefault() {} });
+      } else worker.reply(creatureResults[1]);
+    }
+  }
+  assert.equal(seen.size, ids.length, 'all queued work was dispatched');
+  for (const id of ids) {
+    const result = await outcomes.get(id);
+    if (id === failedId) assert.match(result.message, /worker failed/);
+    else {
+      assert.equal(result, 'success');
+      assert.equal(engine.getVariable(id, 'LEVEL').value, 9);
+    }
+  }
+  const retry = engine.executeOperations(creature(failedId));
+  const retryWorker = workers.find(
+    (worker) => !worker.terminated && worker.requests.at(-1)?.execution.data.id === failedId
+  );
+  assert.equal(retryWorker.requests.at(-1).charStore.variables.LEVEL.value, 9);
+  retryWorker.reply(creatureResults[1]);
+  await retry;
+  assert.equal(engine.getVariable(failedId, 'LEVEL').value, 9);
+  assert.equal(level(), 9);
+});

--- a/frontend/scripts/operation-test-harness.mjs
+++ b/frontend/scripts/operation-test-harness.mjs
@@ -6,13 +6,63 @@ import { build } from 'esbuild';
 
 const frontend = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
-/** Read selected, unmodified official content rows from the checked-in PostgreSQL COPY dump. */
+/** Decode a one-dimensional PostgreSQL array after the COPY layer has been unescaped. */
+function parseContentArray(value) {
+  if (value === '{}') return [];
+  const entries = [];
+  let index = 1;
+  while (index < value.length - 1) {
+    const quoted = value[index] === '"';
+    if (quoted) index++;
+    let entry = '';
+    while (index < value.length - 1) {
+      const character = value[index++];
+      if (character === '\\') entry += value[index++];
+      else if (quoted && character === '"') break;
+      else if (!quoted && character === ',') break;
+      else entry += character;
+    }
+    if (quoted && value[index] === ',') index++;
+    entries.push(!quoted && entry === 'NULL' ? null : entry);
+  }
+  return entries;
+}
+
+/**
+ * Read unmodified content from the checked-in PostgreSQL COPY dump without a database.
+ * Exact IDs fail when absent; source selections load a table's official test corpus.
+ * @param {Array<{ table: string, id: number } | { table: string, sourceIds: number[] }>} targets
+ */
 export async function readContentRows(targets) {
-  const wanted = new Set(targets.map(({ table, id }) => `${table}:${id}`));
+  const wanted = new Set(targets.filter((target) => 'id' in target).map(({ table, id }) => `${table}:${id}`));
+  const sources = new Map();
+  for (const target of targets.filter((target) => 'sourceIds' in target)) {
+    sources.set(target.table, new Set([...(sources.get(target.table) ?? []), ...target.sourceIds]));
+  }
   const rows = [];
   const text = await readFile(join(frontend, '../data/data.sql'), 'utf8');
-  const arrayColumns = new Set(['operations', 'traits', 'prerequisites', 'traditions', 'cast']);
-  const numberColumns = new Set(['id', 'level', 'trait_id', 'content_source_id', 'skill_training_base']);
+  const arrayColumns = new Set([
+    'operations',
+    'traits',
+    'prerequisites',
+    'traditions',
+    'cast',
+    'required_content_sources',
+    'keys',
+  ]);
+  const numberArrayColumns = new Set(['traits', 'required_content_sources']);
+  const numberColumns = new Set([
+    'id',
+    'level',
+    'rank',
+    'trait_id',
+    'content_source_id',
+    'skill_training_base',
+    'class_id',
+    'archetype_id',
+    'override_skill_training_base',
+  ]);
+  const booleanColumns = new Set(['deprecated', 'override_class_operations', 'require_key', 'is_published']);
   const escapes = { '\\': '\\', n: '\n', t: '\t', r: '\r', b: '\b', f: '\f', v: '\v' };
   let table;
   let columns = [];
@@ -26,22 +76,27 @@ export async function readContentRows(targets) {
     if (line === '\\.') table = undefined;
     if (!table) continue;
     const cells = line.split('\t');
-    if (!wanted.has(`${table}:${cells[columns.indexOf('id')]}`)) continue;
+    const matchesId = wanted.has(`${table}:${cells[columns.indexOf('id')]}`);
+    const matchesSource = sources.get(table)?.has(Number(cells[columns.indexOf('content_source_id')]));
+    if (!matchesId && !matchesSource) continue;
     const row = Object.fromEntries(
       columns.map((key, index) => {
         const raw = cells[index];
         if (raw === '\\N') return [key, null];
         const value = raw.replace(/\\([\\ntrbfv])/g, (_, escaped) => escapes[escaped]);
         if (arrayColumns.has(key) && value.startsWith('{')) {
-          const entries = JSON.parse(`[${value.slice(1, -1)}]`);
+          const entries = parseContentArray(value);
           return [
             key,
             key === 'operations'
               ? entries.map((entry) => (typeof entry === 'string' ? JSON.parse(entry) : entry))
-              : entries,
+              : numberArrayColumns.has(key)
+                ? entries.map((entry) => (entry === null ? null : Number(entry)))
+                : entries,
           ];
         }
         if (numberColumns.has(key)) return [key, Number(value)];
+        if (booleanColumns.has(key)) return [key, value === 't'];
         if (value.startsWith('{')) return [key, JSON.parse(value)];
         return [key, value];
       })

--- a/frontend/scripts/pf2e-matrix-support.mjs
+++ b/frontend/scripts/pf2e-matrix-support.mjs
@@ -1,0 +1,163 @@
+import assert from 'node:assert/strict';
+import { createOperationEngine, readContentRows } from './operation-test-harness.mjs';
+
+const sourceIds = [1, 3, 14, 256];
+const contentTables = {
+  abilityBlocks: 'ability_block',
+  classes: 'class',
+  traits: 'trait',
+  ancestries: 'ancestry',
+  backgrounds: 'background',
+  languages: 'language',
+  items: 'item',
+  spells: 'spell',
+  archetypes: 'archetype',
+  versatileHeritages: 'versatile_heritage',
+  classArchetypes: 'class_archetype',
+};
+const classIds = { Fighter: 20, Wizard: 26, Rogue: 25, Monk: 111 };
+const itemIds = {
+  Longsword: 7090,
+  Dagger: 6854,
+  Longbow: 7088,
+  'Leather Armor': 7068,
+  Breastplate: 6765,
+  'Full Plate': 6985,
+};
+
+/** Catch fixture mutation instead of allowing one calculation to alter later test inputs. */
+function freeze(value) {
+  if (value && typeof value === 'object' && !Object.isFrozen(value)) {
+    for (const child of Object.values(value)) freeze(child);
+    Object.freeze(value);
+  }
+  return value;
+}
+
+/**
+ * The audit's four official sources are the local corpus, not generated fixture exports.
+ * Real class features and their grants run through executeOperations; only content I/O is mocked.
+ */
+export async function createPf2eMatrix() {
+  const engine = await createOperationEngine();
+  try {
+    const rows = await readContentRows([
+      ...Object.values(contentTables).map((table) => ({ table, sourceIds })),
+      ...sourceIds.map((id) => ({ table: 'content_source', id })),
+    ]);
+    const content = Object.fromEntries(
+      Object.entries(contentTables).map(([key, table]) => [
+        key,
+        rows.filter((entry) => entry.table === table).map(({ row }) => row),
+      ])
+    );
+    content.sources = rows.filter(({ table }) => table === 'content_source').map(({ row }) => row);
+    content.defaultSources = { PAGE: sourceIds, INFO: sourceIds };
+    freeze(rows);
+    freeze(content);
+    engine.setFixtures(rows);
+
+    /** Select explicit identities so a homebrew/reprint name collision cannot change the oracle. */
+    function fixture(table, id, name, sourceId = 1) {
+      const row = rows.find((entry) => entry.table === table && entry.row.id === id)?.row;
+      assert.ok(row, `Missing ${table} fixture ${id} (${name})`);
+      assert.equal(row.name, name, `${table} ${id} was renamed`);
+      assert.equal(row.content_source_id, sourceId, `${table} ${id} changed source`);
+      return row;
+    }
+    const classes = Object.fromEntries(
+      Object.entries(classIds).map(([name, id]) => [name, fixture('class', id, name, name === 'Monk' ? 256 : 1)])
+    );
+    const items = Object.fromEntries(Object.entries(itemIds).map(([name, id]) => [name, fixture('item', id, name)]));
+    const dwarf = fixture('ancestry', 4, 'Dwarf');
+    fixture('ability_block', 20661, 'Unburdened Iron');
+    let calculations = 0;
+
+    function condition(name, value) {
+      const data = engine.getConditionByName(name);
+      assert.ok(data, `Unknown condition ${name}`);
+      return { ...data, ...(value === undefined ? {} : { value }) };
+    }
+
+    /** Explicit attributes/ancestry HP isolate class progression from optional builder selections. */
+    function character(className, level = 5) {
+      const attributes =
+        className === 'Wizard'
+          ? { STR: 0, DEX: 3, CON: 2, INT: 4, WIS: 0, CHA: 0 }
+          : { STR: 4, DEX: 2, CON: 2, INT: 0, WIS: 1, CHA: 0 };
+      const set = (variable, value) => ({ id: `matrix-set-${variable}`, type: 'setValue', data: { variable, value } });
+      assert.ok(classes[className], `Unknown class fixture ${className}`);
+      return {
+        id: 1,
+        level,
+        hp_current: 20,
+        details: { class: classes[className], conditions: [] },
+        inventory: { items: [], coins: { cp: 0, sp: 0, gp: 0, pp: 0 } },
+        content_sources: { enabled: sourceIds },
+        meta_data: { reset_hp: false },
+        operation_data: { selections: {} },
+        options: { custom_operations: true, ignore_bulk_limit: true },
+        custom_operations: [
+          ...Object.entries(attributes).map(([attribute, value]) => set(`ATTRIBUTE_${attribute}`, { value })),
+          set('MAX_HEALTH_ANCESTRY', 8),
+          set('SPEED', 25),
+        ],
+      };
+    }
+
+    /** Real sheet calculation stages, with independent expected values supplied by the tests. */
+    async function calculate(data, conditions = data.details.conditions ?? [], configure, context = 'CHARACTER-SHEET') {
+      calculations++;
+      engine.clearOperationErrorNotifications();
+      await engine.executeOperations(
+        { type: 'CHARACTER', data: { character: data, content, context } },
+        { directExecution: true }
+      );
+      engine.setVariable('CHARACTER', 'PROF_WITHOUT_LEVEL', data.variants?.proficiency_without_level ?? false);
+      engine.setVariable('CHARACTER', 'STAMINA_VARIANT', data.variants?.stamina ?? false);
+      engine.applyEquipmentPenalties('CHARACTER', data);
+      engine.applyConditions('CHARACTER', conditions);
+      configure?.();
+      const result = {
+        ac: engine.getFinalAcValue('CHARACTER', engine.getBestArmor('CHARACTER', data.inventory)?.item),
+        hp: engine.getFinalHealthValue('CHARACTER'),
+        stamina: engine.getFinalStaminaValue('CHARACTER'),
+        speed: engine.getSpeedValue('CHARACTER', engine.getVariable('CHARACTER', 'SPEED'), data).total,
+        reflex: Number(engine.getFinalProfValue('CHARACTER', 'SAVE_REFLEX')),
+        fort: Number(engine.getFinalProfValue('CHARACTER', 'SAVE_FORT')),
+        sword: engine.getWeaponStats('CHARACTER', items.Longsword).attack_bonus.total[0],
+        dagger: engine.getWeaponStats('CHARACTER', items.Dagger).attack_bonus.total[0],
+        bow: engine.getWeaponStats('CHARACTER', items.Longbow).attack_bonus.total[0],
+        spell: engine.getSpellStats('CHARACTER', null, 'ARCANE', 'ATTRIBUTE_INT').spell_attack.total[0],
+        dc: engine.getSpellStats('CHARACTER', null, 'ARCANE', 'ATTRIBUTE_INT').spell_dc.total,
+        errors: engine.getOperationErrorNotifications(),
+      };
+      assert.deepEqual(
+        result.errors,
+        [],
+        `${data.details.class.name} level ${data.level}, ${context}: operation errors`
+      );
+      return result;
+    }
+
+    return {
+      engine,
+      character,
+      condition,
+      calculate,
+      items,
+      dwarf,
+      feature: (id) => content.abilityBlocks.find((row) => row.id === id),
+      rank: (name) => engine.compileProficiencyType(engine.getVariable('CHARACTER', name).value),
+      bonus: (variable, amount, type, source) =>
+        engine.addVariableBonus('CHARACTER', variable, amount, type, '', source),
+      get calculations() {
+        return calculations;
+      },
+      cleanup: engine.cleanup,
+    };
+  } catch (error) {
+    await engine.cleanup();
+    throw error;
+  }
+}

--- a/frontend/scripts/pf2e-matrix.test.mjs
+++ b/frontend/scripts/pf2e-matrix.test.mjs
@@ -1,0 +1,329 @@
+/**
+ * Durable integration coverage from the PF2e audit: 1,211 comparisons over 469 calculations.
+ * These are related matrix comparisons, not 1,211 independent user journeys or a full rules certification.
+ * Rule oracles: Player Core pp. 400 (typed stacking), 442-447 (conditions), 44 (Unburdened Iron),
+ * and the class HP/skill progression tables. Variant oracles use stamina/proficiency without level formulas.
+ */
+import assert from 'node:assert/strict';
+import { after, before, beforeEach, test } from 'node:test';
+import { createPf2eMatrix } from './pf2e-matrix-support.mjs';
+
+let matrix;
+let comparisons = 0;
+
+/** Count historical audit comparisons while letting node:test fail on every discrepancy. */
+function check(actual, expected, label) {
+  comparisons++;
+  assert.deepEqual(actual, expected, label);
+}
+
+before(async () => {
+  matrix = await createPf2eMatrix();
+});
+after(async () => {
+  await matrix?.cleanup();
+});
+beforeEach(() => matrix.engine.resetVariables());
+
+const classHealth = { Fighter: 10, Wizard: 6, Rogue: 8, Monk: 10 };
+const levels = [1, 3, 5, 7, 10, 15, 20];
+const conditionScenarios = [
+  ['Clumsy 2', [['Clumsy', 2]], { ac: -2, reflex: -2, bow: -2, spell: 0, dc: 0, sword: 0 }],
+  ['Enfeebled 2', [['Enfeebled', 2]], { bow: 0, spell: 0, dc: 0 }],
+  ['Frightened 1', [['Frightened', 1]], { ac: -1, reflex: -1, fort: -1, bow: -1, sword: -1, spell: -1, dc: -1 }],
+  [
+    'Frightened 1 + Clumsy 2',
+    [
+      ['Frightened', 1],
+      ['Clumsy', 2],
+    ],
+    { ac: -2, reflex: -2, bow: -2, spell: -1, dc: -1 },
+  ],
+  [
+    'Frightened 1 + Stupefied 2',
+    [
+      ['Frightened', 1],
+      ['Stupefied', 2],
+    ],
+    { spell: -2, dc: -2 },
+  ],
+  [
+    'Frightened 1 + Sickened 2',
+    [
+      ['Frightened', 1],
+      ['Sickened', 2],
+    ],
+    { ac: -2, reflex: -2, fort: -2, bow: -2, sword: -2, spell: -2, dc: -2 },
+  ],
+];
+
+for (const [className, healthPerLevel] of Object.entries(classHealth)) {
+  for (const level of levels) {
+    test(`${className} level ${level}: condition scope, variants, rebuilding, and builder/sheet parity`, async () => {
+      const { calculate, character, condition } = matrix;
+      const data = character(className, level);
+      const baseline = await calculate(data);
+      check(baseline.errors, [], 'baseline calculation');
+      check(baseline.hp, 8 + (healthPerLevel + 2) * level, 'ancestry + class and Constitution HP');
+      for (const [name, conditions, deltas] of [
+        ...conditionScenarios,
+        ['Drained 2', [['Drained', 2]], { hp: -2 * level, fort: -2 }],
+      ]) {
+        const result = await calculate(
+          data,
+          conditions.map(([name, rank]) => condition(name, rank))
+        );
+        for (const [stat, delta] of Object.entries(deltas)) {
+          check(result[stat], baseline[stat] + delta, `${name}: ${stat}`);
+        }
+      }
+      const forward = await calculate(data, [condition('Encumbered'), condition('Clumsy', 3)]);
+      const reverse = await calculate(data, [condition('Clumsy', 3), condition('Encumbered')]);
+      check(forward, reverse, 'condition order cannot change the result');
+      check(forward.speed, Math.max(5, baseline.speed - 10), 'Encumbered speed penalty');
+      check(await calculate(data), baseline, 'removing conditions restores the complete baseline');
+      check(await calculate(data, [], undefined, 'CHARACTER-BUILDER'), baseline, 'builder/sheet parity');
+      const stamina = await calculate({ ...data, variants: { stamina: true } });
+      check(stamina.hp, 8 + Math.floor(healthPerLevel / 2) * level, 'stamina variant HP');
+      check(stamina.stamina, (Math.floor(healthPerLevel / 2) + 2) * level, 'stamina variant pool');
+      await calculate(character(className === 'Wizard' ? 'Fighter' : 'Wizard', 20));
+      check(await calculate(data), baseline, 'switching characters clears the previous character and variant state');
+    });
+  }
+}
+
+for (const [armorName, strength, expectedAc, expectedSpeed] of [
+  ['Leather Armor', 0, 20, 25],
+  ['Breastplate', 2, 22, 20],
+  ['Breastplate', 3, 22, 25],
+  ['Full Plate', 3, 23, 15],
+  ['Full Plate', 4, 23, 20],
+]) {
+  test(`official ${armorName}, Strength +${strength}: armor cap and Strength threshold`, async () => {
+    const data = matrix.character('Fighter', 5);
+    data.inventory.items = [
+      {
+        id: 'matrix-armor',
+        item: matrix.items[armorName],
+        is_equipped: true,
+        is_invested: false,
+        container_contents: [],
+      },
+    ];
+    data.custom_operations.find((operation) => operation.data.variable === 'ATTRIBUTE_STR').data.value = {
+      value: strength,
+    };
+    const result = await matrix.calculate(data);
+    check(result.ac, expectedAc, 'armor class');
+    check(result.speed, expectedSpeed, 'armor speed penalty');
+  });
+}
+
+test('official Fighter: general/melee status bonuses share one limit, while a penalty still applies', async () => {
+  const data = matrix.character('Fighter');
+  const baseline = await matrix.calculate(data);
+  const mixed = await matrix.calculate(data, [], () => {
+    matrix.bonus('ATTACK_ROLLS_BONUS', 1, 'status', 'General status');
+    matrix.bonus('MELEE_ATTACK_ROLLS_BONUS', 2, 'status', 'Melee status');
+  });
+  check(mixed.sword, baseline.sword + 2, 'general and melee status bonuses');
+  const same = await matrix.calculate(data, [], () => {
+    matrix.bonus('ATTACK_ROLLS_BONUS', 1, 'status', 'First bonus');
+    matrix.bonus('ATTACK_ROLLS_BONUS', 2, 'status', 'Second bonus');
+    matrix.bonus('ATTACK_ROLLS_BONUS', -1, 'status', 'Penalty');
+  });
+  check(same.sword, baseline.sword + 1, 'highest bonus and worst penalty apply separately');
+});
+
+for (const [label, penalties, expected] of [
+  ['one 5-foot penalty', [[-5, 'status']], 25],
+  ['one 10-foot penalty', [[-10, 'status']], 20],
+  [
+    'different penalty types',
+    [
+      [-10, 'status'],
+      [-10, 'circumstance'],
+    ],
+    10,
+  ],
+  [
+    'suppressed same-type penalty',
+    [
+      [-10, 'status'],
+      [-15, 'status'],
+    ],
+    15,
+  ],
+]) {
+  test(`official Fighter with Unburdened Iron enabled: ${label}`, async () => {
+    const result = await matrix.calculate(matrix.character('Fighter'), [], () => {
+      matrix.engine.setVariable('CHARACTER', 'UNBURDENED_IRON', true);
+      penalties.forEach(([amount, type], index) => matrix.bonus('SPEED', amount, type, `Penalty ${index}`));
+    });
+    check(result.speed, expected, 'reduce only one eligible penalty before re-stacking');
+  });
+}
+
+test('official Wizard: explicit Drained HP loss survives rebuilding and replay', async () => {
+  const data = matrix.character('Wizard');
+  await matrix.calculate(data);
+  const edited = matrix.engine.changeEntityConditions('CHARACTER', data, [matrix.condition('Drained', 2)]);
+  const result = await matrix.calculate(edited, edited.details.conditions);
+  const normalized = matrix.engine.confirmHealth(
+    `${edited.hp_current}`,
+    result.hp,
+    edited,
+    undefined,
+    false,
+    'normalize'
+  );
+  check(normalized?.entity.hp_current ?? edited.hp_current, 10, 'Drained 2 removes 2 × level HP exactly once');
+  check(
+    matrix.engine.changeEntityConditions('CHARACTER', edited, edited.details.conditions).hp_current,
+    10,
+    'replayed edit cannot remove HP twice'
+  );
+});
+
+test('official Rogue: historical skill choices survive level oscillation, removal, reassignment, and restoration', async () => {
+  const data = matrix.character('Rogue', 1);
+  const skills = [
+    'SKILL_MEDICINE',
+    'SKILL_ARCANA',
+    'SKILL_NATURE',
+    'SKILL_SOCIETY',
+    'SKILL_OCCULTISM',
+    'SKILL_RELIGION',
+    'SKILL_CRAFTING',
+  ];
+  const path = (id) => {
+    const feature = matrix.feature(id);
+    assert.ok(feature, `Missing skill-increase feature ${id}`);
+    return `class-feature-${id}_${feature.operations[0].id}`;
+  };
+  matrix.engine.getClassSkillTrainings('CHARACTER', 7).forEach((operation, index) => {
+    data.operation_data.selections[`class_${operation.id}`] = skills[index];
+  });
+  for (const id of [21349, 19381, 19385]) data.operation_data.selections[path(id)] = 'SKILL_MEDICINE';
+  for (const level of [1, 2, 3, 6, 7, 14, 15, 20, 1, 20, 2, 15, 7, 3, 1]) {
+    data.level = level;
+    const result = await matrix.calculate(data);
+    check(
+      matrix.rank('SKILL_MEDICINE'),
+      level >= 15 ? 'L' : level >= 7 ? 'M' : level >= 2 ? 'E' : 'T',
+      `Medicine at level ${level}`
+    );
+    check(result.errors, [], `operation errors at level ${level}`);
+  }
+  data.level = 20;
+  delete data.operation_data.selections[path(19381)];
+  await matrix.calculate(data);
+  check(matrix.rank('SKILL_MEDICINE'), 'M', 'removing the middle increase');
+  data.operation_data.selections[path(19385)] = 'SKILL_ARCANA';
+  await matrix.calculate(data);
+  check(['SKILL_MEDICINE', 'SKILL_ARCANA'].map(matrix.rank), ['E', 'E'], 'reassigning the late increase');
+  data.operation_data.selections[path(19381)] = 'SKILL_MEDICINE';
+  data.operation_data.selections[path(19385)] = 'SKILL_MEDICINE';
+  await matrix.calculate(data);
+  check(['SKILL_MEDICINE', 'SKILL_ARCANA'].map(matrix.rank), ['L', 'T'], 'restoring historical increases');
+});
+
+test('official Wizard finesse attack ignores Enfeebled when Dexterity is better', async () => {
+  const data = matrix.character('Wizard');
+  const baseline = await matrix.calculate(data);
+  const result = await matrix.calculate(data, [matrix.condition('Enfeebled', 2)]);
+  check(result.dagger, baseline.dagger, 'Dexterity finesse attack');
+});
+
+test('official Fighter Strength attack stacks Frightened and Enfeebled as one status penalty', async () => {
+  const data = matrix.character('Fighter');
+  const baseline = await matrix.calculate(data);
+  const result = await matrix.calculate(data, [matrix.condition('Frightened', 1), matrix.condition('Enfeebled', 2)]);
+  check(result.sword, baseline.sword - 2, 'Strength attack status penalty');
+});
+
+test('official Fighter armor and an extra item AC bonus do not stack', async () => {
+  const data = matrix.character('Fighter');
+  data.inventory.items = [
+    {
+      id: 'matrix-armor',
+      item: matrix.items.Breastplate,
+      is_equipped: true,
+      is_invested: false,
+      container_contents: [],
+    },
+  ];
+  const result = await matrix.calculate(data, [], () => matrix.bonus('AC_BONUS', 1, 'item', 'Additional item AC'));
+  check(result.ac, 22, 'breastplate competes with the additional item bonus');
+});
+
+test('official Dwarf and Unburdened Iron feat apply the same penalty rules through a real content grant', async () => {
+  const data = matrix.character('Fighter');
+  data.details.ancestry = matrix.dwarf;
+  data.custom_operations.push({
+    id: 'matrix-grant-unburdened',
+    type: 'giveAbilityBlock',
+    data: { type: 'feat', abilityBlockId: 20661 },
+  });
+  const baseline = await matrix.calculate(data);
+  for (const [label, penalties, delta] of [
+    ['one 5-foot penalty', [[-5, 'status']], 0],
+    [
+      'different penalty types',
+      [
+        [-10, 'status'],
+        [-10, 'circumstance'],
+      ],
+      -15,
+    ],
+    [
+      'suppressed same-type penalty',
+      [
+        [-10, 'status'],
+        [-15, 'status'],
+      ],
+      -10,
+    ],
+  ]) {
+    const result = await matrix.calculate(data, [], () =>
+      penalties.forEach(([amount, type], index) => matrix.bonus('SPEED', amount, type, `Penalty ${index}`))
+    );
+    check(result.speed, Math.max(5, baseline.speed + delta), label);
+  }
+});
+
+test('healing stable or nonlethal knockouts cannot create another Wounded increase', () => {
+  const data = matrix.character('Wizard');
+  data.hp_current = 0;
+  data.details.conditions = [matrix.condition('Unconscious')];
+  const healed = matrix.engine.confirmHealth('1', 48, data);
+  check(
+    healed.entity.details.conditions.some((condition) => condition.name === 'Wounded'),
+    false,
+    'nonlethal knockout'
+  );
+  data.details.conditions = [matrix.condition('Unconscious'), matrix.condition('Wounded', 1)];
+  const awake = matrix.engine.confirmHealth('1', 48, data);
+  check(
+    awake.entity.details.conditions.find((condition) => condition.name === 'Wounded')?.value,
+    1,
+    'already stabilized knockout'
+  );
+});
+
+for (const level of [1, 5, 10, 20]) {
+  test(`official Wizard level ${level}: proficiency without level removes exactly the level contribution`, async () => {
+    const data = matrix.character('Wizard', level);
+    const normal = await matrix.calculate(data);
+    const noLevel = await matrix.calculate({ ...data, variants: { proficiency_without_level: true } });
+    check([noLevel.ac, noLevel.spell], [normal.ac - level, normal.spell - level], 'AC and spell proficiency');
+  });
+}
+
+test('the complete original audit matrix executes as a regression suite', (context) => {
+  assert.equal(comparisons, 1211, 'all historical audit comparisons ran');
+  assert.equal(matrix.calculations, 469, '434 broad-matrix and 35 edge-matrix calculations ran');
+  context.diagnostic(
+    `${comparisons} rule comparisons across ${matrix.calculations} actual engine calculations; fixture identity and error checks are additional invariants.`
+  );
+});

--- a/frontend/src/process/content/content-store.ts
+++ b/frontend/src/process/content/content-store.ts
@@ -233,11 +233,13 @@ async function verifyPersistedContentVersions(rec: PersistedContentCache): Promi
   return 'ok';
 }
 
-async function hydrateContentCache(generation: number, actorId: string): Promise<void> {
+async function hydrateContentCache(generation: number, actorId: string, signal: AbortSignal): Promise<void> {
   try {
     await storageWrites;
+    if (signal.aborted || generation !== cacheGeneration || actorId !== cacheActorId) return;
     const rec = await idbGet<PersistedContentCache>(cacheKey(actorId));
     if (
+      signal.aborted ||
       !rec ||
       rec.version !== CONTENT_CACHE_VERSION ||
       rec.actorId !== actorId ||
@@ -246,7 +248,7 @@ async function hydrateContentCache(generation: number, actorId: string): Promise
       return;
     // Check this exact snapshot, not a verdict memoized for a different blob/account.
     if ((await verifyPersistedContentVersions(rec)) === 'stale') return;
-    if (generation !== cacheGeneration || actorId !== cacheActorId) return;
+    if (signal.aborted || generation !== cacheGeneration || actorId !== cacheActorId) return;
     if (rec.contentStore instanceof Map) {
       for (const [key, value] of rec.contentStore) if (!contentStore.has(key)) contentStore.set(key, value);
     }
@@ -263,13 +265,23 @@ async function hydrateContentCache(generation: number, actorId: string): Promise
   }
 }
 
-// Race a timeout so a stuck/blocked IndexedDB can never hold up content loading — if it
-// loses the race, hydration may still populate later (harmlessly, since it never clobbers).
+/** Bound optional hydration and retire its snapshot before fresh network loading starts. */
 function beginHydration(): Promise<void> {
+  const controller = new AbortController();
+  let timeout: ReturnType<typeof setTimeout> | undefined;
   return Promise.race([
-    hydrateContentCache(cacheGeneration, cacheActorId),
-    new Promise<void>((resolve) => setTimeout(resolve, 2500)),
-  ]);
+    hydrateContentCache(cacheGeneration, cacheActorId, controller.signal),
+    new Promise<void>((resolve) => {
+      timeout = setTimeout(() => {
+        // A late cached row could resurrect content absent from a fresh download,
+        // even when hydration never overwrites an existing ID.
+        controller.abort();
+        resolve();
+      }, 2500);
+    }),
+  ]).finally(() => {
+    if (timeout !== undefined) clearTimeout(timeout);
+  });
 }
 // Started at module load and re-armed by resetContentStore(), so the in-memory store can
 // refill from the persisted cache after an in-memory clear instead of re-fetching the corpus.
@@ -598,9 +610,13 @@ export function resetContentStore(resetSources = true, clearPersisted = false) {
   cacheDirty = false;
 
   if (clearPersisted) {
-    // Underlying content changed: drop the persisted copy and don't re-hydrate stale data.
+    // The generation already invalidated old readers. Keep deletion ordered with
+    // persistence, but optional storage must not hold up fresh network content.
     const key = cacheKey();
-    hydrationPromise = writeCache(() => idbDelete(key));
+    void writeCache(() => idbDelete(key)).catch(() => {
+      console.warn('[CONTENT-CACHE] Could not discard saved content');
+    });
+    hydrationPromise = Promise.resolve();
   } else {
     // Re-arm hydration so the next fetch refills the in-memory store from the persisted
     // cache instead of re-downloading the whole corpus.

--- a/frontend/src/process/operations/operation-runner.ts
+++ b/frontend/src/process/operations/operation-runner.ts
@@ -199,6 +199,10 @@ export async function runOperations(
     // Normal
     if (options?.doConditionals && operation.type === 'conditional') {
       return await runConditional(varId, selectionTrack, operation, options, sourceLabel);
+    } else if (options?.doConditionals && operation.type === 'createValue') {
+      // Conditional branches are chosen after the creation pass. Create their
+      // variables only when that branch runs, before its following adjustments.
+      return await runCreateValue(varId, operation, sourceLabel);
     } else if (operation.type === 'adjValue') {
       return await runAdjValue(varId, operation, selectionTrack, options, sourceLabel);
     } else if (operation.type === 'setValue') {
@@ -249,11 +253,13 @@ export async function runOperations(
   try {
     const orderedOperations = operations.map((operation, index) => ({ operation, index }));
     if (options?.doOnlyConditionals || options?.doConditionals) {
-      // Resolve self-guarded rank grants before sibling effects that read the granted proficiency.
+      // Active branches create their local variables before proficiency guards;
+      // guards then precede sibling effects that read their granted proficiency.
       orderedOperations.sort(
         (left, right) =>
+          Number(right.operation.type === 'createValue') - Number(left.operation.type === 'createValue') ||
           Number(getSelfGrantProficiencyVariables(right.operation).size > 0) -
-          Number(getSelfGrantProficiencyVariables(left.operation).size > 0)
+            Number(getSelfGrantProficiencyVariables(left.operation).size > 0)
       );
     }
     for (const { operation, index } of orderedOperations) {
@@ -644,13 +650,78 @@ type DeferredOperation = { scopes: VariableEffectScope[] } & (
     }
 );
 let deferredOperations: DeferredOperation[] = [];
+type DeferredBinding = Extract<DeferredOperation, { type: 'bind' }>;
+
+/** Resolve final-value dependencies without depending on source traversal order or call-stack depth. */
+async function resolveBindings(pending: DeferredOperation[]): Promise<void> {
+  const keyFor = (storeId: StoreID, variable: string): string => JSON.stringify([storeId, variable]);
+  const bindings = new Map<string, DeferredBinding[]>();
+  for (const operation of pending) {
+    if (
+      operation.type === 'bind' &&
+      getVariable(operation.varId, operation.variable) &&
+      getVariable(operation.value.storeId, operation.value.variable)
+    ) {
+      const key = keyFor(operation.varId, operation.variable);
+      // Self-copies cannot replace an earlier source or introduce a dependency.
+      if (key === keyFor(operation.value.storeId, operation.value.variable)) continue;
+      const writes = bindings.get(key) ?? [];
+      writes.push(operation);
+      bindings.set(key, writes);
+    }
+  }
+  const resolved = new Set<string>();
+  const ordered: string[] = [];
+  for (const key of bindings.keys()) {
+    if (resolved.has(key)) continue;
+    const stack = [{ key, next: 0 }];
+    const visiting = new Set([key]);
+    while (stack.length > 0) {
+      const current = stack[stack.length - 1];
+      const writes = bindings.get(current.key)!;
+      if (current.next === writes.length) {
+        ordered.push(current.key);
+        resolved.add(current.key);
+        visiting.delete(current.key);
+        stack.pop();
+        continue;
+      }
+      const write = writes[current.next++];
+      const dependency = keyFor(write.value.storeId, write.value.variable);
+      if (!bindings.has(dependency) || resolved.has(dependency)) continue;
+      if (visiting.has(dependency)) {
+        const start = stack.findIndex((entry) => entry.key === dependency);
+        const cycle = [...stack.slice(start).map((entry) => entry.key), dependency].map((entry) => {
+          const binding = bindings.get(entry)![0];
+          return binding.varId + '.' + binding.variable;
+        });
+        throw new Error('Cyclic variable binding: ' + cycle.join(' -> '));
+      }
+      visiting.add(dependency);
+      stack.push({ key: dependency, next: 0 });
+    }
+  }
+  // Validate the complete graph before applying any binding. A cycle must never
+  // publish a partial result as a successful character or companion calculation.
+  for (const key of ordered) {
+    // Preserve every authored assignment and its provenance. The existing setter
+    // owns maximum-speed/HP rules, proficiency metadata, and ordinary replacement.
+    for (const binding of bindings.get(key)!) {
+      const source = getVariable(binding.value.storeId, binding.value.variable);
+      if (!source) continue;
+      await withVariableEffectScopes(binding.varId, binding.scopes, async () => {
+        setVariable(binding.varId, binding.variable, source.value, binding.sourceLabel);
+      });
+    }
+  }
+}
 
 /** Drops deferred writes from a previous (possibly aborted) execution. */
 export function clearDeferredOperations(): void {
   deferredOperations = [];
 }
 
-/** Apply explicit language replacements after grants, then bindings in their original order against final values. */
+/** Apply explicit language replacements after grants, then bindings against their resolved final source values. */
 export async function resolveDeferredOperations(): Promise<string[]> {
   const pending: DeferredOperation[] = deferredOperations.filter((operation) =>
     areVariableEffectScopesActive(operation.scopes)
@@ -682,15 +753,7 @@ export async function resolveDeferredOperations(): Promise<string[]> {
       replaceLanguages(replacement.varId, replacement.languages, replacement.sourceLabel);
     });
   }
-  for (const bind of pending) {
-    if (bind.type !== 'bind') continue;
-    const bindValue = getVariable(bind.value.storeId, bind.value.variable);
-    if (bindValue) {
-      await withVariableEffectScopes(bind.varId, bind.scopes, async () => {
-        setVariable(bind.varId, bind.variable, bindValue.value, bind.sourceLabel);
-      });
-    }
-  }
+  await resolveBindings(pending);
   return errors;
 }
 


### PR DESCRIPTION
Homebrew conditionals could silently omit custom variables, linked variables could use an intermediate value depending on operation order, and delayed browser-cache work could block fresh content or restore a deleted row. This change fixes those failures and makes the full prior PF2e audit a normal CI regression suite.

- Create active branch variables before nested proficiency guards; rebuild them when the branch changes.
- Resolve linked-variable dependencies before copying values, preserving every source assignment and existing maximum-speed/HP semantics. Self-copies are no-ops; cycles stop calculation without publishing partial state.
- Keep optional IndexedDB invalidation from blocking fresh content, and prevent timed-out hydration from publishing stale rows.
- Retain 1,211 comparisons over 469 real engine calculations using checked-in content and immutable fixtures. Add homebrew, storage-race, four-worker concurrency, and actual sheet/worker/API regressions.

Validation: final CI passes 203 rules/controller tests (including the 1,211-comparison matrix), 140 infrastructure tests, 35 Cypress scenarios, 54 API tests, 7 content-audit tests and 8 release-tool tests. Build, typecheck and docs links pass; lint has zero errors and 69 existing warnings. Read-only production compatibility checks pass for the exact final commit. No API, database, or content migration. Browser writes use synthetic local fixtures with verified cleanup.

The matrix covers controlled builds for four classes, selected levels and variants; its comparison count is not a certification of every complete build or arbitrary homebrew. Documentation explains the test boundaries and remaining limits.
