### PR TITLE
Fix recurring character recovery notice and clarify save controls

### DIFF
--- a/docs/releases.mdx
+++ b/docs/releases.mdx
@@ -199,6 +199,26 @@ before activation; finish edits in other forms before choosing **Reload app**.
 An update activated in another tab shows a prompt instead of forcing this tab to
 reload. The error page also offers an explicit reload for missing old assets.
 
+## Earlier character changes
+
+Retained drafts stay on the device under the same character ID. They do not create
+additional characters on the server. The builder and sheet show **Review earlier
+changes** beside the current save status when a draft cannot be replayed safely.
+Opening or reloading a character does not automatically open a recovery notice.
+
+The **Unsaved changes** dialog offers **Download changes** and **Discard earlier
+changes**. Closing or downloading preserves the draft. Discarding requires a
+confirmation and removes only the exact records shown when the dialog opened.
+Newer replacements and records that could not be removed stay available. These
+controls never discard the current draft waiting for a calculation or server save.
+
+Recovery verification must continue beyond the first download: close, reload,
+switch between builder and sheet, then confirm the server character is unchanged
+and earlier changes remain accessible without a recurring popup. The Cypress
+`saveRecovery` scenario covers that lifecycle and cancel/confirm behavior on phone
+and desktop layouts. Hook integration tests cover newer replacements, storage
+failures, and stale callbacks after account or character changes.
+
 ## Recovery evidence and next drill
 
 On September 5, 2026, production had seven completed daily physical backups (August

--- a/frontend/cypress/e2e/campaigns/encounterSync.cy.ts
+++ b/frontend/cypress/e2e/campaigns/encounterSync.cy.ts
@@ -70,7 +70,7 @@ describe('Campaign encounter synchronization', () => {
       const previousPolls = campaignPolls;
       cy.wrap(null, { timeout: 15000 }).should(() => expect(campaignPolls).to.be.at.least(previousPolls + 2));
     });
-    cy.contains('Not synced: retrying automatically').should('not.exist');
+    cy.contains('Not saved: retrying automatically').should('not.exist');
     cy.then(() => expect(writes, 'accepted snapshot acknowledged by a read, without replay').to.eq(1));
     cy.reload();
     cy.contains('button[role="tab"]', /^Encounters$/, { timeout: 30000 }).click();
@@ -192,7 +192,7 @@ describe('Campaign encounter synchronization', () => {
     });
     cy.get('input[placeholder="HP"]').clear().type('16{enter}');
     cy.wait('@blockedHealthSave');
-    cy.contains('Not synced: retrying automatically', { timeout: 15000 }).should('be.visible');
+    cy.contains('Not saved: retrying automatically', { timeout: 15000 }).should('be.visible');
     addDrained();
     cy.get('input[placeholder="HP"]').should('have.value', '15');
     readPlayer().its('hp_current').should('eq', 20);
@@ -210,7 +210,7 @@ describe('Campaign encounter synchronization', () => {
       expect(character.hp_current).to.eq(15);
       expect(character.details.conditions[0].name).to.eq('Drained');
     });
-    cy.contains('Not synced: retrying automatically').should('not.exist');
+    cy.contains('Not saved: retrying automatically').should('not.exist');
   });
 
   it('retains unsynced GM HP through failed polls and mobile layout changes, then retries successfully', () => {
@@ -224,7 +224,7 @@ describe('Campaign encounter synchronization', () => {
     });
     cy.get('input[placeholder="HP"]').clear().should('have.value', '').type('16{enter}');
     cy.wait('@failedGmSave');
-    cy.contains('Not synced: retrying automatically', { timeout: 15000 }).should('be.visible');
+    cy.contains('Not saved: retrying automatically', { timeout: 15000 }).should('be.visible');
     cy.then(() => {
       failPolls = true;
     });
@@ -237,7 +237,7 @@ describe('Campaign encounter synchronization', () => {
     cy.viewport(390, 844);
     cy.get('button[aria-label="Panel Grid"]').click();
     cy.contains('button', /^Encounters$/).click();
-    cy.contains('Not synced: retrying automatically', { timeout: 10000 }).should('be.visible');
+    cy.contains('Not saved: retrying automatically', { timeout: 10000 }).should('be.visible');
     cy.contains('button', 'Retry now').scrollIntoView();
     cy.document().should((document) => {
       expect(document.documentElement.scrollWidth).to.be.at.most(document.documentElement.clientWidth);
@@ -252,7 +252,7 @@ describe('Campaign encounter synchronization', () => {
         $button[0].click();
       });
     cy.wait('@recoveredGmSave', { timeout: 15000 }).its('response.body.status').should('eq', 'success');
-    cy.contains('Not synced: retrying automatically').should('not.exist');
+    cy.contains('Not saved: retrying automatically').should('not.exist');
     readPlayer().its('hp_current').should('eq', 16);
     cy.viewport(1280, 900);
     cy.get('input[placeholder="HP"]', { timeout: 10000 }).should('have.value', '16');

--- a/frontend/cypress/e2e/characters/conditionMath.cy.ts
+++ b/frontend/cypress/e2e/characters/conditionMath.cy.ts
@@ -293,13 +293,14 @@ describe('Condition math and recovery through the real sheet', () => {
   });
 
   it('waits for delayed content before saving nested homebrew effects and preserves them through level changes', () => {
-    // Level changes can save HP normalization before the calculated-stat update.
+    // Initial and level-change saves can precede the calculated-stat update.
     // Read the API again until it confirms the expected result, rather than
     // assuming the first intercepted save was the final calculation.
     const savedMaximum = (expected: number, retries = 40): Cypress.Chainable<unknown> =>
       read().then((saved) => {
-        if (saved.meta_data.calculated_stats.hp_max === expected || retries === 0) {
-          expect(saved.meta_data.calculated_stats.hp_max).to.eq(expected);
+        const actual = saved.meta_data?.calculated_stats?.hp_max;
+        if (actual === expected || retries === 0) {
+          expect(actual, 'saved calculated maximum HP').to.eq(expected);
           return;
         }
         return cy.wait(250, { log: false }).then(() => savedMaximum(expected, retries - 1));

--- a/frontend/cypress/e2e/characters/connectionRecovery.cy.ts
+++ b/frontend/cypress/e2e/characters/connectionRecovery.cy.ts
@@ -60,7 +60,7 @@ describe('Interrupted character saves', () => {
     });
     cy.get('input[placeholder="Unknown Wanderer"]').type('Kept through a connection drop');
     cy.wait('@droppedSave', { timeout: 15000 });
-    cy.contains('Not synced: retrying automatically', { timeout: 40000 }).should('be.visible');
+    cy.contains('Not saved: retrying automatically', { timeout: 40000 }).should('be.visible');
     cy.window().should((win) => {
       const key = Object.keys(win.localStorage).find((key) =>
         key.startsWith(`autosave-character-${characterId}-${actorId}:writer:`)
@@ -165,7 +165,7 @@ describe('Interrupted character saves', () => {
     cy.get('button[aria-label="Dismiss save notice"]', { timeout: 30000 }).click();
     cy.get('#character-save-failed').should('not.exist');
     cy.get('button.mantine-Modal-close').last().click();
-    cy.contains('Not synced: retrying automatically', { timeout: 30000 }).should('be.visible');
+    cy.contains('Not saved: retrying automatically', { timeout: 30000 }).should('be.visible');
     cy.screenshot('mobile-spells-waiting-to-sync');
     cy.window().then((win) => win.dispatchEvent(new Event('pagehide')));
     cy.reload();

--- a/frontend/cypress/e2e/characters/saveRecovery.cy.ts
+++ b/frontend/cypress/e2e/characters/saveRecovery.cy.ts
@@ -35,7 +35,7 @@ describe('Buffered character recovery', () => {
       .should('eq', 'success');
   });
 
-  it('keeps an unversioned copy accessible after loading the current character', () => {
+  it('keeps earlier changes quiet across download, close, reload and sheet navigation', () => {
     cy.visit(`/builder/${characterId}`, {
       onBeforeLoad(win) {
         win.localStorage.setItem(
@@ -44,9 +44,12 @@ describe('Buffered character recovery', () => {
         );
       },
     });
-    cy.contains('Unsynced character copy kept', { timeout: 30000 }).should('be.visible');
     cy.get('input[placeholder="Unknown Wanderer"]', { timeout: 30000 }).should('have.value', 'Saved remote name');
-    cy.contains('button', 'Download saved copy').should('be.enabled');
+    cy.contains('Unsynced character copy kept').should('not.exist');
+    cy.get('[role="dialog"]').should('not.exist');
+    cy.contains('button', 'Review earlier changes').click();
+    cy.get('[role="dialog"]').should('contain.text', 'Unsaved changes');
+    cy.contains('button', 'Download changes').should('be.enabled');
     cy.viewport(1280, 900);
     cy.screenshot('saved-copy-recovery-desktop');
     cy.viewport(390, 844);
@@ -54,7 +57,7 @@ describe('Buffered character recovery', () => {
     cy.document().then((doc) => {
       expect(doc.documentElement.scrollWidth).to.be.at.most(doc.documentElement.clientWidth);
     });
-    cy.contains('button', 'Download saved copy').click();
+    cy.contains('button', 'Download changes').click();
     cy.readFile(`cypress/downloads/character-${characterId}-saved-copy.json`)
       .its('name')
       .should('eq', 'Unsynced local copy');
@@ -65,6 +68,26 @@ describe('Buffered character recovery', () => {
       const retained = win.localStorage.getItem(key ?? '');
       expect(JSON.parse(retained ?? '{}').body.name).to.eq('Unsynced local copy');
     });
+    cy.reload();
+    cy.contains('button', 'Review earlier changes', { timeout: 30000 }).should('be.visible');
+    cy.get('[role="dialog"]').should('not.exist');
+    cy.contains('button', 'Review earlier changes').click();
+    cy.get('[role="dialog"] button[aria-label="Close"]').click();
+    cy.visit(`/sheet/${characterId}`);
+    cy.contains('button', 'Review earlier changes', { timeout: 30000 }).should('be.visible');
+    cy.get('[role="dialog"]').should('not.exist');
+    cy.screenshot('earlier-changes-sheet-mobile');
+    cy.contains('button', 'Review earlier changes').click();
+    cy.contains('button', 'Discard earlier changes').click();
+    cy.contains('button', 'Cancel').click();
+    cy.contains('button', 'Discard earlier changes').click();
+    cy.screenshot('discard-earlier-changes-mobile');
+    cy.contains('button', /^Discard changes$/).click();
+    cy.contains('button', 'Review earlier changes').should('not.exist');
+    cy.visit(`/builder/${characterId}`);
+    cy.get('input[placeholder="Unknown Wanderer"]', { timeout: 30000 }).should('have.value', 'Saved remote name');
+    cy.contains('button', 'Review earlier changes').should('not.exist');
+    cy.get('[role="dialog"]').should('not.exist');
   });
 
   it('pauses a same-field conflict and lets the user keep the saved version', () => {

--- a/frontend/scripts/character-save-lifecycle.test.mjs
+++ b/frontend/scripts/character-save-lifecycle.test.mjs
@@ -45,6 +45,7 @@ class HookHost {
     this.requests = [];
     this.notices = [];
     this.downloads = [];
+    this.modals = [];
     this.dirty = false;
     this.active = true;
     this.request = async (type, body) =>
@@ -193,6 +194,7 @@ globalThis.__saveHooks = {
   },
   notify: (notice) => harness.notices.push(notice),
   download: (body, name) => harness.downloads.push({ body, name }),
+  openModal: (modal) => harness.modals.push(modal),
   calculate: () => harness.calculate(),
   confirmHealth: (...args) => harness.confirmHealth(...args),
   saveCalculatedStats: (...args) => harness.saveCalculatedStats(...args),
@@ -220,6 +222,8 @@ const boundaries = {
   '@mantine/notifications':
     'export const showNotification = globalThis.__saveHooks.notify; export const hideNotification = () => {};',
   '@mantine/core': 'export const Button = "button"; export const Group = "group"; export const Text = "text";',
+  '@mantine/modals':
+    'export const modals = { open: globalThis.__saveHooks.openModal, openConfirmModal: globalThis.__saveHooks.openModal, close: () => {} };',
   '@export/export-to-json': 'export const downloadObjectAsJson = globalThis.__saveHooks.download;',
   '../supabase-client': 'export const supabase = globalThis.__saveHooks.supabase;',
   '@atoms/characterAtoms': 'export const characterState = {};',
@@ -319,17 +323,131 @@ beforeEach(() => {
   harness = new HookHost();
 });
 
-test('retained replay still loads the server row and exposes a downloadable copy', async () => {
+/** Find a real rendered action within the hook's controlled JSX boundary. */
+const recoveryButton = (node, label) => {
+  if (!node) return undefined;
+  if (Array.isArray(node)) return node.flatMap((child) => recoveryButton(child, label) ?? [])[0];
+  if (node.type === 'button' && node.props.children === label) return node;
+  return recoveryButton(node.props?.children, label);
+};
+
+test('earlier changes stay available without interrupting download, navigation or reopen', async () => {
   bufferCharacterSave({ ...row(), name: 'Unsynced copy' }, 'owner');
   harness.render();
   await harness.flush();
   assert.equal(harness.character.name, 'Character 1');
-  const notice = harness.notices.find((value) => value.id === 'character-recovery-1');
-  assert.ok(notice);
-  notice.message.props.onClick();
+  assert.equal(harness.notices.length, 0, 'historical drafts must not open automatic warnings');
+  assert.equal(harness.modals.length, 0);
+  assert.equal(typeof harness.value.reviewEarlierChanges, 'function');
+  harness.value.reviewEarlierChanges();
+  const review = harness.modals.at(-1);
+  assert.equal(review.title, 'Unsaved changes');
+  recoveryButton(review.children, 'Download changes').props.onClick();
   assert.equal(harness.downloads[0].body.name, 'Unsynced copy');
   assert.equal(getBufferedCharacterSave(1, 'owner').draft.body.name, 'Unsynced copy');
-  assert.equal(harness.requests.filter((value) => value.type === 'update-character').length, 0);
+  assert.ok(harness.requests.every((value) => value.type === 'find-character'));
+  // Both download and closing the review leave the retained data accessible.
+  harness.unmount();
+  harness = new HookHost();
+  harness.render();
+  await harness.flush();
+  assert.equal(harness.notices.length, 0);
+  assert.equal(harness.modals.length, 0);
+  assert.equal(typeof harness.value.reviewEarlierChanges, 'function');
+  assert.equal(harness.character.name, 'Character 1');
+  harness.unmount();
+});
+
+test('discard requires confirmation and removes only earlier changes, never the saved character', async () => {
+  bufferCharacterSave({ ...row(), name: 'Earlier changes' }, 'owner');
+  harness.render();
+  await harness.flush();
+  harness.value.reviewEarlierChanges();
+  recoveryButton(harness.modals.at(-1).children, 'Discard earlier changes').props.onClick();
+  const confirmation = harness.modals.at(-1);
+  assert.equal(confirmation.title, 'Discard earlier changes?');
+  assert.ok('draft' in getBufferedCharacterSave(1, 'owner'), 'opening or cancelling confirmation must keep the draft');
+  confirmation.onConfirm();
+  await harness.flush();
+  assert.equal(getBufferedCharacterSave(1, 'owner').status, 'none');
+  assert.equal(harness.value.reviewEarlierChanges, undefined);
+  assert.equal(harness.character.name, 'Character 1');
+  assert.ok(harness.requests.every((value) => value.type === 'find-character'));
+  harness.unmount();
+  harness = new HookHost();
+  harness.render();
+  await harness.flush();
+  assert.equal(harness.value.reviewEarlierChanges, undefined);
+  assert.equal(harness.notices.length, 0);
+  harness.unmount();
+});
+
+test('discarding a displayed earlier draft preserves a newer replacement', async () => {
+  const original = bufferCharacterSave({ ...row(), name: 'Earlier changes' }, 'owner');
+  harness.render();
+  await harness.flush();
+  harness.value.reviewEarlierChanges();
+  recoveryButton(harness.modals.at(-1).children, 'Discard earlier changes').props.onClick();
+  const newer = { ...original.record.draft, body: { ...original.record.draft.body, name: 'Newer changes' } };
+  localStorage.setItem(original.record.key, JSON.stringify(newer));
+  harness.modals.at(-1).onConfirm();
+  await harness.flush();
+  assert.equal(getBufferedCharacterSave(1, 'owner').draft.body.name, 'Newer changes');
+  assert.equal(typeof harness.value.reviewEarlierChanges, 'function');
+  assert.ok(harness.requests.every((value) => value.type === 'find-character'));
+  harness.unmount();
+});
+
+test('failed local deletion keeps earlier changes accessible for retry', async () => {
+  bufferCharacterSave({ ...row(), name: 'Earlier changes' }, 'owner');
+  harness.render();
+  await harness.flush();
+  harness.value.reviewEarlierChanges();
+  recoveryButton(harness.modals.at(-1).children, 'Discard earlier changes').props.onClick();
+  localStorage.removeItem = () => {
+    throw new Error('Storage denied');
+  };
+  harness.modals.at(-1).onConfirm();
+  await harness.flush();
+  assert.equal(getBufferedCharacterSave(1, 'owner').draft.body.name, 'Earlier changes');
+  assert.equal(typeof harness.value.reviewEarlierChanges, 'function');
+  assert.ok(harness.notices.some((notice) => notice.title === 'Could not discard changes'));
+  harness.unmount();
+});
+
+test('old recovery callbacks cannot download or discard after account or character navigation', async () => {
+  for (const transition of ['account', 'character']) {
+    bufferCharacterSave({ ...row(), name: 'Earlier changes' }, 'owner');
+    harness = new HookHost();
+    harness.render();
+    await harness.flush();
+    harness.value.reviewEarlierChanges();
+    const review = harness.modals.at(-1);
+    recoveryButton(review.children, 'Discard earlier changes').props.onClick();
+    const confirmation = harness.modals.at(-1);
+    if (transition === 'account') harness.session = { user: { id: 'other' } };
+    else harness.characterId = 2;
+    harness.render();
+    await harness.flush();
+    recoveryButton(review.children, 'Download changes').props.onClick();
+    confirmation.onConfirm();
+    assert.equal(harness.downloads.length, 0);
+    assert.equal(getBufferedCharacterSave(1, 'owner').draft.body.name, 'Earlier changes');
+    assert.equal(harness.value.reviewEarlierChanges, undefined);
+    harness.unmount();
+  }
+});
+
+test('new earlier changes become visible on focus without an automatic warning', async () => {
+  harness.render();
+  await harness.flush();
+  assert.equal(harness.value.reviewEarlierChanges, undefined);
+  bufferCharacterSave({ ...row(), name: 'Earlier changes' }, 'owner');
+  events.get('focus')?.();
+  await harness.flush();
+  assert.equal(typeof harness.value.reviewEarlierChanges, 'function');
+  assert.equal(harness.notices.length, 0);
+  assert.equal(harness.modals.length, 0);
   harness.unmount();
 });
 
@@ -444,6 +562,13 @@ test('pending and failed calculations retain inputs locally without writing deri
   assert.equal(getBufferedCharacterSave(1, 'owner').draft.body.name, 'Edit during calculation');
   assert.equal(harness.requests.filter((value) => value.type === 'update-character').length, 0);
   assert.ok(harness.value.operationError);
+  events.get('focus')();
+  await harness.flush();
+  assert.equal(harness.value.reviewEarlierChanges, undefined, 'active edits must never be offered for discard');
+  const recovery = harness.notices.find(({ title }) => title === 'Unsaved changes');
+  assert.ok(recovery, 'a failed current calculation must still offer a download');
+  recoveryButton(recovery.message, 'Download changes').props.onClick();
+  assert.equal(harness.downloads.at(-1).body.name, 'Edit during calculation');
   harness.unmount();
 });
 

--- a/frontend/src/common/CharacterSaveStatus.tsx
+++ b/frontend/src/common/CharacterSaveStatus.tsx
@@ -7,10 +7,12 @@ export function CharacterSaveStatus({
   state,
   draftStored,
   onRetry,
+  onReviewEarlierChanges,
 }: {
   state: CharacterSaveState;
   draftStored: boolean;
   onRetry: () => void;
+  onReviewEarlierChanges?: () => void;
 }) {
   const message =
     state === 'saved'
@@ -22,23 +24,37 @@ export function CharacterSaveStatus({
           : !draftStored
             ? 'Not saved: keep this page open'
             : state === 'failed'
-              ? 'Not synced: retrying automatically'
+              ? 'Not saved: retrying automatically'
               : state === 'offline'
                 ? 'Offline: changes kept on this device'
                 : state === 'saving'
                   ? 'Saving…'
                   : 'Changes waiting to save';
   return (
-    <Group gap='xs' justify='flex-end' px='xs' py='xs' w='100%' data-testid='character-save-status'>
+    <Group
+      gap='xs'
+      justify='flex-end'
+      px='xs'
+      py='xs'
+      w='100%'
+      bg='var(--glass-bg-color)'
+      style={{ borderRadius: 'var(--mantine-radius-md)' }}
+      data-testid='character-save-status'
+    >
       <Text
         size='xs'
-        c={state === 'failed' || state === 'conflict' || !draftStored ? 'orange' : 'dimmed'}
+        c={state === 'failed' || state === 'conflict' || !draftStored ? 'orange.3' : 'gray.0'}
         role='status'
       >
         {message}
       </Text>
+      {onReviewEarlierChanges && (
+        <Button size='compact-xs' variant='subtle' c='gray.0' onClick={onReviewEarlierChanges}>
+          Review earlier changes
+        </Button>
+      )}
       {(state === 'failed' || state === 'offline') && (
-        <Button size='compact-xs' variant='subtle' onClick={onRetry}>
+        <Button size='compact-xs' variant='subtle' c='gray.0' onClick={onRetry}>
           Retry now
         </Button>
       )}

--- a/frontend/src/pages/character_builder/CharBuilderCreation.tsx
+++ b/frontend/src/pages/character_builder/CharBuilderCreation.tsx
@@ -209,6 +209,7 @@ export function CharBuilderCreationInner(props: {
     retrySave,
     loadError,
     retryLoad,
+    reviewEarlierChanges,
   } = useCharacter(props.characterId, {
     type: 'EXECUTE_OPS',
     data: {
@@ -237,7 +238,12 @@ export function CharBuilderCreationInner(props: {
 
   return (
     <Group gap={0} px={isMobile ? undefined : 'sm'}>
-      <CharacterSaveStatus state={saveState} draftStored={draftStored} onRetry={retrySave} />
+      <CharacterSaveStatus
+        state={saveState}
+        draftStored={draftStored}
+        onRetry={retrySave}
+        onReviewEarlierChanges={reviewEarlierChanges}
+      />
       {isMobile ? (
         <Drawer
           opened={statPanelOpened}

--- a/frontend/src/pages/character_builder/CharBuilderHome.tsx
+++ b/frontend/src/pages/character_builder/CharBuilderHome.tsx
@@ -100,12 +100,19 @@ export default function CharBuilderHome(props: { characterId: number; pageHeight
   const queryClient = useQueryClient();
   const [_drawer, openDrawer] = useAtom(drawerState);
 
-  const { character, setCharacter, isLoading, saveState, draftStored, retrySave, loadError, retryLoad } = useCharacter(
-    props.characterId,
-    {
-      type: 'SIMPLE',
-    }
-  );
+  const {
+    character,
+    setCharacter,
+    isLoading,
+    saveState,
+    draftStored,
+    retrySave,
+    loadError,
+    retryLoad,
+    reviewEarlierChanges,
+  } = useCharacter(props.characterId, {
+    type: 'SIMPLE',
+  });
 
   const [loadingGenerateName, setLoadingGenerateName] = useState(false);
   const [displayNameInput, refreshNameInput] = useRefresh();
@@ -1322,7 +1329,12 @@ export default function CharBuilderHome(props: { characterId: number; pageHeight
 
   return (
     <Stack gap={topGap}>
-      <CharacterSaveStatus state={saveState} draftStored={draftStored} onRetry={retrySave} />
+      <CharacterSaveStatus
+        state={saveState}
+        draftStored={draftStored}
+        onRetry={retrySave}
+        onReviewEarlierChanges={reviewEarlierChanges}
+      />
       <Group justify='center' ref={ref} wrap='nowrap'>
         <Stack>
           <Box>

--- a/frontend/src/pages/character_sheet/CharacterSheetPage.tsx
+++ b/frontend/src/pages/character_sheet/CharacterSheetPage.tsx
@@ -247,6 +247,7 @@ function CharacterSheetInner(props: {
     retrySave,
     loadError,
     retryLoad,
+    reviewEarlierChanges,
   } = useCharacter(props.characterId, {
     type: 'EXECUTE_OPS',
     data: {
@@ -284,7 +285,12 @@ function CharacterSheetInner(props: {
   return (
     <Center>
       <Box maw={1000} w='100%' pb={isPhone ? 100 : 'sm'}>
-        <CharacterSaveStatus state={saveState} draftStored={draftStored} onRetry={retrySave} />
+        <CharacterSaveStatus
+          state={saveState}
+          draftStored={draftStored}
+          onRetry={retrySave}
+          onReviewEarlierChanges={reviewEarlierChanges}
+        />
         <Box ref={ref}>
           <Stack gap='xs' style={{ position: 'relative' }}>
             {/* Top stat sections: layout collapses from 3 → 2 → 1 columns on smaller screens */}

--- a/frontend/src/utils/use-character.tsx
+++ b/frontend/src/utils/use-character.tsx
@@ -2,6 +2,7 @@ import { reportClientFailure } from './client-errors';
 import { characterState } from '@atoms/characterAtoms';
 import { sessionState } from '@atoms/supabaseAtoms';
 import { Button, Group, Text } from '@mantine/core';
+import { modals } from '@mantine/modals';
 import { downloadObjectAsJson } from '@export/export-to-json';
 import {
   SAVED_CHARACTER_FIELDS,
@@ -14,6 +15,7 @@ import {
   acknowledgeBufferedCharacterRecovery,
   journalCharacterSaveSubmission,
   type BufferedCharacterSaveRecord,
+  type BufferedCharacterRecoveryRecord,
 } from './character-save-buffer';
 import { mergeCharacterSave } from './character-merge';
 import type { CharacterSaveState } from '@common/CharacterSaveStatus';
@@ -72,18 +74,20 @@ type QueuedCharacterSave = { character: Character; actorId: string; scope: numbe
 const remoteCharacterVersionSchema = CharacterSchema.pick({ id: true, updated_at: true });
 const REMOTE_CHARACTER_INTERVAL = 5000;
 
-/** Offer the preserved input copy without automatically overwriting remote changes. */
-function showCharacterRecovery(characterId: number, recovery: Record<string, unknown>): void {
+/** Failed current calculations retain a download without offering to discard active edits. */
+function showCharacterRecovery(characterId: number, recovery: Record<string, unknown>, isCurrent: () => boolean): void {
   showNotification({
     id: `character-recovery-${characterId}`,
-    title: 'Unsynced character copy kept',
+    title: 'Unsaved changes',
     message: (
       <Button
         size='xs'
         variant='light'
-        onClick={() => downloadObjectAsJson(recovery, `character-${characterId}-saved-copy`)}
+        onClick={() => {
+          if (isCurrent()) downloadObjectAsJson(recovery, `character-${characterId}-saved-copy`);
+        }}
       >
-        Download saved copy
+        Download changes
       </Button>
     ),
     color: 'yellow',
@@ -114,6 +118,7 @@ export default function useCharacter(
   retrySave: () => void;
   loadError: boolean;
   retryLoad: () => void;
+  reviewEarlierChanges: (() => void) | undefined;
 } {
   const [character, setCharacter] = useAtom(characterState);
   const session = useAtomValue(sessionState);
@@ -130,6 +135,7 @@ export default function useCharacter(
   const [isOnline, setIsOnline] = useState(typeof navigator === 'undefined' || navigator.onLine !== false);
   const [loadError, setLoadError] = useState(false);
   const [loadAttempt, setLoadAttempt] = useState(0);
+  const [earlierChanges, setEarlierChanges] = useState<BufferedCharacterRecoveryRecord[]>([]);
   const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const retryCountRef = useRef(0);
   const retrySaveRef = useRef<() => void>(() => {});
@@ -142,6 +148,87 @@ export default function useCharacter(
   const clearSaveRetry = () => {
     if (retryTimerRef.current !== null) clearTimeout(retryTimerRef.current);
     retryTimerRef.current = null;
+  };
+
+  /** Re-read retained history without treating it as a failure of the current save. */
+  const refreshEarlierChanges = useCallback((): BufferedCharacterRecoveryRecord[] | null => {
+    if (!sessionActorId || loadedActorRef.current !== sessionActorId) return null;
+    const loaded = loadBufferedCharacterSaves(characterId, sessionActorId);
+    if (loaded.status !== 'loaded') return null;
+    const records = loaded.retained.filter((record) => !!record.body);
+    setEarlierChanges(records);
+    return records;
+  }, [characterId, sessionActorId]);
+
+  /** Historical drafts only open on request; closing or downloading never deletes them. */
+  const reviewEarlierChanges = (): void => {
+    if (!hasLoadedCharacter || !sessionActorId || loadedActorRef.current !== sessionActorId) return;
+    const records = refreshEarlierChanges();
+    if (records === null) {
+      showNotification({ title: 'Could not load earlier changes', message: 'Please try again.', color: 'yellow' });
+      return;
+    }
+    if (!records.length) return;
+    const scope = saveScopeRef.current;
+    const actor = sessionActorId;
+    const isCurrent = (): boolean => scope === saveScopeRef.current && actor === loadedActorRef.current;
+    const modalId = `character-recovery-${characterId}`;
+    const copies = records.flatMap((record) => (record.body ? [record.body] : []));
+    modals.open({
+      modalId,
+      title: 'Unsaved changes',
+      closeButtonProps: { 'aria-label': 'Close' },
+      children: (
+        <>
+          <Text size='sm'>Earlier changes are available to review.</Text>
+          <Group gap='xs' mt='sm'>
+            <Button
+              variant='light'
+              onClick={() => {
+                if (!isCurrent()) return;
+                downloadObjectAsJson(
+                  copies.length === 1 ? copies[0] : { copies },
+                  `character-${characterId}-saved-copy`
+                );
+                modals.close(modalId);
+              }}
+            >
+              Download changes
+            </Button>
+            <Button
+              variant='subtle'
+              color='red'
+              onClick={() => {
+                if (!isCurrent()) return;
+                modals.openConfirmModal({
+                  modalId: `character-recovery-discard-${characterId}`,
+                  title: 'Discard earlier changes?',
+                  closeButtonProps: { 'aria-label': 'Cancel' },
+                  children: <Text size='sm'>This permanently removes those earlier changes from this device.</Text>,
+                  labels: { confirm: 'Discard changes', cancel: 'Cancel' },
+                  confirmProps: { color: 'red' },
+                  onConfirm: () => {
+                    if (!isCurrent()) return;
+                    const results = records.map((record) => acknowledgeBufferedCharacterRecovery(record));
+                    // A newer replacement or failed removal must remain discoverable.
+                    refreshEarlierChanges();
+                    modals.close(modalId);
+                    if (results.some((result) => result.status === 'unavailable'))
+                      showNotification({
+                        title: 'Could not discard changes',
+                        message: 'Please try again.',
+                        color: 'yellow',
+                      });
+                  },
+                });
+              }}
+            >
+              Discard earlier changes
+            </Button>
+          </Group>
+        </>
+      ),
+    });
   };
 
   // Always-current view of the atom (the `character` closure goes stale inside async
@@ -217,7 +304,7 @@ export default function useCharacter(
 
   /** Keep conflicting input recoverable until the same account chooses which copy to save. */
   const offerConflictResolution = useCallback(
-    (local: Character, remote: Character, fields: string[]) => {
+    (local: Character, remote: Character) => {
       saveConflictRef.current = true;
       hideNotification('character-save-failed');
       clearSaveRetry();
@@ -254,10 +341,7 @@ export default function useCharacter(
         title: 'Conflicting character edits',
         message: (
           <>
-            <Text size='sm'>
-              Saving paused: {fields.slice(0, 3).join(', ')}
-              {fields.length > 3 ? ', …' : ''}
-            </Text>
+            <Text size='sm'>Choose which changes to keep.</Text>
             <Group gap='xs' mt='xs'>
               <Button size='xs' onClick={() => resolve(true)}>
                 Keep my edits
@@ -306,6 +390,7 @@ export default function useCharacter(
     retryCountRef.current = 0;
     uncertainSaveRef.current = null;
     recoveredDraftsRef.current = [];
+    setEarlierChanges([]);
     needsCalculationRef.current = false;
     lastSyncedRef.current = null;
     readOnlyRef.current = false;
@@ -330,12 +415,14 @@ export default function useCharacter(
       let displayed = dbCharacter;
       const conflicts: string[] = [];
       if (restored?.status === 'loaded') {
-        const copies = restored.retained.flatMap((record) => (record.body ? [record.body] : []));
-        if (copies.length) showCharacterRecovery(characterId, copies.length === 1 ? copies[0] : { copies });
+        setEarlierChanges(restored.retained.filter((record) => !!record.body));
         for (const record of restored.records) {
           const draft = record.draft;
           if (!draft.base || !draft.body.expected_updated_at) {
-            showCharacterRecovery(characterId, draft.body);
+            setEarlierChanges((records) => [
+              ...records,
+              { key: record.key, raw: record.raw, body: draft.body, reason: 'missing-base' },
+            ]);
             continue;
           }
           const merged = mergeCharacterSave(draft.base, draft.body, displayed, draft.submission?.body);
@@ -350,7 +437,7 @@ export default function useCharacter(
         // Original records remain available until the user resolves the conflict.
         const firstBase = recoveredDraftsRef.current[0]?.draft.base;
         if (firstBase) lastSyncedRef.current = { ...dbCharacter, ...firstBase };
-        offerConflictResolution(displayed, dbCharacter, [...new Set(conflicts)]);
+        offerConflictResolution(displayed, dbCharacter);
       } else if (sessionActorId) {
         if (recoveredDraftsRef.current.length) {
           const reconciled = reconcileBufferedCharacterSave(displayed, sessionActorId, dbCharacter, {
@@ -378,6 +465,8 @@ export default function useCharacter(
       clearSaveRetry();
       window.removeEventListener('online', retryLoadOnReconnect);
       hideNotification(recoveryNoticeId);
+      modals.close(recoveryNoticeId);
+      modals.close(`character-recovery-discard-${characterId}`);
       hideNotification('character-save-failed');
     };
   }, [characterId, sessionActorId, loadAttempt, handleFetchedCharacter, offerConflictResolution]);
@@ -610,7 +699,14 @@ export default function useCharacter(
     if (!operationError || !loadedActorRef.current) return;
     reportClientFailure('calculation_failed');
     const stored = getBufferedCharacterSave(characterId, loadedActorRef.current);
-    if ('draft' in stored && stored.draft.requiresCalculation) showCharacterRecovery(characterId, stored.draft.body);
+    const scope = saveScopeRef.current;
+    const actor = loadedActorRef.current;
+    if ('draft' in stored && stored.draft.requiresCalculation)
+      showCharacterRecovery(
+        characterId,
+        stored.draft.body,
+        () => scope === saveScopeRef.current && actor === loadedActorRef.current
+      );
   }, [operationError, characterId]);
 
   const isCurrentSave = (save: QueuedCharacterSave) =>
@@ -631,11 +727,7 @@ export default function useCharacter(
     if (merge.conflicts.length || repeatedConflict) {
       characterRef.current = merged;
       setCharacter(merged);
-      offerConflictResolution(
-        merged,
-        remote,
-        merge.conflicts.length ? merge.conflicts : ['Repeated changes from another session']
-      );
+      offerConflictResolution(merged, remote);
       return null;
     }
     const changed = SAVED_CHARACTER_FIELDS.some(
@@ -798,7 +890,7 @@ export default function useCharacter(
       if (!hasSessionExpiredNotice() && retryCountRef.current === 0)
         showNotification({
           id: 'character-save-failed',
-          title: 'Changes not synced',
+          title: 'Changes not saved',
           message: (
             <Group gap='xs'>
               <Text size='sm'>Retrying automatically.</Text>
@@ -917,7 +1009,11 @@ export default function useCharacter(
   useEffect(() => {
     const wake = () => {
       setIsOnline(typeof navigator === 'undefined' || navigator.onLine !== false);
+      refreshEarlierChanges();
       retrySaveRef.current();
+    };
+    const storageChanged = () => {
+      refreshEarlierChanges();
     };
     const offline = () => setIsOnline(false);
     const visible = () => {
@@ -926,15 +1022,17 @@ export default function useCharacter(
     window.addEventListener('online', wake);
     window.addEventListener('focus', wake);
     window.addEventListener('offline', offline);
+    window.addEventListener('storage', storageChanged);
     document.addEventListener('visibilitychange', visible);
     return () => {
       clearSaveRetry();
       window.removeEventListener('online', wake);
       window.removeEventListener('focus', wake);
       window.removeEventListener('offline', offline);
+      window.removeEventListener('storage', storageChanged);
       document.removeEventListener('visibilitychange', visible);
     };
-  }, [characterId, sessionActorId]);
+  }, [characterId, sessionActorId, refreshEarlierChanges]);
 
   const hasPendingChanges =
     !!uncertainSaveRef.current ||
@@ -972,6 +1070,7 @@ export default function useCharacter(
     retrySave: () => retrySaveRef.current(),
     loadError,
     retryLoad: () => setLoadAttempt((attempt) => attempt + 1),
+    reviewEarlierChanges: hasLoadedCharacter && earlierChanges.length ? reviewEarlierChanges : undefined,
     results: operationResults ?? null,
     operationError,
     isCalculating,


### PR DESCRIPTION
Opening a character with a retained draft repeatedly showed “Unsynced character copy kept,” even after downloading and closing it. Earlier drafts now appear as a quiet **Review earlier changes** action in the builder and sheet. The review preserves changes on close/download and offers an explicit, confirmed discard that cannot delete a newer replacement or the current draft awaiting calculation.

The recovery heading is **Unsaved changes**. Save failures say **Changes not saved**, and conflicts ask **Choose which changes to keep** without exposing internal field paths. Save controls have a themed background and readable text over character artwork. Added text contains no em dashes.

Validation: 145 infrastructure checks passed, including six recovery lifecycle scenarios; TypeScript/build and scoped lint passed (existing hook warnings remain). Cypress covers download, close, reload, builder/sheet navigation, cancelled and confirmed discard, interrupted saves, mobile prepared spells under CPU/network throttling, and incoming remote changes. All 22 targeted browser scenarios passed, including six encounter scenarios and seven condition/homebrew scenarios. Desktop and phone screenshots were inspected. The earlier regression test stopped after download; the expanded test now exercises reopening, which caught the original bug before the fix.

The full CI browser run caught an existing homebrew polling helper dereferencing calculated stats before they existed. It now retries that transitional state while preserving the exact expected HP assertion and its deadline. The final GitHub CI and full E2E rerun passed, including all 35 browser scenarios. The read-only production compatibility gate passed against 1c57ef65 with no issues. No API, database, or storage-format changes.
