### PR TITLE
Reduce mobile loading work and keep save retries quiet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,9 @@ jobs:
           VITE_SUPABASE_URL: http://localhost:8000
           VITE_SUPABASE_KEY: ci-placeholder
           VITE_ENV: production
-        run: npm run build
+        run: |
+          npm run build
+          npm run test:build
 
   docs:
     runs-on: ubuntu-latest

--- a/docs/development.mdx
+++ b/docs/development.mdx
@@ -334,6 +334,9 @@ and content store with network and authentication lookups unavailable. It checks
 source boundaries, consecutive packages, missing tables, and cleanup after failure.
 Separate cases cover cross-book references: their existing scoped lookup must still
 work online and fail clearly when an uncached dependency cannot be downloaded.
+The real Wizard fixture also exercises its legacy trait-name filter with all network
+access disabled; duplicate trait names preserve the API's first-by-ID result across
+INFO and PAGE while selection lists keep their PAGE source boundaries.
 Use a production build and preview for startup measurements; development modules have
 different download behavior. These are controlled Chromium scenarios, not measurements
 on a physical phone.

--- a/docs/development.mdx
+++ b/docs/development.mdx
@@ -329,6 +329,11 @@ download throughput, 96 KiB/s upload throughput, and 4x CPU throttling before vi
 the app. It creates a fresh account scope, loads a sheet, waits for the actual content
 cache transaction, and reloads with a delayed freshness check and unavailable catalog
 endpoints. The cached sheet must become usable without replacement catalog requests.
+The worker-package regression in `test:infra` runs the real worker entry point, controller,
+and content store with network and authentication lookups unavailable. It checks grants,
+source boundaries, consecutive packages, missing tables, and cleanup after failure.
+Separate cases cover cross-book references: their existing scoped lookup must still
+work online and fail clearly when an uncached dependency cannot be downloaded.
 Use a production build and preview for startup measurements; development modules have
 different download behavior. These are controlled Chromium scenarios, not measurements
 on a physical phone.

--- a/docs/development.mdx
+++ b/docs/development.mdx
@@ -313,7 +313,7 @@ npm --prefix frontend run cy:e2e -- --spec "cypress/e2e/login/*.cy.ts"
 ```
 
 The `characters/calculationRecovery.cy.ts` and `characters/saveRecovery.cy.ts` specs
-verify worker failure/retry and retained-copy download in the rendered app, including
+verify worker failure/retry and retained-edit recovery in the rendered app, including
 desktop and mobile screenshots. Both create and clean up their own local test character.
 
 The `characters/connectionRecovery.cy.ts` spec interrupts real character writes, lets a
@@ -324,11 +324,27 @@ simulate flaky transport, constrained CPU and page lifecycle boundaries, not iOS
 process eviction or a measured physical-device performance profile. The save-hook regressions also cover uncertain writes,
 intentional reversions, separate-tab drafts, storage exhaustion, and account changes.
 
+The `characters/mobileLoading.cy.ts` scenario applies 150 ms latency, 192 KiB/s
+download throughput, 96 KiB/s upload throughput, and 4x CPU throttling before visiting
+the app. It creates a fresh account scope, loads a sheet, waits for the actual content
+cache transaction, and reloads with a delayed freshness check and unavailable catalog
+endpoints. The cached sheet must become usable without replacement catalog requests.
+Use a production build and preview for startup measurements; development modules have
+different download behavior. These are controlled Chromium scenarios, not measurements
+on a physical phone.
+
+After `npm --prefix frontend run build`, run `npm --prefix frontend run test:build`.
+This checks the generated service worker and output files: the app shell stays precached,
+the developer report is excluded, and the optional game-icon chunk is cached after use.
+Bundle reports are written to `frontend/.scratch/bundle-stats.html` for local analysis.
+The first use of a game icon or icon picker can require a download; reopening it can
+use the runtime cache. The complete icon library is not fetched on an idle timer.
+
 The encounter writer regressions run in `test:infra`. They exercise GM/player races,
 serialized HP edits, lost acknowledgements, narrow guarded writes, retained drafts,
 and failure/conflict responses. The encounter keeps unsynced edits visible and retries
-transport failures. Conflicting edits offer **Review changes**, which opens the sheet's
-existing recovery flow. Navigating away preserves its versioned local draft; the campaign
+transport failures. Conflicting edits offer **Open character**, which opens the sheet's
+existing conflict resolution flow. Navigating away preserves its versioned local draft; the campaign
 does not automatically restore old drafts into encounter controls on a new visit.
 
 `campaigns/encounterSync.cy.ts` creates two confirmed synthetic accounts, joins a real

--- a/docs/guides/content-data.mdx
+++ b/docs/guides/content-data.mdx
@@ -34,11 +34,14 @@ preserves unsynced character drafts.
 
 Optional browser-cache work cannot block authoritative content loading. Homebrew
 invalidation clears the current in-memory generation immediately and queues persistent
-deletion in order with other storage writes. Cache hydration has a 2.5-second deadline;
-after that deadline its late result cannot publish rows, even after a delayed source
-version check. A successful empty download therefore stays empty. If browser storage
+deletion in order with other storage writes. Reading storage has a 2.5-second deadline;
+a late read cannot publish rows after fresh downloads start. A recent snapshot gets a
+separate 750-millisecond source-version check. Confirmed changes reject the snapshot;
+a slow or unavailable check uses the account-scoped snapshot for this visit. A late
+verdict never replaces content during calculations. Unverified snapshots keep their
+original timestamp when persisted, preserving the 24-hour age limit. If browser storage
 itself remains stalled, fresh content still loads but persistence waits for that storage
-operation to finish.
+operation to finish. Catalog artwork loads only when displayed.
 
 The builder waits for the current character's authoritative save context before
 exposing editable controls. A cached route row cannot make the form ready early.
@@ -61,7 +64,7 @@ repeatedly loading the server's older sources would otherwise create a reload lo
 
 Concurrent character edits merge at nested fields and stable entry IDs. Independent
 changes survive. When both writers change the same value, saving pauses and offers
-**Keep my edits**, **Use saved version**, and **Download my copy**. The local input and
+**Keep my edits** and **Use saved version**. The local input and
 its original base remain buffered until the conflict is resolved. Choosing the saved
 version removes the matching rejected draft so reloading cannot restore that edit.
 

--- a/docs/guides/content-data.mdx
+++ b/docs/guides/content-data.mdx
@@ -50,8 +50,13 @@ content from another book; when that reference is absent from the package, the e
 scoped lookup still runs without storing fallback rows in the worker cache. A failed
 lookup stops calculation rather than dropping the grant. Such uncached dependencies
 still require a connection. Explicit main-thread calculations retain the normal content
-store behavior. Spell panels use the same complete page package, so an early render
-cannot cache an empty catalog while a character is being restored.
+store behavior. Trait-name filters also receive a separately cached INFO+PAGE trait
+catalog, preserving the endpoint's first-by-ID choice when names occur in more than one
+book. This optional metadata starts loading with the PAGE package and gets at most
+750 milliseconds of extra wait after the required tables finish. Failure or a late result
+cannot block an unrelated character or mutate a posted package; an actual missing lookup
+uses the existing scoped request. Spell panels use the same complete page package, so an
+early render cannot cache an empty catalog while a character is being restored.
 
 The builder waits for the current character's authoritative save context before
 exposing editable controls. A cached route row cannot make the form ready early.

--- a/docs/guides/content-data.mdx
+++ b/docs/guides/content-data.mdx
@@ -43,6 +43,16 @@ original timestamp when persisted, preserving the 24-hour age limit. If browser 
 itself remains stalled, fresh content still loads but persistence waits for that storage
 operation to finish. Catalog artwork loads only when displayed.
 
+Calculation workers reuse the package posted for their current job. Catalog selections
+remain scoped to its enabled sources, and the reader is released after success or
+failure. A missing required table fails the calculation. Explicit grants can reference
+content from another book; when that reference is absent from the package, the existing
+scoped lookup still runs without storing fallback rows in the worker cache. A failed
+lookup stops calculation rather than dropping the grant. Such uncached dependencies
+still require a connection. Explicit main-thread calculations retain the normal content
+store behavior. Spell panels use the same complete page package, so an early render
+cannot cache an empty catalog while a character is being restored.
+
 The builder waits for the current character's authoritative save context before
 exposing editable controls. A cached route row cannot make the form ready early.
 A failed load leaves the character route available for retry. Save status distinguishes

--- a/docs/releases.mdx
+++ b/docs/releases.mdx
@@ -205,8 +205,11 @@ Normal saving, successful retries and compatible remote updates run without a
 status row, toast or recovery controls on the character sheet and builder. Changes
 to that layout require an intentional UI scope decision.
 
-Actual save failures use an error toast while retries continue automatically. The
-toast disappears after server confirmation. Conflicting edits that cannot be safely
+Temporary network failures retry quietly while edits remain retained on the device.
+A toast appears when local retention fails, editing permission is lost, or the server
+explicitly rejects the change. An explicitly rejected payload stays buffered and is
+not repeatedly submitted; a corrected edit can save again. Storage warnings clear
+after local retention or server confirmation succeeds. Conflicting edits that cannot be safely
 merged ask which version to keep. An encounter conflict links to the character to
 resolve it. Authentication and calculation failures retain their existing recovery
 paths. There is no download or discard workflow for save history.

--- a/frontend/cypress/e2e/campaigns/encounterSync.cy.ts
+++ b/frontend/cypress/e2e/campaigns/encounterSync.cy.ts
@@ -71,7 +71,7 @@ describe('Campaign encounter synchronization', () => {
       cy.wrap(null, { timeout: 15000 }).should(() => expect(campaignPolls).to.be.at.least(previousPolls + 2));
     });
     // A campaign poll is independent of the writer's reconciliation read. Wait for
-    // acknowledgement to retire the draft before expecting its error toast to clear.
+    // acknowledgement to retire the draft before checking recovery is complete.
     cy.window({ timeout: 15000 }).should((win) => {
       expect(
         Object.keys(win.localStorage).filter((key) => key.startsWith(`autosave-character-${fixture!.characterId}-`))
@@ -132,7 +132,7 @@ describe('Campaign encounter synchronization', () => {
     cy.screenshot('campaign-drained-player-damage-conflict');
   });
 
-  it('replaces a failed-save toast when retry discovers conflicting player damage', () => {
+  it('keeps interrupted saves quiet until a retry discovers conflicting player damage', () => {
     let writes = 0;
     cy.intercept('POST', '**/functions/v1/update-character', (request) => {
       if (request.body.id !== fixture!.characterId) return;
@@ -142,7 +142,7 @@ describe('Campaign encounter synchronization', () => {
     });
     cy.get('input[placeholder="HP"]').clear().type('16{enter}');
     cy.wait('@failedDamageSave');
-    cy.contains('Changes not saved', { timeout: 15000 }).should('be.visible');
+    cy.contains('Changes not saved').should('not.exist');
     cy.task('campaignFixture:playerUpdate', { key: fixture!.key, hp: 12 }, { log: false });
     cy.window().then((win) => win.dispatchEvent(new Event('online')));
     cy.contains('Conflicting character edits', { timeout: 15000 }).should('be.visible');
@@ -151,6 +151,54 @@ describe('Campaign encounter synchronization', () => {
     cy.get('input[placeholder="HP"]').should('have.value', '16');
     readPlayer().its('hp_current').should('eq', 12);
     cy.then(() => expect(writes, 'conflicting damage must not be retried as a write').to.eq(1));
+  });
+
+  it('warns only while pending encounter edits cannot be retained locally', () => {
+    let disrupted = true;
+    let restoreStorage: () => void;
+    cy.intercept('POST', '**/functions/v1/update-character', (request) => {
+      if (request.body.id !== fixture!.characterId) return;
+      if (disrupted) {
+        request.alias = 'blockedUnretainedHp';
+        request.reply({ statusCode: 503, body: { status: 'error', message: 'Simulated weak connection' } });
+      } else request.alias = 'recoveredRetainedHp';
+    });
+    cy.window().then((win) => {
+      const setItem = win.Storage.prototype.setItem;
+      const stub = cy.stub(win.Storage.prototype, 'setItem').callsFake(function (
+        this: Storage,
+        key: string,
+        value: string
+      ) {
+        if (key.startsWith(`autosave-character-${fixture!.characterId}-`))
+          throw new Error('Test storage quota exceeded');
+        return setItem.call(this, key, value);
+      });
+      restoreStorage = () => stub.restore();
+    });
+    cy.get('input[placeholder="HP"]').clear().type('16{enter}');
+    cy.wait('@blockedUnretainedHp');
+    cy.contains('Keep this page open until saving completes.').should('be.visible');
+    readPlayer().its('hp_current').should('eq', 20);
+    cy.window().then((win) => {
+      restoreStorage();
+      win.dispatchEvent(new Event('online'));
+    });
+    cy.wait('@blockedUnretainedHp');
+    cy.contains('Changes not saved').should('not.exist');
+    cy.window().should((win) => {
+      const key = Object.keys(win.localStorage).find((key) =>
+        key.startsWith(`autosave-character-${fixture!.characterId}-`)
+      );
+      expect(JSON.parse(win.localStorage.getItem(key ?? '') ?? '{}').body?.hp_current).to.eq(16);
+    });
+    cy.window().then((win) => {
+      disrupted = false;
+      win.dispatchEvent(new Event('online'));
+    });
+    cy.wait('@recoveredRetainedHp').its('response.body.status').should('eq', 'success');
+    readPlayer().its('hp_current').should('eq', 16);
+    cy.contains('Changes not saved').should('not.exist');
   });
 
   it('keeps typed HP through fresh player polls, preserves player details, and sends one Enter/blur write', () => {
@@ -220,7 +268,7 @@ describe('Campaign encounter synchronization', () => {
     });
     cy.get('input[placeholder="HP"]').clear().type('16{enter}');
     cy.wait('@blockedHealthSave');
-    cy.contains('Changes not saved', { timeout: 15000 }).should('be.visible');
+    cy.contains('Changes not saved').should('not.exist');
     addDrained();
     cy.get('input[placeholder="HP"]').should('have.value', '15');
     readPlayer().its('hp_current').should('eq', 20);
@@ -250,7 +298,7 @@ describe('Campaign encounter synchronization', () => {
     });
     cy.get('input[placeholder="HP"]').clear().should('have.value', '').type('16{enter}');
     cy.wait('@failedGmSave');
-    cy.contains('Changes not saved', { timeout: 15000 }).should('be.visible');
+    cy.contains('Changes not saved').should('not.exist');
     cy.then(() => {
       failPolls = true;
     });
@@ -263,7 +311,7 @@ describe('Campaign encounter synchronization', () => {
     cy.viewport(390, 844);
     cy.get('button[aria-label="Panel Grid"]').click();
     cy.contains('button', /^Encounters$/).click();
-    cy.contains('Changes not saved', { timeout: 10000 }).should('be.visible');
+    cy.contains('Changes not saved').should('not.exist');
     cy.document().should((document) => {
       expect(document.documentElement.scrollWidth).to.be.at.most(document.documentElement.clientWidth);
     });

--- a/frontend/cypress/e2e/characters/connectionRecovery.cy.ts
+++ b/frontend/cypress/e2e/characters/connectionRecovery.cy.ts
@@ -60,7 +60,6 @@ describe('Interrupted character saves', () => {
     });
     cy.get('input[placeholder="Unknown Wanderer"]').type('Kept through a connection drop');
     cy.wait('@droppedSave', { timeout: 15000 });
-    cy.contains('Changes not saved', { timeout: 40000 }).should('be.visible');
     cy.window().should((win) => {
       const key = Object.keys(win.localStorage).find((key) =>
         key.startsWith(`autosave-character-${characterId}-${actorId}:writer:`)
@@ -68,6 +67,7 @@ describe('Interrupted character saves', () => {
       const draft = JSON.parse(win.localStorage.getItem(key ?? '') ?? '{}');
       expect(draft.body?.name).to.eq('Kept through a connection drop');
     });
+    cy.contains('Changes not saved').should('not.exist');
     cy.window().then((win) => {
       disrupted = false;
       win.dispatchEvent(new Event('online'));
@@ -109,12 +109,82 @@ describe('Interrupted character saves', () => {
     readCharacter().its('name').should('eq', 'Committed before timeout');
     cy.get('input[placeholder="Unknown Wanderer"]').clear().type('Newest edit during timeout');
     cy.wait('@latestSave', { timeout: 45000 }).its('response.body.status').should('eq', 'success');
+    cy.contains('Changes not saved').should('not.exist');
     readCharacter().its('name').should('eq', 'Newest edit during timeout');
     cy.reload();
     cy.get('input[placeholder="Unknown Wanderer"]', { timeout: 30000 }).should(
       'have.value',
       'Newest edit during timeout'
     );
+  });
+
+  it('warns when an interrupted edit cannot be retained locally, then clears when storage recovers', () => {
+    let disrupted = true;
+    let restoreStorage: () => void;
+    cy.intercept('POST', '**/functions/v1/update-character', (req) => {
+      if (disrupted) {
+        req.alias = 'unretainedSave';
+        req.reply({ statusCode: 503, body: { status: 'error', message: 'Test connection interruption' } });
+      } else req.alias = 'retainedSave';
+    });
+    cy.window().then((win) => {
+      const setItem = win.Storage.prototype.setItem;
+      const stub = cy.stub(win.Storage.prototype, 'setItem').callsFake(function (
+        this: Storage,
+        key: string,
+        value: string
+      ) {
+        if (key.startsWith(`autosave-character-${characterId}-`)) throw new Error('Test storage quota exceeded');
+        return setItem.call(this, key, value);
+      });
+      restoreStorage = () => stub.restore();
+    });
+    cy.get('input[placeholder="Unknown Wanderer"]').type('Retained after storage recovery');
+    cy.wait('@unretainedSave', { timeout: 15000 });
+    cy.contains('Keep this page open until saving completes.').should('be.visible');
+    cy.window().then((win) => {
+      restoreStorage();
+      win.dispatchEvent(new Event('pagehide'));
+    });
+    cy.contains('Changes not saved').should('not.exist');
+    cy.window().should((win) => {
+      const key = Object.keys(win.localStorage).find((key) =>
+        key.startsWith(`autosave-character-${characterId}-${actorId}:writer:`)
+      );
+      expect(JSON.parse(win.localStorage.getItem(key ?? '') ?? '{}').body?.name).to.eq(
+        'Retained after storage recovery'
+      );
+    });
+    cy.window().then((win) => {
+      disrupted = false;
+      win.dispatchEvent(new Event('online'));
+    });
+    cy.wait('@retainedSave', { timeout: 15000 }).its('response.body.status').should('eq', 'success');
+    readCharacter().its('name').should('eq', 'Retained after storage recovery');
+  });
+
+  it('retains an explicitly rejected save and saves a corrected edit', () => {
+    cy.intercept('POST', '**/functions/v1/update-character', (req) => {
+      if (req.body.name === 'Rejected save') {
+        req.alias = 'rejectedSave';
+        req.reply({ statusCode: 413, body: { status: 'fail', data: { message: 'Test payload rejection' } } });
+      } else if (req.body.name === 'Corrected save') req.alias = 'correctedSave';
+    });
+    cy.get('input[placeholder="Unknown Wanderer"]').type('Rejected save');
+    cy.wait('@rejectedSave', { timeout: 15000 });
+    cy.contains('These changes could not be saved.').should('be.visible');
+    cy.window().should((win) => {
+      const key = Object.keys(win.localStorage).find((key) =>
+        key.startsWith(`autosave-character-${characterId}-${actorId}:writer:`)
+      );
+      const draft = JSON.parse(win.localStorage.getItem(key ?? '') ?? '{}');
+      expect(draft.body?.name).to.eq('Rejected save');
+      expect(draft.submission).to.eq(undefined);
+    });
+    cy.get('input[placeholder="Unknown Wanderer"]').clear().type('Corrected save');
+    cy.wait('@correctedSave', { timeout: 15000 }).its('response.body.status').should('eq', 'success');
+    cy.contains('Changes not saved').should('not.exist');
+    readCharacter().its('name').should('eq', 'Corrected save');
   });
 
   it('recovers prepared spells after interruption and reopening at phone width', () => {
@@ -133,8 +203,10 @@ describe('Interrupted character saves', () => {
     cy.contains('button', /^Spells$/).click();
     let disrupted = true;
     cy.intercept('POST', '**/functions/v1/update-character', (req) => {
-      if (disrupted) req.reply({ statusCode: 503, body: { status: 'error', message: 'Test connection interruption' } });
-      else {
+      if (disrupted) {
+        req.alias = 'interruptedSpellSave';
+        req.reply({ statusCode: 503, body: { status: 'error', message: 'Test connection interruption' } });
+      } else {
         req.alias = 'spellsSaved';
         req.continue((res) => {
           res.setDelay(750);
@@ -160,8 +232,8 @@ describe('Interrupted character saves', () => {
     chooseCharm();
     cy.get('[data-wg-name="rank-1"]').contains('Select Spell').first().click();
     chooseCharm();
-    cy.get('button[aria-label="Dismiss save notice"]', { timeout: 30000 }).click();
-    cy.get('#character-save-failed').should('not.exist');
+    cy.wait('@interruptedSpellSave', { timeout: 30000 });
+    cy.contains('Changes not saved').should('not.exist');
     cy.get('button.mantine-Modal-close').last().click();
     cy.get('[data-testid="character-save-status"]').should('not.exist');
     cy.screenshot('mobile-spells-waiting-to-sync');

--- a/frontend/cypress/e2e/characters/connectionRecovery.cy.ts
+++ b/frontend/cypress/e2e/characters/connectionRecovery.cy.ts
@@ -222,7 +222,7 @@ describe('Interrupted character saves', () => {
       cy.get('input[placeholder="Search spells"]')
         .last()
         .closest('.mantine-Modal-body')
-        .contains('p', /^Charm$/)
+        .contains('p', /^Charm$/, { timeout: 30000 })
         .parents('.mantine-Group-root')
         .filter(':has(button)')
         .first()
@@ -237,7 +237,16 @@ describe('Interrupted character saves', () => {
     cy.get('button.mantine-Modal-close').last().click();
     cy.get('[data-testid="character-save-status"]').should('not.exist');
     cy.screenshot('mobile-spells-waiting-to-sync');
-    cy.window().then((win) => win.dispatchEvent(new Event('pagehide')));
+    cy.window().then((win) => {
+      win.dispatchEvent(new Event('pagehide'));
+      const drafts = Object.entries(win.localStorage)
+        .filter(([key]) => key.startsWith(`autosave-character-${characterId}-${actorId}:writer:`))
+        .map(([, raw]) => JSON.parse(raw));
+      expect(
+        drafts.some((draft) => draft.body?.spells?.slots?.some((slot: { spell_id?: number }) => !!slot.spell_id)),
+        'prepared spell retained before reopening'
+      ).to.eq(true);
+    });
     cy.reload();
     cy.get('button[aria-label="Panel Grid"]', { timeout: 30000 }).should('be.visible').click();
     cy.contains('button', /^Spells$/).click();

--- a/frontend/cypress/e2e/characters/mobileLoading.cy.ts
+++ b/frontend/cypress/e2e/characters/mobileLoading.cy.ts
@@ -30,6 +30,7 @@ describe('Mobile content loading', () => {
         uploadThroughput: 96 * 1024,
       });
       protocol('Emulation.setCPUThrottlingRate', { rate: 4 });
+      cy.intercept('GET', '**/assets/game-icons-*.js').as('gameIcons');
       cy.intercept('POST', '**/auth/v1/token*').as('signIn');
       cy.login(created.gm.email, created.gm.password);
       cy.wait('@signIn').then(({ response }) => {
@@ -84,6 +85,7 @@ describe('Mobile content loading', () => {
             cy.contains('Hit Points', { timeout: 60000 }).should('be.visible');
             cy.get('[data-testid="character-save-status"]').should('not.exist');
             cy.contains('Changes not saved').should('not.exist');
+            cy.get('@gameIcons.all').should('have.length', 0);
             cy.screenshot('mobile-cold-content-loaded');
             // Wait for the actual IndexedDB transaction, not a guessed debounce sleep.
             cy.window().then((win) => win.dispatchEvent(new Event('pagehide')));

--- a/frontend/cypress/e2e/characters/mobileLoading.cy.ts
+++ b/frontend/cypress/e2e/characters/mobileLoading.cy.ts
@@ -1,0 +1,132 @@
+/** Real content/cache startup under whole-browser latency, bandwidth and CPU constraints. */
+type LoadingFixture = { key: string; gm: { email: string; password: string } };
+
+describe('Mobile content loading', () => {
+  let fixture: LoadingFixture | undefined;
+  const protocol = (command: string, params: Record<string, unknown>) =>
+    cy.then(() => Cypress.automation('remote:debugger:protocol', { command, params }));
+
+  afterEach(() => {
+    protocol('Emulation.setCPUThrottlingRate', { rate: 1 });
+    protocol('Network.emulateNetworkConditions', {
+      offline: false,
+      latency: 0,
+      downloadThroughput: -1,
+      uploadThroughput: -1,
+    });
+    if (fixture) cy.task('campaignFixture:cleanup', fixture.key, { log: false });
+  });
+
+  it('loads with an empty account cache, then reopens from cache while freshness and catalog requests stall', () => {
+    cy.task<LoadingFixture>('campaignFixture:create', null, { log: false }).then((created) => {
+      fixture = created;
+      cy.viewport(390, 844);
+      protocol('Network.enable', {});
+      protocol('Network.clearBrowserCache', {});
+      protocol('Network.emulateNetworkConditions', {
+        offline: false,
+        latency: 150,
+        downloadThroughput: 192 * 1024,
+        uploadThroughput: 96 * 1024,
+      });
+      protocol('Emulation.setCPUThrottlingRate', { rate: 4 });
+      cy.intercept('POST', '**/auth/v1/token*').as('signIn');
+      cy.login(created.gm.email, created.gm.password);
+      cy.wait('@signIn').then(({ response }) => {
+        const token = response?.body.access_token;
+        const actor = response?.body.user.id;
+        const call = (endpoint: string, body: Record<string, unknown>) =>
+          cy
+            .request({
+              method: 'POST',
+              url: `${Cypress.env('functions_url')}/${endpoint}`,
+              headers: { Authorization: `Bearer ${token}` },
+              body,
+              log: false,
+            })
+            .then(({ body }) => {
+              expect(body.status).to.eq('success');
+              return body.data;
+            });
+        call('find-class', { id: 26 })
+          .then((playerClass) =>
+            call('create-character', {
+              name: 'Mobile Mage',
+              level: 1,
+              hp_current: 6,
+              details: { class: playerClass, conditions: [] },
+              inventory: { items: [] },
+              content_sources: { enabled: [1, 3] },
+              meta_data: { reset_hp: false },
+            })
+          )
+          .then((character) => {
+            let stallCatalog = false;
+            let catalogRequests = 0;
+            cy.intercept('POST', '**/functions/v1/find-*', (req) => {
+              if (req.url.endsWith('/find-character')) return;
+              catalogRequests += 1;
+              if (stallCatalog)
+                req.reply({ statusCode: 503, body: { status: 'error', message: 'Synthetic content outage' } });
+            });
+            cy.intercept('POST', '**/functions/v1/get-content-versions', (req) => {
+              if (stallCatalog) {
+                req.alias = 'slowFreshness';
+                req.reply({
+                  delay: 10000,
+                  statusCode: 503,
+                  body: { status: 'error', message: 'Synthetic freshness delay' },
+                });
+              }
+            });
+            cy.visit(`/sheet/${character.id}`);
+            cy.contains('Mobile Mage', { timeout: 60000 }).should('be.visible');
+            cy.contains('Hit Points', { timeout: 60000 }).should('be.visible');
+            cy.get('[data-testid="character-save-status"]').should('not.exist');
+            cy.contains('Changes not saved').should('not.exist');
+            cy.screenshot('mobile-cold-content-loaded');
+            // Wait for the actual IndexedDB transaction, not a guessed debounce sleep.
+            cy.window().then((win) => win.dispatchEvent(new Event('pagehide')));
+            const cached = (): Cypress.Chainable<unknown> =>
+              cy.window().then(
+                (win) =>
+                  new Cypress.Promise((resolve, reject) => {
+                    const open = win.indexedDB.open('wg-content-cache', 1);
+                    open.onerror = () => reject(open.error);
+                    open.onsuccess = () => {
+                      const db = open.result;
+                      const tx = db.transaction('kv', 'readonly');
+                      const read = tx.objectStore('kv').get(`content-store:${actor}`);
+                      read.onsuccess = () => resolve(read.result);
+                      read.onerror = () => reject(read.error);
+                      tx.oncomplete = () => db.close();
+                    };
+                  })
+              );
+            const waitForCache = (remaining = 40): Cypress.Chainable<unknown> =>
+              cached().then((snapshot: any) => {
+                if (snapshot?.contentStore?.size) return;
+                expect(remaining, 'content snapshot persisted').to.be.greaterThan(0);
+                return cy.wait(250, { log: false }).then(() => waitForCache(remaining - 1));
+              });
+            waitForCache();
+            cy.then(() => {
+              expect(catalogRequests).to.be.greaterThan(0);
+              stallCatalog = true;
+              catalogRequests = 0;
+            });
+            cy.reload();
+            cy.contains('Hit Points', { timeout: 20000 }).should('be.visible');
+            cy.contains('Mobile Mage').should('be.visible');
+            cy.then(() =>
+              expect(catalogRequests, 'no replacement catalog downloads on a slow freshness check').to.eq(0)
+            );
+            cy.get('@slowFreshness.all').should('have.length.at.least', 1);
+            cy.contains("Couldn't load game content").should('not.exist');
+            cy.contains('Changes not saved').should('not.exist');
+            cy.screenshot('mobile-cached-content-loaded');
+          });
+      });
+    });
+  });
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,7 @@
     "deploy": "gh-pages -d dist",
     "lint": "eslint src --ext ts,tsx --report-unused-disable-directives",
     "test:rules": "node --test scripts/feat-selection.test.mjs scripts/language-operations.test.mjs scripts/eidolon-runes.test.mjs scripts/item-drawers.test.mjs scripts/inventory-panel.test.mjs scripts/operation-removal.test.mjs scripts/skill-progression.test.mjs scripts/pf2e-stress-audit.mjs scripts/condition-compilation.test.mjs scripts/health-transitions.test.mjs scripts/modifier-math.test.mjs scripts/pf2e-matrix.test.mjs scripts/homebrew-operations.test.mjs",
-    "test:infra": "node --test scripts/operation-lifecycle.test.mjs scripts/session-recovery.test.mjs scripts/character-save-lifecycle.test.mjs scripts/encounter-character-writer.test.mjs scripts/content-cache.test.mjs scripts/content-selection.test.mjs scripts/browser-recovery.test.mjs scripts/character-health-merge.test.mjs",
+    "test:infra": "node --test scripts/operation-lifecycle.test.mjs scripts/session-recovery.test.mjs scripts/character-save-lifecycle.test.mjs scripts/encounter-character-writer.test.mjs scripts/content-cache.test.mjs scripts/content-selection.test.mjs scripts/browser-recovery.test.mjs scripts/character-health-merge.test.mjs scripts/operation-content-package.test.mjs",
     "preview": "vite preview",
     "start:local": "vite",
     "build:local": "tsc && vite build",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,7 +24,8 @@
     "cy:e2e:open": "CYPRESS_BASE_URL=http://localhost:3000 CYPRESS_TEST_EMAIL=test@wanderersguide.app CYPRESS_TEST_PASSWORD=test1234 cypress open",
     "validate:content": "esbuild scripts/validate-content.ts --bundle --platform=node --format=esm --target=node20 --outfile=scripts/.dist/validate.mjs && node scripts/.dist/validate.mjs",
     "audit:content": "esbuild scripts/audit-content.ts --bundle --platform=node --format=esm --target=node20 --outfile=scripts/.dist/audit.mjs && node scripts/.dist/audit.mjs",
-    "test:audit:content": "esbuild scripts/audit-content.ts --bundle --platform=node --format=esm --target=node20 --outfile=scripts/.dist/audit.mjs && node --test scripts/audit-content.test.mjs"
+    "test:audit:content": "esbuild scripts/audit-content.ts --bundle --platform=node --format=esm --target=node20 --outfile=scripts/.dist/audit.mjs && node --test scripts/audit-content.test.mjs",
+    "test:build": "node scripts/check-mobile-build.mjs"
   },
   "dependencies": {
     "@mantine/carousel": "^9.0.0",

--- a/frontend/scripts/character-save-lifecycle.test.mjs
+++ b/frontend/scripts/character-save-lifecycle.test.mjs
@@ -37,6 +37,7 @@ class HookHost {
     };
     this.character = null;
     this.session = { user: { id: 'owner' } };
+    this.sessionExpired = false;
     this.characterId = 1;
     this.options = { type: 'SIMPLE' };
     this.slots = [];
@@ -193,6 +194,7 @@ globalThis.__saveHooks = {
   },
   notify: (notice) => harness.notices.push(notice),
   hideNotice: (id) => harness.hiddenNotices.push(id),
+  hasSessionExpiredNotice: () => harness.sessionExpired,
   calculate: () => harness.calculate(),
   confirmHealth: (...args) => harness.confirmHealth(...args),
   saveCalculatedStats: (...args) => harness.saveCalculatedStats(...args),
@@ -215,8 +217,7 @@ const boundaries = {
     'export const {useDidUpdate} = globalThis.__saveHooks; export const useDebouncedValue = value => [globalThis.__saveHooks.debounce(value)]; export const useDebouncedCallback = globalThis.__saveHooks.debounceCallback;',
   '@tanstack/react-query': 'export const {useMutation,useQuery} = globalThis.__saveHooks;',
   '@constants/data': 'export const COMMON_CORE_ID = 3;',
-  '@requests/request-manager':
-    'export const {makeRequest} = globalThis.__saveHooks; export const hasSessionExpiredNotice = () => false;',
+  '@requests/request-manager': 'export const {makeRequest,hasSessionExpiredNotice} = globalThis.__saveHooks;',
   '@mantine/notifications':
     'export const showNotification = globalThis.__saveHooks.notify; export const hideNotification = globalThis.__saveHooks.hideNotice;',
   '@mantine/core': 'export const Button = "button"; export const Group = "group"; export const Text = "text";',
@@ -259,7 +260,7 @@ await build({
   define: { 'import.meta.env.PROD': 'false' },
   stdin: {
     contents:
-      "export {default} from './src/utils/use-character'; export * from './src/utils/character-save-buffer'; export * from './src/utils/character-merge'; export {confirmHealth as actualConfirmHealth} from './src/pages/character_sheet/entity-handler'; export {saveCalculatedStats as actualSaveCalculatedStats} from './src/process/variables/calculated-stats';",
+      "export {default} from './src/utils/use-character'; export * from './src/utils/character-save-buffer'; export * from './src/utils/character-merge'; export * from './src/request/request-rejection'; export {confirmHealth as actualConfirmHealth} from './src/pages/character_sheet/entity-handler'; export {saveCalculatedStats as actualSaveCalculatedStats} from './src/process/variables/calculated-stats';",
     resolveDir: root,
   },
   bundle: true,
@@ -291,6 +292,7 @@ const {
   mergeCharacterSave,
   actualConfirmHealth,
   actualSaveCalculatedStats,
+  RequestRejectedError,
 } = await import(pathToFileURL(join(directory, 'hook.mjs')).href);
 const row = (id = 1) => ({
   id,
@@ -703,7 +705,7 @@ test('choosing the saved version discards the matching conflict draft before nav
   harness.unmount();
 });
 
-test('a completed failed save retries through the editor when connectivity returns', async () => {
+test('a completed failed save retries quietly through the editor when connectivity returns', async () => {
   let online = false;
   harness.request = async (type, body) =>
     type === 'find-character' ? row() : online ? [{ ...row(), ...body, updated_at: 'version-2' }] : null;
@@ -712,18 +714,187 @@ test('a completed failed save retries through the editor when connectivity retur
   harness.edit({ name: 'Survives interruption' });
   await harness.flush();
   assert.equal(getBufferedCharacterSave(1, 'owner').draft.body.name, 'Survives interruption');
-  assert.equal(harness.notices.length, 1);
-  assert.equal(harness.notices[0].title, 'Changes not saved');
-  harness.hiddenNotices = [];
+  assert.equal(harness.notices.length, 0);
   online = true;
   events.get('online')?.();
   await harness.flush();
   assert.equal(harness.requests.filter((request) => request.type === 'update-character').length, 2);
   assert.equal(getBufferedCharacterSave(1, 'owner').status, 'none');
-  assert.equal(harness.notices.length, 1, 'successful retry must not add another toast');
-  assert.ok(harness.hiddenNotices.includes('character-save-failed'));
+  assert.equal(harness.notices.length, 0, 'recovery must not require or produce a toast');
   harness.unmount();
 });
+
+test('repeated failures recover with automatic backoff without a reconnect event or toast', async (t) => {
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+  let attempts = 0;
+  harness.request = async (type, body) => {
+    if (type === 'find-character') return row();
+    attempts += 1;
+    return attempts < 3 ? null : [{ ...row(), ...body, updated_at: 'version-2' }];
+  };
+  harness.render();
+  await harness.flush();
+  harness.edit({ name: 'Eventually saved quietly' });
+  await harness.flush();
+  assert.equal(attempts, 1);
+  t.mock.timers.tick(2000);
+  await harness.flush();
+  assert.equal(attempts, 2);
+  assert.equal(getBufferedCharacterSave(1, 'owner').draft.body.name, 'Eventually saved quietly');
+  assert.equal(harness.notices.length, 0);
+  t.mock.timers.tick(4000);
+  await harness.flush();
+  assert.equal(attempts, 3);
+  assert.equal(getBufferedCharacterSave(1, 'owner').status, 'none');
+  assert.equal(harness.value.saveState, 'saved');
+  assert.equal(harness.notices.length, 0);
+  harness.unmount();
+});
+
+test('session expiry keeps the draft and leaves notification and recovery to authentication', async (t) => {
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+  harness.request = async (type) => {
+    if (type === 'find-character') return row();
+    harness.sessionExpired = true;
+    return null;
+  };
+  harness.render();
+  await harness.flush();
+  harness.edit({ name: 'Sign in to finish saving' });
+  await harness.flush();
+  t.mock.timers.tick(30000);
+  events.get('online')?.();
+  await harness.flush();
+  assert.equal(harness.requests.filter(({ type }) => type === 'update-character').length, 1);
+  assert.equal(getBufferedCharacterSave(1, 'owner').draft.body.name, 'Sign in to finish saving');
+  assert.equal(harness.notices.length, 0, 'the request manager already owns the session-expiry notice');
+  harness.unmount();
+});
+
+test('a confirmed rejected snapshot remains local and paused until a changed edit can save', async (t) => {
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+  harness.request = async (type, body) => {
+    if (type === 'find-character') return row();
+    if (body.name === 'Rejected input') throw new RequestRejectedError(type);
+    return [{ ...row(), ...body, updated_at: 'version-2' }];
+  };
+  harness.render();
+  await harness.flush();
+  harness.edit({ name: 'Rejected input' });
+  await harness.flush();
+  assert.equal(harness.notices.length, 1);
+  assert.equal(harness.notices[0].title, 'Changes not saved');
+  assert.equal(getBufferedCharacterSave(1, 'owner').draft.body.name, 'Rejected input');
+  assert.equal(getBufferedCharacterSave(1, 'owner').draft.submission, undefined);
+  t.mock.timers.tick(60000);
+  events.get('online')?.();
+  events.get('focus')?.();
+  harness.value.retrySave();
+  await harness.flush();
+  assert.equal(harness.requests.filter(({ type }) => type === 'update-character').length, 1);
+  harness.edit({ name: 'Corrected input' });
+  await harness.flush();
+  assert.equal(harness.requests.filter(({ type }) => type === 'update-character').length, 2);
+  assert.equal(harness.value.saveState, 'saved');
+  assert.equal(getBufferedCharacterSave(1, 'owner').status, 'none');
+  assert.ok(harness.hiddenNotices.includes('character-save-rejected-1'));
+  harness.unmount();
+});
+
+test('a newer edit queued during a rejected request still reaches the server', async () => {
+  const rejection = deferred();
+  harness.request = async (type, body) => {
+    if (type === 'find-character') return row();
+    if (body.name === 'Rejected input') return rejection.promise;
+    return [{ ...row(), ...body, updated_at: 'version-2' }];
+  };
+  harness.render();
+  await harness.flush();
+  harness.edit({ name: 'Rejected input' });
+  await harness.flush();
+  harness.edit({ name: 'Already corrected while waiting' });
+  await harness.flush();
+  rejection.reject(new RequestRejectedError('update-character'));
+  await harness.flush();
+  assert.equal(harness.requests.filter(({ type }) => type === 'update-character').length, 2);
+  assert.equal(harness.character.name, 'Already corrected while waiting');
+  assert.equal(harness.value.saveState, 'saved');
+  assert.equal(getBufferedCharacterSave(1, 'owner').status, 'none');
+  assert.equal(harness.notices.length, 0, 'an already corrected rejection needs no stale warning');
+  harness.unmount();
+});
+
+for (const editor of ['owner', 'known-gm', 'public-viewer']) {
+  test(`forbidden writes stop retrying and notify only a known editor: ${editor}`, async () => {
+    harness.session = { user: { id: editor === 'owner' ? 'owner' : 'other' } };
+    let remote = row();
+    let revoked = editor !== 'known-gm';
+    harness.request = async (type, body) => {
+      if (type === 'find-character') return remote;
+      if (revoked) return { __forbidden: true };
+      remote = { ...remote, ...body, updated_at: 'version-2' };
+      return [remote];
+    };
+    harness.render();
+    await harness.flush();
+    if (editor === 'known-gm') {
+      harness.edit({ name: 'Earlier authorized edit' });
+      await harness.flush();
+      revoked = true;
+    }
+    harness.edit({ name: 'Rejected edit' });
+    await harness.flush();
+    assert.equal(harness.value.saveState, 'read-only');
+    assert.equal(harness.notices.length, editor === 'public-viewer' ? 0 : 1);
+    if (editor !== 'public-viewer') {
+      assert.equal(harness.notices[0].title, 'Changes not saved');
+      assert.match(harness.notices[0].message, /permission/);
+    }
+    assert.equal(getBufferedCharacterSave(1, harness.session.user.id).draft.body.name, 'Rejected edit');
+    const requests = harness.requests.length;
+    events.get('online')?.();
+    harness.value.retrySave();
+    await harness.flush();
+    assert.equal(harness.requests.length, requests);
+    harness.unmount();
+  });
+}
+
+for (const recovery of ['local storage', 'server acknowledgement']) {
+  test(`pending edits warn once when local storage fails, then clear after ${recovery}`, async () => {
+    const save = deferred();
+    harness.request = async (type) => (type === 'find-character' ? row() : save.promise);
+    harness.render();
+    await harness.flush();
+    const setItem = localStorage.setItem;
+    localStorage.setItem = () => {
+      throw new Error('Quota exceeded');
+    };
+    harness.edit({ name: 'Keep this pending edit' });
+    await harness.flush();
+    assert.equal(harness.value.draftStored, false);
+    assert.equal(harness.notices.length, 1);
+    assert.equal(harness.notices[0].message, 'Keep this page open until saving completes.');
+    harness.render();
+    await harness.flush();
+    assert.equal(harness.notices.length, 1, 'repeated storage failures must not produce repeated notices');
+    if (recovery === 'local storage') {
+      localStorage.setItem = setItem;
+      harness.render();
+      await harness.flush();
+      assert.equal(harness.value.draftStored, true);
+      assert.equal(getBufferedCharacterSave(1, 'owner').draft.body.name, 'Keep this pending edit');
+    } else {
+      save.resolve([{ ...row(), name: 'Keep this pending edit', updated_at: 'version-2' }]);
+      await harness.flush();
+      assert.equal(harness.value.saveState, 'saved');
+    }
+    assert.ok(harness.hiddenNotices.includes('character-save-storage-1'));
+    harness.unmount();
+    save.resolve([{ ...row(), name: 'Keep this pending edit', updated_at: 'version-2' }]);
+    await harness.flush();
+  });
+}
 
 test('an uncertain write preserves a later deliberate revert whether it committed or not', () => {
   const base = { ...row(), hp_current: 20 };

--- a/frontend/scripts/check-mobile-build.mjs
+++ b/frontend/scripts/check-mobile-build.mjs
@@ -1,0 +1,25 @@
+/** Guard the generated offline bundle against optional downloads returning to startup. */
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs';
+import { resolve, join } from 'node:path';
+const directory = resolve(process.argv[2] ?? 'dist');
+const worker = readFileSync(join(directory, 'sw.js'), 'utf8');
+const precached = [...worker.matchAll(/url:"([^"]+)"/g)].map((match) => match[1]);
+assert(precached.includes('index.html'), 'the app shell must remain available offline');
+assert(!existsSync(join(directory, 'stats.html')), 'developer reports must stay out of the shipped app');
+assert(!precached.some((url) => /stats\.html|game-icons-/.test(url)), 'optional reports/icons must not be precached');
+const icons = readdirSync(join(directory, 'assets')).filter((name) => /^game-icons-.*\.js$/.test(name));
+assert.equal(icons.length, 1, 'the existing icon set must remain an independent optional chunk');
+assert(worker.includes('wg-game-icons') && worker.includes('CacheFirst'), 'icons must be cached after use');
+console.log(
+  JSON.stringify(
+    {
+      precachedFiles: precached.length,
+      precachedUncompressedBytes: precached.reduce((total, url) => total + statSync(join(directory, url)).size, 0),
+      optionalIconBytes: statSync(join(directory, 'assets', icons[0])).size,
+      developerReportShipped: false,
+    },
+    null,
+    2
+  )
+);

--- a/frontend/scripts/content-cache.test.mjs
+++ b/frontend/scripts/content-cache.test.mjs
@@ -275,26 +275,108 @@ test('content packages and cache respect failures, sources, actors and generatio
         store.resetContentStore(false, true);
       }
     });
-    await t.test('a late source-version response cannot publish its timed-out snapshot', async () => {
+    const cachedSnapshot = (savedAt = Date.now()) => ({
+      version: 4,
+      actorId: state.actor,
+      savedAt,
+      idStore: new Map([
+        ['content-source', new Map([[81000, { id: 81000, updated_at: 'old-source-token' }]])],
+        ['language', new Map([[row.id, row]])],
+      ]),
+      contentStore: new Map(),
+    });
+
+    await t.test('a slow version check uses the recent snapshot without extending its age', async (t) => {
       const checking = deferred();
-      const snapshot = {
-        version: 4,
-        actorId: state.actor,
-        savedAt: Date.now(),
-        idStore: new Map([
-          ['content-source', new Map([[81000, { id: 81000, updated_at: 'old-source-token' }]])],
-          ['language', new Map([[row.id, row]])],
-        ]),
-        contentStore: new Map(),
-      };
+      const snapshot = cachedSnapshot(Date.now() - 20 * 60 * 60 * 1000);
       state.read = async () => snapshot;
       state.request = async (type) => (type === 'get-content-versions' ? checking.promise : []);
       store.resetContentStore(false);
       try {
-        assert.deepEqual(await store.fetchContent('language', { content_sources: [81000] }), []);
-        checking.resolve([{ id: 81000, updated_at: 'old-source-token' }]);
+        const before = state.requests.length;
+        assert.deepEqual(await store.fetchContent('language', query), [row]);
+        assert.deepEqual(
+          state.requests.slice(before).map(([type]) => type),
+          ['get-content-versions'],
+          'slow freshness must not trigger a replacement download'
+        );
+        checking.resolve([{ id: 81000, updated_at: 'new-source-token' }]);
         await new Promise((resolve) => setImmediate(resolve));
+        assert.deepEqual(
+          await store.fetchContent('language', query),
+          [row],
+          'a late verdict cannot change content underneath running calculations'
+        );
+
+        t.mock.timers.enable({ apis: ['setTimeout'] });
+        await store.fetchContent('language', { ...query, id: 81002 });
+        t.mock.timers.tick(10000);
+        await new Promise((resolve) => setImmediate(resolve));
+        assert.equal(
+          state.records.get(`content-store:${state.actor}`).savedAt,
+          snapshot.savedAt,
+          'persisting another lookup must not renew unverified cached content'
+        );
+      } finally {
+        checking.resolve(null);
+        t.mock.timers.reset();
+        state.read = async (key) => state.records.get(key);
+        store.resetContentStore(false, true);
+      }
+    });
+
+    await t.test('a prompt changed source token still rejects stale cached content', async () => {
+      state.read = async () => cachedSnapshot();
+      state.request = async (type) =>
+        type === 'get-content-versions' ? [{ id: 81000, updated_at: 'new-source-token' }] : [];
+      store.resetContentStore(false);
+      try {
+        assert.deepEqual(await store.fetchContent('language', query), []);
         assert.deepEqual(store.getCachedContent('language'), []);
+      } finally {
+        state.read = async (key) => state.records.get(key);
+        store.resetContentStore(false, true);
+      }
+    });
+
+    await t.test('an expired snapshot cannot be used during an outage', async () => {
+      state.read = async () => cachedSnapshot(Date.now() - 25 * 60 * 60 * 1000);
+      state.request = async () => [];
+      store.resetContentStore(false);
+      try {
+        const before = state.requests.length;
+        assert.deepEqual(await store.fetchContent('language', query), []);
+        assert.deepEqual(
+          state.requests.slice(before).map(([type]) => type),
+          ['find-language']
+        );
+      } finally {
+        state.read = async (key) => state.records.get(key);
+        store.resetContentStore(false, true);
+      }
+    });
+
+    await t.test('account changes retire a snapshot waiting for its version check', async () => {
+      const checking = deferred(),
+        started = deferred();
+      const snapshot = cachedSnapshot();
+      state.read = async () => snapshot;
+      state.request = async (type) => {
+        if (type === 'get-content-versions') {
+          started.resolve();
+          return checking.promise;
+        }
+        return [];
+      };
+      store.resetContentStore(false);
+      const pending = store.fetchContent('language', query);
+      const rejected = assert.rejects(pending, /Content changed/);
+      try {
+        await started.promise;
+        state.actor = 'D';
+        store.setContentCacheActor('D');
+        checking.resolve([{ id: 81000, updated_at: 'old-source-token' }]);
+        await rejected;
         assert.deepEqual(await store.fetchContent('language', query), []);
       } finally {
         checking.resolve(null);

--- a/frontend/scripts/content-cache.test.mjs
+++ b/frontend/scripts/content-cache.test.mjs
@@ -180,6 +180,105 @@ test('content packages and cache respect failures, sources, actors and generatio
       /content-source/,
       'failed source resolution cannot masquerade as an empty source set'
     );
+    const pageTrait = {
+      id: 81001,
+      name: 'Wizard School',
+      description: 'Fixture',
+      created_at: row.created_at,
+      meta_data: {},
+      content_source_id: 81000,
+    };
+    const infoTrait = { ...pageTrait, id: 81002, content_source_id: 81009 };
+    const prepareTraitLookup = (readLookup) => {
+      store.resetContentStore(true, true);
+      store.defineDefaultSources('PAGE', [81000]);
+      store.defineDefaultSources('INFO', [81009]);
+      state.request = async (type, body) => {
+        if (type === 'find-content-source') return body.id.map((id) => ({ id, name: `Fixture source ${id}` }));
+        if (type === 'find-trait') {
+          if (body.content_sources.includes(81009)) {
+            assert.deepEqual(body.content_sources, [3, 81000, 81009], 'lookup catalog keeps captured INFO+PAGE scope');
+            return readLookup();
+          }
+          return [pageTrait];
+        }
+        return [];
+      };
+    };
+    await t.test(
+      'trait lookup metadata uses the normal cache while PAGE candidates keep their source scope',
+      async () => {
+        prepareTraitLookup(async () => [infoTrait, pageTrait]);
+        const content = await store.fetchContentPackage([3, 81000]);
+        assert.deepEqual(content.traits, [pageTrait]);
+        assert.deepEqual(content.lookupTraits, [infoTrait, pageTrait]);
+        const before = state.requests.length;
+        const warm = await store.fetchContentPackage([3, 81000]);
+        assert.deepEqual(warm.lookupTraits, content.lookupTraits);
+        assert.equal(state.requests.length, before, 'a warm package does not download lookup metadata again');
+      }
+    );
+    await t.test('unavailable optional trait lookup metadata does not fail otherwise complete content', async () => {
+      prepareTraitLookup(async () => null);
+      const content = await store.fetchContentPackage([3, 81000]);
+      assert.deepEqual(content.traits, [pageTrait]);
+      assert.equal(content.lookupTraits, undefined);
+    });
+    await t.test(
+      'slow optional metadata has a bounded wait and cannot change an already returned packet',
+      async (t) => {
+        const lookup = deferred(),
+          started = deferred();
+        prepareTraitLookup(() => {
+          started.resolve();
+          return lookup.promise;
+        });
+        t.mock.timers.enable({ apis: ['setTimeout'] });
+        const pending = store.fetchContentPackage([3, 81000]);
+        try {
+          await started.promise;
+          await new Promise((resolve) => setImmediate(resolve));
+          t.mock.timers.tick(750);
+          const content = await pending;
+          assert.deepEqual(content.traits, [pageTrait]);
+          assert.equal(
+            content.lookupTraits,
+            undefined,
+            'required content returns without waiting for the network timeout'
+          );
+          lookup.resolve([infoTrait, pageTrait]);
+          await new Promise((resolve) => setImmediate(resolve));
+          assert.equal(content.lookupTraits, undefined, 'late data cannot enter a running calculation');
+          assert.deepEqual(content.traits, [pageTrait]);
+        } finally {
+          lookup.resolve([]);
+          await pending;
+          t.mock.timers.reset();
+          store.resetContentStore(true, true);
+        }
+      }
+    );
+    await t.test('an account change retires both a pending package and its optional trait catalog', async () => {
+      const lookup = deferred(),
+        started = deferred();
+      prepareTraitLookup(() => {
+        started.resolve();
+        return lookup.promise;
+      });
+      const pending = store.fetchContentPackage([3, 81000]);
+      const rejected = assert.rejects(pending, /Content changed/);
+      try {
+        await started.promise;
+        state.actor = 'trait-next-actor';
+        store.setContentCacheActor(state.actor);
+        lookup.resolve([infoTrait, pageTrait]);
+        await rejected;
+        assert.deepEqual(store.getCachedContent('trait'), [], 'old actor metadata never populates the new cache');
+      } finally {
+        lookup.resolve([]);
+        store.resetContentStore(true, true);
+      }
+    });
     await t.test('a stalled optional cache deletion cannot block fresh homebrew content', async () => {
       const deleting = deferred();
       state.delete = () => deleting.promise;

--- a/frontend/scripts/encounter-character-writer.test.mjs
+++ b/frontend/scripts/encounter-character-writer.test.mjs
@@ -12,7 +12,7 @@ const folder = mkdtempSync(join(tmpdir(), 'wg-encounter-save-'));
 after(() => rmSync(folder, { recursive: true, force: true }));
 await build({
   stdin: {
-    contents: `export * from './src/utils/encounter-character-writer'; export * from './src/utils/character-version';`,
+    contents: `export * from './src/utils/encounter-character-writer'; export * from './src/utils/character-version'; export * from './src/request/request-rejection';`,
     resolveDir: root,
   },
   absWorkingDir: root,
@@ -21,7 +21,9 @@ await build({
   format: 'esm',
   outfile: `${folder}/writer.mjs`,
 });
-const { createEncounterCharacterWriter, compareCharacterVersions } = await import(`${folder}/writer.mjs`);
+const { createEncounterCharacterWriter, compareCharacterVersions, RequestRejectedError } = await import(
+  `${folder}/writer.mjs`
+);
 const storage = new Map();
 globalThis.localStorage = {
   getItem: (key) => storage.get(key) ?? null,
@@ -257,6 +259,48 @@ test('forbidden and empty results never claim the change was saved', async (t) =
     assert.equal(storage.size, 1);
     state.writer.dispose();
   }
+});
+
+test('confirmed encounter rejection retains its draft and only a changed edit retries it', async (t) => {
+  const state = setup(t, row(), (request) => {
+    if (request.type === 'find-character') return structuredClone(request.server);
+    if (request.body.hp_current === 15) throw new RequestRejectedError(request.type);
+    return request.commit(request.body);
+  });
+  state.writer.update(row(), { ...row(), hp_current: 15 });
+  await until(() => state.writer.status(1)?.phase === 'rejected');
+  assert.equal(JSON.parse([...storage.values()][0]).body.hp_current, 15);
+  assert.equal(JSON.parse([...storage.values()][0]).submission, undefined);
+  state.writer.retry();
+  state.writer.activate();
+  assert.equal(state.requests.filter(({ type }) => type === 'update-character').length, 1);
+  const current = state.writer.display(row());
+  state.writer.update(current, { ...current, hp_current: 16 });
+  await until(() => state.writer.status(1)?.phase === 'saved');
+  assert.equal(state.server.hp_current, 16);
+  assert.equal(state.requests.filter(({ type }) => type === 'update-character').length, 2);
+  assert.equal(storage.size, 0);
+});
+
+test('a corrected encounter edit queued during rejection still saves automatically', async (t) => {
+  const pending = deferred();
+  const state = setup(t, row(), async (request) => {
+    if (request.type === 'find-character') return structuredClone(request.server);
+    if (request.body.hp_current === 15) {
+      await pending.promise;
+      throw new RequestRejectedError(request.type);
+    }
+    return request.commit(request.body);
+  });
+  state.writer.update(row(), { ...row(), hp_current: 15 });
+  await until(() => state.requests.filter(({ type }) => type === 'update-character').length === 1);
+  const current = state.writer.display(row());
+  state.writer.update(current, { ...current, hp_current: 16 });
+  pending.resolve();
+  await until(() => state.writer.status(1)?.phase === 'saved');
+  assert.equal(state.server.hp_current, 16);
+  assert.equal(state.requests.filter(({ type }) => type === 'update-character').length, 2);
+  assert.equal(storage.size, 0);
 });
 
 test('acknowledged overlay prevents stale polling from reverting HP, then follows newer reads', async (t) => {

--- a/frontend/scripts/operation-content-package.test.mjs
+++ b/frontend/scripts/operation-content-package.test.mjs
@@ -5,6 +5,7 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { build } from 'esbuild';
+import { readContentRows } from './operation-test-harness.mjs';
 
 const directory = await mkdtemp(join(tmpdir(), 'wg-worker-package-'));
 const root = resolve(import.meta.dirname, '..');
@@ -348,4 +349,91 @@ test('the dedicated worker override cannot hijack a main-thread direct calculati
   } finally {
     delete globalThis.document;
   }
+});
+
+test('implicit trait lookups preserve the complete INFO catalog and first matching ID without expanding PAGE', async () => {
+  const content = packet();
+  const pageTrait = { id: 30, name: 'Wizard School', content_source_id: 1 };
+  const infoTrait = { id: 10, name: 'Wizard School', content_source_id: 9 };
+  const privateTrait = { id: 20, name: 'Wizard School', content_source_id: 8 };
+  content.traits = [pageTrait];
+  content.lookupTraits = [pageTrait, privateTrait, infoTrait, { id: 40, name: 'School_1', content_source_id: 9 }];
+  await api.withWorkerContentPackage(content, async () => {
+    assert.deepEqual(await api.fetchContent('trait', { name: '  WIZARD school  ' }), [infoTrait]);
+    assert.deepEqual(await api.fetchContent('trait', { name: 'Wizard %' }), [infoTrait]);
+    assert.deepEqual(await api.fetchContent('trait', { id: [30, 10] }), [infoTrait, pageTrait]);
+    assert.deepEqual(await api.fetchContent('trait', { id: 30, name: 'ignored by API' }), [pageTrait]);
+    assert.equal((await api.fetchContent('trait', { name: 'School\\_1' }))[0].id, 40);
+    assert.deepEqual(await api.fetchContent('trait', { name: 'Missing trait' }), []);
+    assert.deepEqual(await api.fetchContent('trait', { name: '' }), [infoTrait]);
+    assert.deepEqual(await api.fetchContent('trait', { name: '   ' }), []);
+    assert.deepEqual(await api.fetchContent('trait', { content_sources: [1, 3] }), [pageTrait]);
+    assert.deepEqual(api.getCachedContent('trait'), [pageTrait]);
+    assert.equal(networkCalls, 0);
+  });
+  assert.equal(api.getWorkerContentReader(), undefined);
+  assert.deepEqual(api.getCachedContent('trait'), [], 'lookup metadata is not retained between actors or jobs');
+});
+
+test('older packets without trait metadata retain the original implicit lookup fallback', async () => {
+  allowCrossBookLookup();
+  const request = globalThis.__workerPackageTest.request;
+  globalThis.__workerPackageTest.request = async (type, body) => {
+    if (type !== 'find-trait') return request(type, body);
+    networkCalls += 1;
+    assert.ok(body.content_sources.includes(9));
+    return { id: 10, name: 'Wizard School', content_source_id: 9 };
+  };
+  await api.withWorkerContentPackage(packet(), async () => {
+    assert.equal((await api.fetchContent('trait', { name: 'Wizard School' }))[0].id, 10);
+  });
+  assert.ok(networkCalls > 0);
+  assert.equal(api.getWorkerContentReader(), undefined);
+});
+
+test('a real core Wizard resolves its complete selection catalog without another network request', async () => {
+  const tables = {
+    ability_block: 'abilityBlocks',
+    ancestry: 'ancestries',
+    archetype: 'archetypes',
+    background: 'backgrounds',
+    class: 'classes',
+    class_archetype: 'classArchetypes',
+    creature: 'creatures',
+    item: 'items',
+    language: 'languages',
+    spell: 'spells',
+    trait: 'traits',
+    versatile_heritage: 'versatileHeritages',
+  };
+  const rows = await readContentRows([
+    ...Object.keys(tables)
+      .filter((table) => table !== 'creature')
+      .map((table) => ({ table, sourceIds: [1, 3] })),
+    { table: 'content_source', id: 1 },
+    { table: 'content_source', id: 3 },
+  ]);
+  const content = {
+    ...Object.fromEntries(
+      Object.entries(tables).map(([table, field]) => [
+        field,
+        rows.filter((entry) => entry.table === table).map((entry) => entry.row),
+      ])
+    ),
+    sources: rows.filter((entry) => entry.table === 'content_source').map((entry) => entry.row),
+    lookupTraits: rows.filter((entry) => entry.table === 'trait').map((entry) => entry.row),
+    defaultSources: { PAGE: [1, 3], INFO: [1, 3] },
+  };
+  const wizard = {
+    ...character(),
+    custom_operations: [],
+    details: { class: content.classes.find((row) => row.id === 26) },
+  };
+  assert.equal(wizard.details.class?.name, 'Wizard');
+  await self.onmessage({
+    data: { id: 1, execution: { type: 'CHARACTER', data: { character: wizard, content, context: 'CHARACTER-SHEET' } } },
+  });
+  const result = messages.pop();
+  assert.equal(result.status, 'success', result.message);
+  assert.equal(networkCalls, 0, JSON.stringify(requests));
 });

--- a/frontend/scripts/operation-content-package.test.mjs
+++ b/frontend/scripts/operation-content-package.test.mjs
@@ -1,0 +1,351 @@
+/** Exercise the actual worker, controller and content-store seam with every network boundary unavailable. */
+import assert from 'node:assert/strict';
+import { after, beforeEach, test } from 'node:test';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { build } from 'esbuild';
+
+const directory = await mkdtemp(join(tmpdir(), 'wg-worker-package-'));
+const root = resolve(import.meta.dirname, '..');
+const messages = [];
+let networkCalls = 0;
+const requests = [];
+const originalSelf = globalThis.self;
+const originalFetch = globalThis.fetch;
+const originalLog = console.log;
+globalThis.self = { postMessage: (message) => messages.push(message) };
+globalThis.__workerPackageTest = {
+  unavailable: async () => {
+    networkCalls += 1;
+    throw new Error('Network is unavailable');
+  },
+};
+globalThis.__workerPackageTest.request = (...args) => globalThis.__workerPackageTest.unavailable(...args);
+globalThis.__workerPackageTest.session = () => globalThis.__workerPackageTest.unavailable();
+globalThis.__workerPackageTest.user = () => globalThis.__workerPackageTest.unavailable();
+globalThis.fetch = globalThis.__workerPackageTest.unavailable;
+console.log = () => {};
+after(async () => {
+  globalThis.self = originalSelf;
+  globalThis.fetch = originalFetch;
+  console.log = originalLog;
+  delete globalThis.__workerPackageTest;
+  await rm(directory, { recursive: true, force: true });
+});
+const boundaries = {
+  '@requests/request-manager':
+    'export const makeRequest = (...args) => globalThis.__workerPackageTest.request(...args);',
+  '@auth/user-manager':
+    'export const getPublicUser = () => globalThis.__workerPackageTest.user(); export const getCachedPublicUser = () => null;',
+  '@utils/client-errors': 'export const reportClientFailure = () => {};',
+  '@utils/notifications': 'export const displayError = () => {};',
+};
+await build({
+  absWorkingDir: root,
+  stdin: {
+    contents: `import './src/process/operations/operations.worker'; export * from './src/process/operations/operation-content-package'; export {fetchContent, getCachedContent} from './src/process/content/content-store';`,
+    resolveDir: root,
+  },
+  outfile: join(directory, 'worker.mjs'),
+  platform: 'node',
+  format: 'esm',
+  bundle: true,
+  define: { 'import.meta.env': JSON.stringify({ VITE_ENV: 'production' }) },
+  plugins: [
+    {
+      name: 'network-boundaries',
+      setup(builder) {
+        builder.onResolve({ filter: /.*/ }, ({ path }) =>
+          path in boundaries || path.endsWith('/supabase-client') ? { path, namespace: 'boundary' } : undefined
+        );
+        builder.onLoad({ filter: /.*/, namespace: 'boundary' }, ({ path }) => ({
+          loader: 'js',
+          contents: path.endsWith('/supabase-client')
+            ? 'export const supabase = {auth:{getSession:() => globalThis.__workerPackageTest.session()}};'
+            : boundaries[path],
+        }));
+      },
+    },
+  ],
+});
+const api = await import(join(directory, 'worker.mjs'));
+beforeEach(() => {
+  messages.length = 0;
+  networkCalls = 0;
+  requests.length = 0;
+  globalThis.__workerPackageTest.request = (...args) => globalThis.__workerPackageTest.unavailable(...args);
+  globalThis.__workerPackageTest.session = () => globalThis.__workerPackageTest.unavailable();
+  globalThis.__workerPackageTest.user = () => globalThis.__workerPackageTest.unavailable();
+});
+
+const operation = (id, type, data) => ({ id, type, data });
+const source = (id, user_id = null, is_published = true) => ({
+  id,
+  name: `Source ${id}`,
+  user_id,
+  is_published,
+  operations: [],
+});
+const packet = (languageName = 'Auran', sourceId = 1) => ({
+  defaultSources: { PAGE: [sourceId], INFO: 'ALL-USER-ACCESSIBLE' },
+  ancestries: [],
+  backgrounds: [],
+  classes: [],
+  archetypes: [],
+  versatileHeritages: [],
+  classArchetypes: [],
+  items: [],
+  spells: [],
+  traits: [],
+  creatures: [],
+  sources: [
+    source(sourceId, sourceId === 8 ? 'different-actor' : null, sourceId !== 8),
+    source(2, 'another-user', false),
+  ],
+  languages: [
+    { id: 101, name: languageName, content_source_id: sourceId },
+    { id: 102, name: 'Disabled language', content_source_id: 2 },
+  ],
+  abilityBlocks: [
+    {
+      id: 700,
+      name: 'Language Feat',
+      type: 'feat',
+      content_source_id: sourceId,
+      traits: [11],
+      prerequisites: ['Trained'],
+      operations: [operation('grant-language', 'giveLanguage', { languageId: 101 })],
+    },
+  ],
+});
+const character = () => ({
+  id: 1,
+  level: 1,
+  name: 'Offline calculation',
+  details: {},
+  content_sources: { enabled: [1] },
+  inventory: { coins: { cp: 0, sp: 0, gp: 0, pp: 0 }, items: [] },
+  operation_data: {},
+  meta_data: {},
+  variants: {},
+  companions: { list: [] },
+  options: { custom_operations: true },
+  custom_operations: [operation('select-feat', 'giveAbilityBlock', { type: 'feat', abilityBlockId: 700 })],
+});
+const run = async (content, id = 1) => {
+  await self.onmessage({
+    data: {
+      id,
+      execution: { type: 'CHARACTER', data: { character: character(), content, context: 'CHARACTER-SHEET' } },
+    },
+  });
+  assert.equal(messages.length, 1);
+  return messages.pop();
+};
+
+test('actual worker calculates grants from its posted package with all network calls unavailable', async () => {
+  const response = await run(packet());
+  assert.equal(response.status, 'success', response.message);
+  assert.deepEqual(response.data.store.variables.LANGUAGE_IDS.value, ['101']);
+  assert.deepEqual(response.data.store.variables.LANGUAGE_NAMES.value, ['AURAN']);
+  assert.equal(networkCalls, 0);
+  assert.equal(api.getWorkerContentReader(), undefined);
+  assert.deepEqual(api.getCachedContent('language'), [], 'the job package never seeds the ordinary cache');
+});
+
+test('next worker job sees only its own package, including reused IDs from another source or actor', async () => {
+  assert.equal((await run(packet())).status, 'success');
+  const response = await run(packet('Different private language', 8), 2);
+  assert.equal(response.status, 'success', response.message);
+  assert.deepEqual(response.data.store.variables.LANGUAGE_NAMES.value, ['DIFFERENT PRIVATE LANGUAGE']);
+  const returned = await run(packet(), 3);
+  assert.deepEqual(returned.data.store.variables.LANGUAGE_NAMES.value, ['AURAN']);
+  assert.equal(networkCalls, 0);
+  assert.deepEqual(api.getCachedContent('language'), []);
+});
+
+test('missing required tables fail and the next complete worker job still calculates', async () => {
+  const incomplete = packet();
+  delete incomplete.languages;
+  const failed = await run(incomplete);
+  assert.equal(failed.status, 'error');
+  assert.match(failed.message, /missing language content/);
+  assert.equal(api.getWorkerContentReader(), undefined);
+  assert.equal((await run(packet(), 2)).status, 'success');
+  assert.equal(networkCalls, 0);
+});
+
+test('controller failures release the package without keeping a partial worker context', async () => {
+  await self.onmessage({
+    data: {
+      id: 1,
+      execution: {
+        type: 'CHARACTER',
+        data: {
+          character: null,
+          content: packet(),
+          context: 'CHARACTER-SHEET',
+        },
+      },
+    },
+  });
+  assert.equal(messages.pop().status, 'error');
+  assert.equal(api.getWorkerContentReader(), undefined);
+  assert.equal((await run(packet())).status, 'success');
+  assert.equal(networkCalls, 0);
+});
+
+test('creature jobs use their posted content and parent store without another network request', async () => {
+  const parent = await run(packet());
+  await self.onmessage({
+    data: {
+      id: 2,
+      charStore: parent.data.store,
+      execution: {
+        type: 'CREATURE',
+        data: {
+          id: 'creature-offline',
+          content: packet(),
+          creature: {
+            name: 'Offline companion',
+            level: 3,
+            abilities_base: [],
+            abilities_added: [],
+            inventory: { coins: { cp: 0, sp: 0, gp: 0, pp: 0 }, items: [] },
+            operations: [operation('companion-language', 'giveLanguage', { languageId: 101 })],
+          },
+        },
+      },
+    },
+  });
+  const response = messages.pop();
+  assert.equal(response.status, 'success', response.message);
+  assert.deepEqual(response.data.store.variables.LANGUAGE_IDS.value, ['101']);
+  assert.equal(response.data.store.variables.LEVEL.value, 3);
+  assert.equal(parent.data.store.variables.LEVEL.value, 1);
+  assert.equal(networkCalls, 0);
+  assert.equal(api.getWorkerContentReader(), undefined);
+});
+
+test('package lookup preserves explicit ID, names, subtype, array and source filtering', () => {
+  const reader = api.createOperationContentReader(packet());
+  assert.equal(reader.fetch('ability-block', { id: 700 })[0].name, 'Language Feat');
+  assert.equal(
+    reader.fetch('ability-block', { name: 'language feat', type: 'feat', traits: [11], prerequisites: ['Trained'] })
+      .length,
+    1
+  );
+  assert.equal(reader.fetch('ability-block', { name: '%FEAT', type: 'action' }).length, 0);
+  assert.equal(reader.fetch('ability-block', { name: 'Language _eat' }).length, 1);
+  assert.equal(reader.fetch('language', { id: [101, 102] }).length, 1);
+  assert.deepEqual(reader.fetch('language', { content_sources: [] }), []);
+  assert.deepEqual(reader.fetch('language', { content_sources: [2] }), []);
+  assert.equal(reader.fetch('language', { content_sources: 'ALL-USER-ACCESSIBLE' }).length, 1);
+  assert.deepEqual(
+    reader.sources('ALL-USER-ACCESSIBLE').map((row) => row.id),
+    [1]
+  );
+  assert.deepEqual(reader.cached('feat'), [], 'prose lookups still fall back to ability-block');
+});
+
+test('packages without optional source metadata can calculate but cannot pretend to resolve source metadata', async () => {
+  const withoutSources = packet();
+  delete withoutSources.sources;
+  assert.equal((await run(withoutSources)).status, 'success');
+  const reader = api.createOperationContentReader(withoutSources);
+  assert.deepEqual(reader.cached('content-source'), []);
+  assert.deepEqual(reader.fetch('content-source', { id: 1 }), [], 'an identity miss can use the original lookup');
+  assert.throws(() => reader.sources('ALL-USER-ACCESSIBLE'), /missing content-source content/);
+});
+
+/** Controlled old request boundary, including the INFO book catalog outside the PAGE package. */
+function allowCrossBookLookup(languageResult = { id: 101, name: 'Cross-book language', content_source_id: 9 }) {
+  globalThis.__workerPackageTest.session = async () => ({ data: { session: null } });
+  globalThis.__workerPackageTest.user = async () => null;
+  globalThis.__workerPackageTest.request = async (type, body) => {
+    networkCalls += 1;
+    requests.push({ type, body });
+    if (type === 'find-content-source') {
+      const all = [source(1), source(3), source(9)];
+      return Array.isArray(body.id) ? all.filter((row) => body.id.includes(row.id)) : all;
+    }
+    assert.equal(type, 'find-language');
+    assert.ok(body.content_sources.includes(9), 'original INFO+PAGE scope includes the referenced book');
+    if (languageResult instanceof Error) throw languageResult;
+    return languageResult;
+  };
+}
+
+test('explicit missing cross-book grants preserve original scope without storing fallback rows', async () => {
+  allowCrossBookLookup();
+  const content = packet();
+  content.languages = [];
+  const response = await run(content);
+  assert.equal(response.status, 'success', response.message);
+  assert.deepEqual(response.data.store.variables.LANGUAGE_NAMES.value, ['CROSS-BOOK LANGUAGE']);
+  assert.ok(networkCalls > 0);
+  assert.equal(api.getWorkerContentReader(), undefined);
+  assert.deepEqual(api.getCachedContent('language'), []);
+  assert.deepEqual(api.getCachedContent('content-source'), []);
+});
+
+test('unavailable cross-book references fail the worker instead of silently dropping a grant', async () => {
+  allowCrossBookLookup(new Error('Required reference unavailable'));
+  const content = packet();
+  content.languages = [];
+  const failed = await run(content);
+  assert.equal(failed.status, 'error');
+  assert.match(failed.message, /Required reference unavailable/);
+  assert.equal(api.getWorkerContentReader(), undefined);
+  assert.deepEqual(api.getCachedContent('language'), []);
+  const previousCalls = networkCalls;
+  assert.equal((await run(packet(), 2)).status, 'success');
+  assert.equal(networkCalls, previousCalls);
+});
+
+test('confirmed absent removed references retain the existing successful not-found behavior', async () => {
+  allowCrossBookLookup(null);
+  const content = packet();
+  content.languages = [];
+  const response = await run(content);
+  assert.equal(response.status, 'success', response.message);
+  assert.deepEqual(response.data.store.variables.LANGUAGE_IDS.value, []);
+  assert.equal(api.getWorkerContentReader(), undefined);
+});
+
+test('implicit INFO name queries keep all server matches while explicit PAGE lists stay package-bound', async () => {
+  allowCrossBookLookup([
+    { id: 101, name: 'Auran', content_source_id: 1 },
+    { id: 201, name: 'Auran', content_source_id: 9 },
+  ]);
+  await api.withWorkerContentPackage(packet(), async () => {
+    const names = await api.fetchContent('language', { name: 'Auran' });
+    assert.deepEqual(
+      names.map((row) => row.id),
+      [101, 201]
+    );
+    const previousCalls = networkCalls;
+    const page = await api.fetchContent('language', { content_sources: [1, 3] });
+    assert.deepEqual(
+      page.map((row) => row.id),
+      [101]
+    );
+    assert.equal(networkCalls, previousCalls);
+  });
+  assert.equal(api.getWorkerContentReader(), undefined);
+  assert.deepEqual(api.getCachedContent('language'), []);
+});
+
+test('the dedicated worker override cannot hijack a main-thread direct calculation or UI fetch', async () => {
+  globalThis.document = {};
+  try {
+    await assert.rejects(
+      api.withWorkerContentPackage(packet(), async () => {}),
+      /restricted to workers/
+    );
+    assert.equal(api.getWorkerContentReader(), undefined);
+  } finally {
+    delete globalThis.document;
+  }
+});

--- a/frontend/scripts/session-recovery.test.mjs
+++ b/frontend/scripts/session-recovery.test.mjs
@@ -73,7 +73,7 @@ await build({
     'import.meta.env.PROD': 'false',
   },
   stdin: {
-    contents: `export * from './src/request/request-manager'; export * from './src/utils/character-save-buffer';`,
+    contents: `export * from './src/request/request-manager'; export * from './src/request/request-rejection'; export * from './src/utils/character-save-buffer';`,
     resolveDir: root,
   },
   outfile: join(directory, 'session.mjs'),
@@ -207,6 +207,47 @@ test('permission, API-key, and application failures never trigger auth retries',
     assert.equal(calls.length, 1);
     assert.equal(refreshes, 0);
     assert.equal(notices, 0);
+  }
+});
+
+test('character writes can distinguish confirmed input rejection without changing default callers', async () => {
+  for (const response of [
+    http(400, { message: 'Invalid input' }),
+    http(413, { message: 'Payload too large' }),
+    http(422, { message: 'Invalid character value' }),
+    { data: { status: 'fail', data: { name: 'Invalid input' } }, error: null },
+  ]) {
+    calls = [];
+    invoke = async () => response;
+    await assert.rejects(
+      api.makeRequest('update-character', { id: 1 }, false, { throwOnRejection: true }),
+      api.RequestRejectedError
+    );
+    assert.equal(calls.length, 1);
+    assert.equal(refreshes, 0);
+    assert.equal(notices, 0);
+    assert.equal(await api.makeRequest('update-character', { id: 1 }, false), null);
+  }
+});
+
+test('rejection-aware writes preserve JWT recovery and never classify ambiguous failures as rejected', async () => {
+  invoke = async () => (calls.length === 1 ? expired() : ok());
+  assert.deepEqual(await api.makeRequest('update-character', { id: 1 }, false, { throwOnRejection: true }), [
+    { id: 1 },
+  ]);
+  assert.equal(refreshes, 1);
+  for (const response of [
+    http(429, { status: 'fail', data: { message: 'Rate limited' } }),
+    http(500, { message: 'Server failure' }),
+    http(503, { message: 'Unavailable' }),
+    { data: null, error: new FunctionsFetchError('Offline') },
+    { data: null, error: new Error('Timeout') },
+    { data: { status: 'error', message: 'Unavailable' }, error: null },
+  ]) {
+    calls = [];
+    invoke = async () => response;
+    assert.equal(await api.makeRequest('update-character', { id: 1 }, false, { throwOnRejection: true }), null);
+    assert.equal(calls.length, 1);
   }
 });
 

--- a/frontend/src/common/Icon.tsx
+++ b/frontend/src/common/Icon.tsx
@@ -142,28 +142,22 @@ const gameIconSubscribers = new Set<() => void>();
 /** Load + cache the game-icon set once. Notifies mounted <GameIcon>s when it resolves. */
 export function loadGameIcons(): Promise<Record<string, IconType>> {
   if (gameIconsCache) return Promise.resolve(gameIconsCache);
-  gameIconsPromise ??= import('react-icons/gi').then((mod) => {
-    const map: Record<string, IconType> = {};
-    for (const [rawName, Component] of Object.entries(mod)) {
-      // Strip the leading 'Gi' and lowercase, matching the previous naming.
-      map[rawName.slice(2).toLowerCase()] = Component as IconType;
-    }
-    gameIconsCache = map;
-    gameIconSubscribers.forEach((cb) => cb());
-    return map;
-  });
+  gameIconsPromise ??= import('react-icons/gi')
+    .then((mod) => {
+      const map: Record<string, IconType> = {};
+      for (const [rawName, Component] of Object.entries(mod)) {
+        // Strip the leading 'Gi' and lowercase, matching the previous naming.
+        map[rawName.slice(2).toLowerCase()] = Component as IconType;
+      }
+      gameIconsCache = map;
+      gameIconSubscribers.forEach((cb) => cb());
+      return map;
+    })
+    .catch((error: unknown) => {
+      gameIconsPromise = null;
+      throw error;
+    });
   return gameIconsPromise;
-}
-
-// Preload during idle time so game icons in content are usually ready before they render,
-// without blocking the initial critical path (the reason for splitting them out).
-if (typeof window !== 'undefined') {
-  const w = window as unknown as {
-    requestIdleCallback?: (cb: () => void, opts?: { timeout: number }) => void;
-  };
-  const preload = () => void loadGameIcons();
-  if (typeof w.requestIdleCallback === 'function') w.requestIdleCallback(preload, { timeout: 3000 });
-  else setTimeout(preload, 2000);
 }
 
 // Tabler Icons
@@ -315,12 +309,16 @@ function GameIcon({ name, ...restProps }: IconProps) {
   const [, rerender] = useReducer((n: number) => n + 1, 0);
 
   useEffect(() => {
-    if (gameIconsCache) return; // already available — no need to subscribe
+    if (gameIconsCache) return;
     const onLoaded = () => rerender();
     gameIconSubscribers.add(onLoaded);
-    void loadGameIcons();
+    const load = () =>
+      void loadGameIcons().catch(() => console.warn('Could not load game icons; retrying on reconnect.'));
+    load();
+    window.addEventListener('online', load);
     return () => {
       gameIconSubscribers.delete(onLoaded);
+      window.removeEventListener('online', load);
     };
   }, []);
 

--- a/frontend/src/drawers/types/CreatureDrawer.tsx
+++ b/frontend/src/drawers/types/CreatureDrawer.tsx
@@ -448,6 +448,7 @@ export function CreatureDrawerContent(props: {
 
                 {activeTab === 'spells' && (
                   <SpellsPanel
+                    content={content}
                     panelHeight={panelHeight}
                     panelWidth={panelWidth}
                     id={STORE_ID}

--- a/frontend/src/modals/SelectIconModal.tsx
+++ b/frontend/src/modals/SelectIconModal.tsx
@@ -51,11 +51,17 @@ export function SelectIconModalContents(props: {
   const [allIconNames, setAllIconNames] = useState<string[] | null>(null);
   useEffect(() => {
     let active = true;
-    getAllIconsAsync().then((names) => {
-      if (active) setAllIconNames(names);
-    });
+    const load = () =>
+      void getAllIconsAsync()
+        .then((names) => {
+          if (active) setAllIconNames(names);
+        })
+        .catch(() => console.warn('Could not load the icon picker; retrying on reconnect.'));
+    load();
+    window.addEventListener('online', load);
     return () => {
       active = false;
+      window.removeEventListener('online', load);
     };
   }, []);
 

--- a/frontend/src/pages/campaign/CampaignOverviewPage.tsx
+++ b/frontend/src/pages/campaign/CampaignOverviewPage.tsx
@@ -403,25 +403,35 @@ function SectionPanels(props: {
       session?.user.id && props.campaign?.id
         ? createEncounterCharacterWriter({
             actorId: session.user.id,
-            request: (type, body) => makeRequest(type, body, false, { expectedActorId: session.user.id }),
+            request: (type, body) =>
+              makeRequest(type, body, false, {
+                expectedActorId: session.user.id,
+                throwOnRejection: type === 'update-character',
+              }),
             changed: () => refreshCharacterSaves((value) => value + 1),
           })
         : undefined,
     [session?.user.id, props.campaign?.id]
   );
-  /** Report actual failures once per incident, without adding status controls to combatants. */
+  /** Report actionable failures once per incident; safe queued retries stay quiet. */
   useEffect(() => {
     for (const player of props.players) {
       const save = characterWriter?.status(player.id);
       if (!save) continue;
       const noticeId = `encounter-character-save-${player.id}`;
-      if (save.phase === 'saved') {
+      const problem =
+        save.phase === 'conflict' || save.phase === 'forbidden' || save.phase === 'rejected'
+          ? save.phase
+          : save.phase !== 'saved' && !save.stored
+            ? 'storage'
+            : null;
+      if (!problem) {
         if (saveNoticesRef.current.delete(player.id)) hideNotification(noticeId);
         continue;
       }
-      if (save.phase === 'saving' || saveNoticesRef.current.get(player.id) === save.phase) continue;
-      saveNoticesRef.current.set(player.id, save.phase);
-      const conflict = save.phase === 'conflict';
+      if (saveNoticesRef.current.get(player.id) === problem) continue;
+      saveNoticesRef.current.set(player.id, problem);
+      const conflict = problem === 'conflict';
       // Mantine ignores show calls for an existing ID. Replace the previous failure
       // when a retry discovers a conflict or revoked access, including dismissed notices.
       hideNotification(noticeId);
@@ -433,9 +443,11 @@ function SectionPanels(props: {
             <Text size='sm'>
               {conflict
                 ? `${player.name} was changed elsewhere. Open the character to resolve the conflicting edits.`
-                : save.phase === 'forbidden'
+                : problem === 'forbidden'
                   ? `You no longer have permission to edit ${player.name}.`
-                  : `Could not save ${player.name}. Retrying automatically.`}
+                  : problem === 'rejected'
+                    ? 'These changes could not be saved.'
+                    : 'Keep this page open until saving completes.'}
             </Text>
             {conflict && (
               <Button component='a' href={`/sheet/${player.id}`} variant='light' size='compact-xs' mt='xs'>

--- a/frontend/src/pages/character_sheet/CharacterSheetPage.tsx
+++ b/frontend/src/pages/character_sheet/CharacterSheetPage.tsx
@@ -508,6 +508,7 @@ function SectionPanels(props: {
 
             {activeTab === 'spells' && (
               <SpellsPanel
+                content={props.content}
                 panelHeight={props.panelHeight}
                 panelWidth={props.panelWidth}
                 id={'CHARACTER'}
@@ -881,6 +882,7 @@ function SectionPanels(props: {
               <AnimatePresence mode='wait'>
                 <motion.div key='spells' {...panelMotion}>
                   <SpellsPanel
+                    content={props.content}
                     panelHeight={props.panelHeight}
                     panelWidth={props.panelWidth}
                     id={'CHARACTER'}

--- a/frontend/src/pages/character_sheet/panels/SpellsPanel.tsx
+++ b/frontend/src/pages/character_sheet/panels/SpellsPanel.tsx
@@ -1,7 +1,7 @@
 import { ActionSymbol } from '@common/Actions';
 import TokenSelect from '@common/TokenSelect';
 import { collectEntitySpellcasting } from '@content/collect-content';
-import { fetchContentAll, getContentFast, getDefaultSources, getDefaultSourcesKey } from '@content/content-store';
+import { getContentFast } from '@content/content-store';
 import {
   Accordion,
   ActionIcon,
@@ -18,10 +18,10 @@ import {
 import ManageSpellsModal from '@modals/ManageSpellsModal';
 import { isCantrip } from '@spells/spell-utils';
 import { IconSearch, IconSquareRounded, IconSquareRoundedFilled, IconX } from '@tabler/icons-react';
-import { useQuery } from '@tanstack/react-query';
 import {
   ActionCost,
   CastingSource,
+  ContentPackage,
   LivingEntity,
   Spell,
   SpellInnateEntry,
@@ -51,6 +51,7 @@ import { IMPRINT_BG_COLOR, IMPRINT_BORDER_COLOR } from '@constants/data';
 
 export default function SpellsPanel(props: {
   id: StoreID;
+  content: ContentPackage;
   entity: LivingEntity | null;
   setEntity: SetterOrUpdater<LivingEntity | null>;
   panelHeight: number;
@@ -75,14 +76,9 @@ export default function SpellsPanel(props: {
     | undefined
   >();
 
-  const { data: spells } = useQuery({
-    queryKey: [`find-spells-and-data`, { sources: getDefaultSourcesKey('PAGE') }],
-    queryFn: async () => {
-      if (!props.entity) return null;
-
-      return await fetchContentAll<Spell>('spell', getDefaultSources('PAGE'));
-    },
-  });
+  // The page already loaded this complete catalog before calculating the entity.
+  // A separate query could cache null while the entity was still being restored.
+  const spells = props.content.spells;
 
   const charData = useMemo(() => {
     if (!props.entity) return null;

--- a/frontend/src/process/content/content-store.ts
+++ b/frontend/src/process/content/content-store.ts
@@ -146,6 +146,7 @@ const CONTENT_CACHE_VERSION = 4;
 const CONTENT_CACHE_TTL_MS = 1000 * 60 * 60 * 24; // 24h
 const CONTENT_CACHE_READ_TIMEOUT_MS = 2500;
 const CONTENT_CACHE_VERSION_TIMEOUT_MS = 750;
+const CONTENT_LOOKUP_TIMEOUT_MS = 750;
 // Unverified snapshots keep their original age even when new lookups are persisted.
 let unverifiedCacheSavedAt: number | undefined;
 
@@ -520,6 +521,10 @@ export async function fetchContent<T = Record<string, any>>(
 
   const workerContent = getWorkerContentReader();
   if (workerContent && !bypassWorkerPackage) {
+    if (type === 'trait' && data.content_sources === undefined) {
+      const traits = workerContent.lookupTrait(data);
+      if (traits !== undefined) return traits as T[];
+    }
     // Name/filter reads with the implicit INFO+PAGE scope may have more matches
     // outside the posted PAGE package. Preserve their original scoped lookup.
     if (type !== 'content-source' && data.id === undefined && data.content_sources === undefined)
@@ -747,6 +752,18 @@ export async function fetchContentPackage(
   await ensureCacheActor();
   const generation = cacheGeneration;
   const defaultSources = { PAGE: getDefaultSources('PAGE'), INFO: getDefaultSources('INFO') };
+  // Legacy operation filters resolve trait names across INFO+PAGE. Capture that
+  // full catalog without expanding PAGE candidates or blocking unrelated sheets.
+  const lookupTraitsPromise: Promise<Trait[] | undefined> = (async () => {
+    const lookupSources = await Promise.all([
+      fetchContentSources(defaultSources.INFO),
+      fetchContentSources(defaultSources.PAGE),
+    ]);
+    assertCurrentGeneration(generation);
+    return await fetchContent<Trait>('trait', {
+      content_sources: uniq(lookupSources.flat().map((source) => source.id)),
+    });
+  })().catch(() => undefined);
   const content = await Promise.all([
     fetchContentAll<Ancestry>('ancestry', sources),
     fetchContentAll<Background>('background', sources),
@@ -763,6 +780,7 @@ export async function fetchContentPackage(
     options?.fetchSources ? fetchContentSources(sources) : null,
   ]);
 
+  const lookupTraits = await withinCacheBudget(lookupTraitsPromise, CONTENT_LOOKUP_TIMEOUT_MS, undefined);
   assertCurrentGeneration(generation);
   const p = {
     ancestries: ((content[0] ?? []) as Ancestry[]).sort((a, b) => (a.name ?? '').localeCompare(b.name ?? '')),
@@ -782,6 +800,7 @@ export async function fetchContentPackage(
       (a.name ?? '').localeCompare(b.name ?? '')
     ),
     sources: content[12] as ContentSource[],
+    lookupTraits,
     defaultSources,
   } satisfies ContentPackage;
 

--- a/frontend/src/process/content/content-store.ts
+++ b/frontend/src/process/content/content-store.ts
@@ -39,7 +39,6 @@ import {
 import { RequestType } from '@schemas/requests';
 import { formatZodError } from '@schemas/shared';
 import { z } from 'zod';
-import { preloadImage } from '@utils/images';
 import { hashData } from '@utils/numbers';
 import { isTruthy } from '@utils/type-fixing';
 import { cloneDeep, isString, uniq, uniqBy } from 'lodash-es';
@@ -144,6 +143,25 @@ const CONTENT_CACHE_VERSION = 4;
 // get-content-versions on load (see verifyPersistedContentVersions). The TTL exists for the
 // cases where that check cannot run (offline, endpoint unreachable, >500 sources).
 const CONTENT_CACHE_TTL_MS = 1000 * 60 * 60 * 24; // 24h
+const CONTENT_CACHE_READ_TIMEOUT_MS = 2500;
+const CONTENT_CACHE_VERSION_TIMEOUT_MS = 750;
+// Unverified snapshots keep their original age even when new lookups are persisted.
+let unverifiedCacheSavedAt: number | undefined;
+
+/** Optional cache work has a deadline; late results never publish into the working set. */
+async function withinCacheBudget<T>(work: Promise<T>, timeoutMs: number, fallback: T): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      work,
+      new Promise<T>((resolve) => {
+        timeout = setTimeout(() => resolve(fallback), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout !== undefined) clearTimeout(timeout);
+  }
+}
 
 type PersistedContentCache = {
   version: number;
@@ -208,47 +226,56 @@ function assertCurrentGeneration(generation: number): void {
  * backstop — this is what makes every rollout order safe. A cached source with NO token
  * (pre-migration blob) compares as `undefined` vs a server string and reads as stale.
  */
-async function verifyPersistedContentVersions(rec: PersistedContentCache): Promise<'ok' | 'stale'> {
+async function verifyPersistedContentVersions(rec: PersistedContentCache): Promise<'ok' | 'stale' | 'unverified'> {
   const sourceMap = rec.idStore instanceof Map ? rec.idStore.get('content-source') : undefined;
   const sources = sourceMap instanceof Map ? ([...sourceMap.values()].filter(isTruthy) as ContentSource[]) : [];
   // Nothing to compare against (or too many for one call): fall back to the TTL.
-  if (sources.length === 0 || sources.length > 500) return 'ok';
+  if (sources.length === 0 || sources.length > 500) return 'unverified';
 
   const result = await makeRequest<{ id: number; updated_at: string }[]>(
     'get-content-versions',
     { ids: sources.map((s) => s.id) },
     false
   );
-  if (!Array.isArray(result)) return 'ok';
+  if (!Array.isArray(result)) return 'unverified';
 
   const serverTokens = new Map(result.map((r) => [r.id, r.updated_at]));
   for (const source of sources) {
     // Missing on the server = the source was deleted; token mismatch = something in it
     // changed. Raw string comparison on purpose — tokens are opaque, never date-parsed.
     if (serverTokens.get(source.id) !== source.updated_at) {
-      console.log('[CONTENT-CACHE] Source', source.id, 'changed on the server; dropping persisted cache');
+      console.log('[CONTENT-CACHE] Source', source.id, 'changed on the server');
       return 'stale';
     }
   }
   return 'ok';
 }
 
-async function hydrateContentCache(generation: number, actorId: string, signal: AbortSignal): Promise<void> {
+async function hydrateContentCache(generation: number, actorId: string): Promise<void> {
   try {
-    await storageWrites;
-    if (signal.aborted || generation !== cacheGeneration || actorId !== cacheActorId) return;
-    const rec = await idbGet<PersistedContentCache>(cacheKey(actorId));
+    const rec = await withinCacheBudget(
+      storageWrites.then(() => idbGet<PersistedContentCache>(cacheKey(actorId))),
+      CONTENT_CACHE_READ_TIMEOUT_MS,
+      null
+    );
     if (
-      signal.aborted ||
+      generation !== cacheGeneration ||
+      actorId !== cacheActorId ||
       !rec ||
       rec.version !== CONTENT_CACHE_VERSION ||
       rec.actorId !== actorId ||
       Date.now() - rec.savedAt > CONTENT_CACHE_TTL_MS
     )
       return;
-    // Check this exact snapshot, not a verdict memoized for a different blob/account.
-    if ((await verifyPersistedContentVersions(rec)) === 'stale') return;
-    if (signal.aborted || generation !== cacheGeneration || actorId !== cacheActorId) return;
+    // A slow freshness endpoint must not turn a usable local snapshot into a full download.
+    // Keep this visit consistent: a late verdict cannot swap content during calculations.
+    const freshness = await withinCacheBudget(
+      verifyPersistedContentVersions(rec),
+      CONTENT_CACHE_VERSION_TIMEOUT_MS,
+      'unverified'
+    );
+    if (freshness === 'stale' || generation !== cacheGeneration || actorId !== cacheActorId) return;
+    unverifiedCacheSavedAt = freshness === 'unverified' ? rec.savedAt : undefined;
     if (rec.contentStore instanceof Map) {
       for (const [key, value] of rec.contentStore) if (!contentStore.has(key)) contentStore.set(key, value);
     }
@@ -265,23 +292,9 @@ async function hydrateContentCache(generation: number, actorId: string, signal: 
   }
 }
 
-/** Bound optional hydration and retire its snapshot before fresh network loading starts. */
+/** Read one account's cache and check freshness within separate storage/network budgets. */
 function beginHydration(): Promise<void> {
-  const controller = new AbortController();
-  let timeout: ReturnType<typeof setTimeout> | undefined;
-  return Promise.race([
-    hydrateContentCache(cacheGeneration, cacheActorId, controller.signal),
-    new Promise<void>((resolve) => {
-      timeout = setTimeout(() => {
-        // A late cached row could resurrect content absent from a fresh download,
-        // even when hydration never overwrites an existing ID.
-        controller.abort();
-        resolve();
-      }, 2500);
-    }),
-  ]).finally(() => {
-    if (timeout !== undefined) clearTimeout(timeout);
-  });
+  return hydrateContentCache(cacheGeneration, cacheActorId);
 }
 // Started at module load and re-armed by resetContentStore(), so the in-memory store can
 // refill from the persisted cache after an in-memory clear instead of re-fetching the corpus.
@@ -299,7 +312,7 @@ async function persistContentCache(): Promise<void> {
   const record: PersistedContentCache = structuredClone({
     version: CONTENT_CACHE_VERSION,
     actorId,
-    savedAt: Date.now(),
+    savedAt: unverifiedCacheSavedAt ?? Date.now(),
     idStore,
     contentStore,
   });
@@ -608,6 +621,7 @@ export function resetContentStore(resetSources = true, clearPersisted = false) {
     persistTimer = null;
   }
   cacheDirty = false;
+  unverifiedCacheSavedAt = undefined;
 
   if (clearPersisted) {
     // The generation already invalidated old readers. Keep deletion ordered with
@@ -740,9 +754,7 @@ export async function fetchContentPackage(
     defaultSources,
   } satisfies ContentPackage;
 
-  // Preload high-need images from package
-  void Promise.allSettled([...p.ancestries, ...p.classes].map((record) => preloadImage(record.artwork_url)));
-  // Background artwork loads when displayed; preloading the entire catalog competes with sheet data.
+  // Artwork loads when displayed so unused catalog images do not compete with sheet data.
 
   return p;
 }

--- a/frontend/src/process/content/content-store.ts
+++ b/frontend/src/process/content/content-store.ts
@@ -42,6 +42,7 @@ import { z } from 'zod';
 import { hashData } from '@utils/numbers';
 import { isTruthy } from '@utils/type-fixing';
 import { cloneDeep, isString, uniq, uniqBy } from 'lodash-es';
+import { getWorkerContentReader } from '@operations/operation-content-package';
 
 ///////////////////////////////////////////////////////
 //                      Storing                      //
@@ -298,7 +299,12 @@ function beginHydration(): Promise<void> {
 }
 // Started at module load and re-armed by resetContentStore(), so the in-memory store can
 // refill from the persisted cache after an in-memory clear instead of re-fetching the corpus.
-let hydrationPromise: Promise<void> = beginHydration();
+// Calculation workers receive their complete package from the page. They must not
+// hydrate an anonymous browser cache or start a competing freshness request.
+let hydrationPromise: Promise<void> =
+  typeof WorkerGlobalScope !== 'undefined' && globalThis instanceof WorkerGlobalScope
+    ? Promise.resolve()
+    : beginHydration();
 
 let cacheDirty = false;
 let persistTimer: ReturnType<typeof setTimeout> | null = null;
@@ -404,6 +410,8 @@ export function getDefaultSourcesKey(view: SourceKey): string {
  * @param packageData - Content package data to import
  */
 export function importFromContentPackage(packageData: ContentPackage) {
+  // A worker reads its posted snapshot directly; never accumulate it in a shared cache.
+  if (getWorkerContentReader()) return;
   // Import all content
   packageData.abilityBlocks.forEach((c) => idStore.get('ability-block')?.set(c.id, c));
   packageData.ancestries.forEach((c) => idStore.get('ancestry')?.set(c.id, c));
@@ -426,6 +434,8 @@ export function importFromContentPackage(packageData: ContentPackage) {
  * @returns - Array of cached content
  */
 export function getCachedContent<T = Record<string, any>>(type: ContentType): T[] {
+  const workerContent = getWorkerContentReader();
+  if (workerContent) return workerContent.cached<T>(type);
   return [...(idStore.get(type)?.values() ?? [])].filter(isTruthy) as T[];
 }
 
@@ -463,7 +473,8 @@ export async function fetchContentAll<T = Record<string, any>>(type: ContentType
 export async function fetchContent<T = Record<string, any>>(
   type: ContentType,
   data: Record<string, any>,
-  dontStore?: boolean
+  dontStore?: boolean,
+  bypassWorkerPackage = false
 ) {
   const CONTENT_SCHEMA_MAP: Record<ContentType, z.ZodTypeAny> = {
     'ability-block': AbilityBlockSchema,
@@ -507,6 +518,19 @@ export async function fetchContent<T = Record<string, any>>(
     throw new Error(`Unknown content type: ${type}`);
   }
 
+  const workerContent = getWorkerContentReader();
+  if (workerContent && !bypassWorkerPackage) {
+    // Name/filter reads with the implicit INFO+PAGE scope may have more matches
+    // outside the posted PAGE package. Preserve their original scoped lookup.
+    if (type !== 'content-source' && data.id === undefined && data.content_sources === undefined)
+      return await fetchContent<T>(type, data, true, true);
+    const rows = workerContent.fetch<T>(type, data);
+    const ids = data.id === undefined ? null : [...new Set((Array.isArray(data.id) ? data.id : [data.id]).map(Number))];
+    if (ids && rows.length !== ids.length) return await fetchContent<T>(type, data, true, true);
+    return rows;
+  }
+  if (bypassWorkerPackage) dontStore = true;
+
   await ensureCacheActor();
   const generation = cacheGeneration;
   await hydrationPromise;
@@ -523,16 +547,19 @@ export async function fetchContent<T = Record<string, any>>(
       ? uniq(scope).sort((a, b) => a - b)
       : uniq(
           (scope
-            ? await fetchContentSources(scope)
-            : [...(await fetchContentSources(info)), ...(await fetchContentSources(page))]
+            ? await fetchContentSources(scope, bypassWorkerPackage)
+            : [
+                ...(await fetchContentSources(info, bypassWorkerPackage)),
+                ...(await fetchContentSources(page, bypassWorkerPackage)),
+              ]
           ).map((source) => source.id)
         ).sort((a, b) => a - b);
     assertCurrentGeneration(generation);
   }
 
   const onlyIdentity = Object.keys(data).every((key) => ['id', 'content_sources'].includes(key));
-  const storedIds = onlyIdentity ? getStoredIds(type, data) : null;
-  const storedFetch = getStoredFetch(type, data);
+  const storedIds = onlyIdentity && !bypassWorkerPackage ? getStoredIds(type, data) : null;
+  const storedFetch = bypassWorkerPackage ? null : getStoredFetch(type, data);
   // Name filters are substring searches on the API, so an exact cached name is not a complete result.
 
   if (storedFetch) {
@@ -550,7 +577,7 @@ export async function fetchContent<T = Record<string, any>>(
   } else {
     // Coalesce concurrent identical fetches (keyed including dontStore so a non-storing
     // fetch can't swallow a storing one). They share a single in-flight network request.
-    const fetchKey = `${hashFetch(type, data)}|${dontStore ? 1 : 0}`;
+    const fetchKey = `${hashFetch(type, data)}|${dontStore ? 1 : 0}|${bypassWorkerPackage ? 1 : 0}`;
     const inFlight = inFlightFetches.get(fetchKey);
     if (inFlight) return (await inFlight) as T[];
 
@@ -642,23 +669,27 @@ export function resetContentStore(resetSources = true, clearPersisted = false) {
 //                 Utility Functions                 //
 ///////////////////////////////////////////////////////
 
-export async function fetchContentSources(sources: SourceValue) {
+export async function fetchContentSources(sources: SourceValue, bypassWorkerPackage = false) {
+  const workerContent = getWorkerContentReader();
+  if (workerContent && !bypassWorkerPackage) return workerContent.sources(sources);
+  const fetchSources = (data: Record<string, unknown>) =>
+    fetchContent<ContentSource>('content-source', data, bypassWorkerPackage, bypassWorkerPackage);
   let results: ContentSource[] = [];
 
   if (Array.isArray(sources)) {
     // Fetch by ids
-    results = await fetchContent<ContentSource>('content-source', {
+    results = await fetchSources({
       id: sources,
     });
   } else if (sources === 'ALL-OFFICIAL-PUBLIC') {
     // This gives us everything public that is not homebrew
-    results = await fetchContent<ContentSource>('content-source', {
+    results = await fetchSources({
       homebrew: false,
       published: true,
     });
   } else if (sources === 'ALL-HOMEBREW-PUBLIC') {
     // This gives us everything public, including homebrew
-    const r = await fetchContent<ContentSource>('content-source', {
+    const r = await fetchSources({
       homebrew: true,
       published: true,
     });
@@ -667,27 +698,27 @@ export async function fetchContentSources(sources: SourceValue) {
     //
   } else if (sources === 'ALL-PUBLIC') {
     // This gives us everything public, including homebrew
-    results = await fetchContent<ContentSource>('content-source', {
+    results = await fetchSources({
       homebrew: true,
       published: true,
     });
   } else if (sources === 'ALL-USER-ACCESSIBLE') {
     // This gives us everything public that is not homebrew
-    const pr = await fetchContent<ContentSource>('content-source', {
+    const pr = await fetchSources({
       homebrew: false,
       published: true,
     });
 
     const user = await getPublicUser(undefined, { throwOnFailure: true });
     // Now fetch all the other sources the user has subscribed to
-    const ur = await fetchContent<ContentSource>('content-source', {
+    const ur = await fetchSources({
       id: user?.subscribed_content_sources?.map((s) => s.source_id) ?? [],
     });
 
     results = uniqBy([...pr, ...ur], (source) => source.id);
   } else if (sources === 'ALL-HOMEBREW-ACCESSIBLE') {
     // This gives everything with homebrew (that the user can access)
-    const pr = await fetchContent<ContentSource>('content-source', {
+    const pr = await fetchSources({
       id: undefined,
       homebrew: true,
     });

--- a/frontend/src/process/operations/operation-content-package.ts
+++ b/frontend/src/process/operations/operation-content-package.ts
@@ -1,0 +1,142 @@
+import type { ContentPackage, ContentSource, ContentType, SourceValue } from '@schemas/content';
+import { COMMON_CORE_ID } from '@constants/data';
+import { SourceValueSchema } from '@schemas/shared';
+
+const TABLES = {
+  'ability-block': 'abilityBlocks',
+  ancestry: 'ancestries',
+  archetype: 'archetypes',
+  background: 'backgrounds',
+  class: 'classes',
+  'class-archetype': 'classArchetypes',
+  'content-source': 'sources',
+  creature: 'creatures',
+  item: 'items',
+  language: 'languages',
+  spell: 'spells',
+  trait: 'traits',
+  'versatile-heritage': 'versatileHeritages',
+} as const satisfies Record<ContentType, keyof ContentPackage>;
+
+type PackageRow = { id: number; name: string; content_source_id?: number };
+
+/** Match the endpoint's case-insensitive SQL LIKE name filter, including explicit wildcards. */
+function matchesName(name: string, pattern: string): boolean {
+  const expression = [...pattern]
+    .map((character) =>
+      character === '%' ? '.*' : character === '_' ? '.' : character.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    )
+    .join('');
+  return new RegExp(`^${expression}$`, 'i').test(name);
+}
+
+/** Read only the complete content supplied for this calculation, without another account or network lookup. */
+export function createOperationContentReader(content: ContentPackage) {
+  for (const [type, field] of Object.entries(TABLES)) {
+    if (field !== 'sources' && !Array.isArray(content[field]))
+      throw new Error(`Calculation is missing ${type} content.`);
+  }
+  const page = SourceValueSchema.parse(content.defaultSources?.PAGE);
+  const enabled = Array.isArray(page) ? new Set([COMMON_CORE_ID, ...page]) : null;
+  const scopedTables = new Map<ContentType, PackageRow[]>();
+  const indexedTables = new Map<ContentType, Map<number, PackageRow>>();
+
+  const table = (type: ContentType, required: boolean): PackageRow[] => {
+    const cached = scopedTables.get(type);
+    if (cached) return cached;
+    const field = TABLES[type];
+    if (!field) return [];
+    const rows = content[field];
+    if (!Array.isArray(rows)) {
+      if (required) throw new Error(`Calculation is missing ${type} content.`);
+      return [];
+    }
+    const scoped = rows.filter((row) => {
+      const sourceId =
+        type === 'content-source' ? row.id : 'content_source_id' in row ? row.content_source_id : undefined;
+      return !enabled || (typeof sourceId === 'number' && enabled.has(sourceId));
+    });
+    scopedTables.set(type, scoped);
+    return scoped;
+  };
+  const sources = (scope: SourceValue): ContentSource[] => {
+    const rows = table('content-source', true) as ContentSource[];
+    if (Array.isArray(scope)) return rows.filter((source) => scope.includes(source.id));
+    if (scope === 'ALL-USER-ACCESSIBLE') return rows;
+    return rows.filter((source) => {
+      if (scope === 'ALL-OFFICIAL-PUBLIC') return source.user_id === null && source.is_published;
+      if (scope === 'ALL-HOMEBREW-PUBLIC') return source.user_id !== null && source.is_published;
+      if (scope === 'ALL-PUBLIC') return source.is_published;
+      return source.user_id !== null;
+    });
+  };
+  return {
+    sources,
+    /** Optional prose/cache lookups retain their existing empty result for unknown subtypes. */
+    cached<T>(type: ContentType): T[] {
+      // Fetch boundaries already validated these rows. Preserve extension fields and
+      // the content store's existing caller-selected return type without cloning them.
+      return table(type, false) as T[];
+    },
+    fetch<T>(type: ContentType, data: Record<string, unknown>): T[] {
+      let rows = table(type, type !== 'content-source' || data.id === undefined);
+      if (data.id !== undefined) {
+        let index = indexedTables.get(type);
+        if (!index) {
+          index = new Map(rows.map((row) => [row.id, row]));
+          indexedTables.set(type, index);
+        }
+        const ids = new Set((Array.isArray(data.id) ? data.id : [data.id]).map(Number));
+        rows = [...ids].map((id) => index.get(id)).filter((row): row is PackageRow => !!row);
+      }
+      const scope = data.content_sources === undefined ? undefined : SourceValueSchema.parse(data.content_sources);
+      if (type !== 'content-source' && scope !== undefined) {
+        const ids = Array.isArray(scope)
+          ? new Set(scope)
+          : scope === page || scope === 'ALL-USER-ACCESSIBLE'
+            ? null
+            : new Set(sources(scope).map((source) => source.id));
+        if (ids)
+          rows = rows.filter((row) => typeof row.content_source_id === 'number' && ids.has(row.content_source_id));
+      }
+      for (const [key, value] of Object.entries(data)) {
+        if (value === undefined || key === 'content_sources' || key === 'id') continue;
+        if (key === 'homebrew') {
+          if (!data.id && value === false) rows = rows.filter((row) => 'user_id' in row && row.user_id === null);
+          continue;
+        }
+        rows = rows.filter((row) => {
+          const column = key === 'published' ? 'is_published' : key;
+          const actual = Reflect.get(row, column);
+          if (key === 'name' && typeof value === 'string') return matchesName(row.name, value);
+          if (Array.isArray(value)) {
+            if (key === 'traits' || key === 'prerequisites')
+              return Array.isArray(actual) && value.every((item) => actual.includes(item));
+            return value.includes(actual);
+          }
+          return actual === value;
+        });
+      }
+      return rows as T[];
+    },
+  };
+}
+
+let workerContent: ReturnType<typeof createOperationContentReader> | undefined;
+
+/** The regular browser cache is unchanged unless the dedicated worker installs a job package. */
+export function getWorkerContentReader(): typeof workerContent {
+  return workerContent;
+}
+
+/** Install one worker job's package and always release it before another calculation runs. */
+export async function withWorkerContentPackage<T>(content: ContentPackage, execute: () => Promise<T>): Promise<T> {
+  if (typeof document !== 'undefined') throw new Error('Calculation package overrides are restricted to workers.');
+  if (workerContent) throw new Error('A calculation content package is already active.');
+  workerContent = createOperationContentReader(content);
+  try {
+    return await execute();
+  } finally {
+    workerContent = undefined;
+  }
+}

--- a/frontend/src/process/operations/operation-content-package.ts
+++ b/frontend/src/process/operations/operation-content-package.ts
@@ -1,4 +1,4 @@
-import type { ContentPackage, ContentSource, ContentType, SourceValue } from '@schemas/content';
+import type { ContentPackage, ContentSource, ContentType, SourceValue, Trait } from '@schemas/content';
 import { COMMON_CORE_ID } from '@constants/data';
 import { SourceValueSchema } from '@schemas/shared';
 
@@ -21,13 +21,24 @@ const TABLES = {
 type PackageRow = { id: number; name: string; content_source_id?: number };
 
 /** Match the endpoint's case-insensitive SQL LIKE name filter, including explicit wildcards. */
-function matchesName(name: string, pattern: string): boolean {
-  const expression = [...pattern]
-    .map((character) =>
-      character === '%' ? '.*' : character === '_' ? '.' : character.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-    )
-    .join('');
-  return new RegExp(`^${expression}$`, 'i').test(name);
+function namePattern(pattern: string): RegExp {
+  let expression = '';
+  let escaped = false;
+  for (const character of pattern) {
+    if (!escaped && character === '\\') {
+      escaped = true;
+      continue;
+    }
+    expression +=
+      !escaped && character === '%'
+        ? '.*'
+        : !escaped && character === '_'
+          ? '.'
+          : character.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    escaped = false;
+  }
+  if (escaped) throw new Error('Invalid trailing escape in a content name filter.');
+  return new RegExp(`^${expression}$`, 'is');
 }
 
 /** Read only the complete content supplied for this calculation, without another account or network lookup. */
@@ -40,6 +51,9 @@ export function createOperationContentReader(content: ContentPackage) {
   const enabled = Array.isArray(page) ? new Set([COMMON_CORE_ID, ...page]) : null;
   const scopedTables = new Map<ContentType, PackageRow[]>();
   const indexedTables = new Map<ContentType, Map<number, PackageRow>>();
+  const lookupTraits = content.lookupTraits
+    ? [...content.lookupTraits].sort((left, right) => left.id - right.id)
+    : undefined;
 
   const table = (type: ContentType, required: boolean): PackageRow[] => {
     const cached = scopedTables.get(type);
@@ -72,6 +86,21 @@ export function createOperationContentReader(content: ContentPackage) {
   };
   return {
     sources,
+    /** Match find-trait's implicit scope, ID precedence, trimming and first-row behavior. */
+    lookupTrait(data: Record<string, unknown>): Trait[] | undefined {
+      if (!lookupTraits) return undefined;
+      if (data.id) {
+        const ids = new Set((Array.isArray(data.id) ? data.id : [data.id]).map(Number));
+        const rows = lookupTraits.filter((row) => ids.has(row.id));
+        return Array.isArray(data.id) && data.name === undefined ? rows : rows.slice(0, 1);
+      }
+      if (typeof data.name === 'string') {
+        const match = data.name ? namePattern(data.name.trim()) : null;
+        const row = lookupTraits.find((row) => !match || match.test(row.name));
+        return row ? [row] : [];
+      }
+      return undefined;
+    },
     /** Optional prose/cache lookups retain their existing empty result for unknown subtypes. */
     cached<T>(type: ContentType): T[] {
       // Fetch boundaries already validated these rows. Preserve extension fields and
@@ -105,10 +134,11 @@ export function createOperationContentReader(content: ContentPackage) {
           if (!data.id && value === false) rows = rows.filter((row) => 'user_id' in row && row.user_id === null);
           continue;
         }
+        const nameMatch = key === 'name' && typeof value === 'string' ? namePattern(value) : null;
         rows = rows.filter((row) => {
           const column = key === 'published' ? 'is_published' : key;
           const actual = Reflect.get(row, column);
-          if (key === 'name' && typeof value === 'string') return matchesName(row.name, value);
+          if (nameMatch) return nameMatch.test(row.name);
           if (Array.isArray(value)) {
             if (key === 'traits' || key === 'prerequisites')
               return Array.isArray(actual) && value.every((item) => actual.includes(item));

--- a/frontend/src/process/operations/operations.worker.ts
+++ b/frontend/src/process/operations/operations.worker.ts
@@ -4,6 +4,7 @@ export {};
 import { OperationExecution } from '@schemas/content';
 import { _executeCharacterOperations, _executeCreatureOperations } from '../operations/operation-controller';
 import { VariableStore } from '@schemas/variables';
+import { withWorkerContentPackage } from './operation-content-package';
 
 type WorkerRequest = {
   id: number;
@@ -17,18 +18,12 @@ self.onmessage = async (e: MessageEvent<WorkerRequest>) => {
   const { id, execution, charStore } = e.data;
 
   try {
-    let result;
-
-    if (execution.type === 'CHARACTER') {
-      result = await _executeCharacterOperations(execution.data);
-    } else if (execution.type === 'CREATURE') {
-      result = await _executeCreatureOperations({
-        ...execution.data,
-        charStore: charStore!,
-      });
-    } else {
+    const result = await withWorkerContentPackage(execution.data.content, async () => {
+      if (execution.type === 'CHARACTER') return await _executeCharacterOperations(execution.data);
+      if (execution.type === 'CREATURE')
+        return await _executeCreatureOperations({ ...execution.data, charStore: charStore! });
       throw new Error('Unknown operation execution type');
-    }
+    });
 
     const response: WorkerResponse = {
       id,

--- a/frontend/src/request/request-manager.ts
+++ b/frontend/src/request/request-manager.ts
@@ -4,6 +4,7 @@ import { JSendResponse, RequestType } from '@schemas/requests';
 import { logError, throwError } from '@utils/error-handling';
 import { hideNotification, showNotification } from '@mantine/notifications';
 import { supabase } from '../supabase-client';
+import { RequestRejectedError } from './request-rejection';
 
 const MAX_TRANSIENT_RETRIES = 1;
 // A lost response can follow a committed write. Only explicitly read-only handlers
@@ -115,7 +116,7 @@ export async function makeRequest<T = Record<string, any>>(
   type: RequestType,
   body: Record<string, any>,
   notifyFailure = true,
-  options?: { expectedActorId?: string; throwOnFailure?: boolean }
+  options?: { expectedActorId?: string; throwOnFailure?: boolean; throwOnRejection?: boolean }
 ): Promise<T | null> {
   let lastError: any = null;
   let lastErrorBody: unknown = null;
@@ -139,6 +140,7 @@ export async function makeRequest<T = Record<string, any>>(
       }
       if (response.status !== 'success') {
         if (notifyFailure) logError('Failed to make request');
+        if (response.status === 'fail' && options?.throwOnRejection) throw new RequestRejectedError(type);
         return failure();
       }
       return response.data as T;
@@ -170,6 +172,12 @@ export async function makeRequest<T = Record<string, any>>(
         )
           notifySessionExpired();
         break;
+      }
+      // JWT-related 400 responses above retain their existing auth recovery. Only
+      // explicit input rejection can stop a writer repeating the same payload.
+      if (options?.throwOnRejection && [400, 413, 422].includes(error.context.status)) {
+        console.error(`Request to '${type}' rejected (HTTP ${error.context.status})`, lastErrorBody);
+        throw new RequestRejectedError(type);
       }
     }
 

--- a/frontend/src/request/request-rejection.ts
+++ b/frontend/src/request/request-rejection.ts
@@ -1,0 +1,7 @@
+/** A confirmed input rejection, distinct from an ambiguous timeout or connection failure. */
+export class RequestRejectedError extends Error {
+  constructor(requestType: string) {
+    super(`Request rejected: ${requestType}`);
+    this.name = 'RequestRejectedError';
+  }
+}

--- a/frontend/src/schemas/content.ts
+++ b/frontend/src/schemas/content.ts
@@ -1124,6 +1124,8 @@ export const ContentPackageSchema = z.object({
   versatileHeritages: z.array(VersatileHeritageSchema),
   classArchetypes: z.array(ClassArchetypeSchema),
   sources: z.array(ContentSourceSchema).optional(),
+  // Complete INFO+PAGE trait lookup data, separate from PAGE selection candidates.
+  lookupTraits: z.array(TraitSchema).optional(),
   defaultSources: z.record(SourceKeySchema, SourceValueSchema),
 });
 export type ContentPackage = z.infer<typeof ContentPackageSchema>;

--- a/frontend/src/utils/encounter-character-writer.ts
+++ b/frontend/src/utils/encounter-character-writer.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { mergeCharacterSave } from './character-merge';
 import { compareCharacterVersions } from './character-version';
 import { EncounterCharacterSchema } from './encounter-character-schema';
+import { RequestRejectedError } from '@requests/request-rejection';
 import {
   bufferCharacterSave,
   characterSaveValuesEqual,
@@ -14,7 +15,7 @@ import {
 
 export type EncounterCharacterSave = {
   character: Character;
-  phase: 'saving' | 'saved' | 'failed' | 'conflict' | 'forbidden';
+  phase: 'saving' | 'saved' | 'failed' | 'conflict' | 'forbidden' | 'rejected';
   stored: boolean;
   conflicts: string[];
 };
@@ -22,6 +23,7 @@ type Entry = EncounterCharacterSave & {
   base: Character;
   running: boolean;
   uncertain?: Character;
+  rejected?: Character;
   retries: number;
   timer?: ReturnType<typeof setTimeout>;
 };
@@ -72,10 +74,12 @@ export function createEncounterCharacterWriter(options: { actorId: string; reque
   /** Re-read before retries, including an ambiguous write whose response was lost. */
   const run = async (entry: Entry): Promise<void> => {
     if (disposed || entry.running || entry.phase === 'conflict' || entry.phase === 'forbidden') return;
+    if (entry.phase === 'rejected' && (!entry.rejected || same(entry.character, entry.rejected))) return;
     if (entry.timer) clearTimeout(entry.timer);
     entry.timer = undefined;
     entry.running = true;
     entry.phase = 'saving';
+    entry.rejected = undefined;
     publish();
     try {
       let remote = parseRow(await options.request('find-character', { id: entry.character.id }), entry.character.id);
@@ -142,12 +146,20 @@ export function createEncounterCharacterWriter(options: { actorId: string; reque
     } catch (error) {
       if (disposed) return;
       console.error('Encounter character save failed:', error);
+      if (error instanceof RequestRejectedError) {
+        entry.phase = 'rejected';
+        entry.rejected = entry.uncertain;
+        reconcile(entry, entry.base);
+        return;
+      }
       entry.phase = 'failed';
       retain(entry);
       entry.timer = setTimeout(() => void run(entry), Math.min(30000, 2000 * 2 ** Math.min(entry.retries++, 4)));
     } finally {
       entry.running = false;
       publish();
+      // A newer edit queued while the rejected request was in flight still saves.
+      if (entry.phase === 'rejected' && entry.rejected && !same(entry.character, entry.rejected)) void run(entry);
     }
   };
 

--- a/frontend/src/utils/use-character.tsx
+++ b/frontend/src/utils/use-character.tsx
@@ -27,6 +27,7 @@ import { hideNotification, showNotification } from '@mantine/notifications';
 import { executeOperations, isOperationCancelled } from '@operations/operations.main';
 import { confirmHealth } from '@pages/character_sheet/entity-handler';
 import { hasSessionExpiredNotice, makeRequest } from '@requests/request-manager';
+import { RequestRejectedError } from '@requests/request-rejection';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { Character, CharacterSchema, ContentPackage, OperationCharacterResultPackage } from '@schemas/content';
 import { saveCalculatedStats } from '@variables/calculated-stats';
@@ -114,6 +115,9 @@ export default function useCharacter(
   const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const retryCountRef = useRef(0);
   const retrySaveRef = useRef<() => void>(() => {});
+  const hasSavedRef = useRef(false);
+  const storageNoticeRef = useRef(false);
+  const rejectedSaveRef = useRef<Character | null>(null);
 
   /** Only retire recovered snapshots after their merged values are accepted. */
   const acknowledgeRecoveredDrafts = () => {
@@ -200,7 +204,7 @@ export default function useCharacter(
   const offerConflictResolution = useCallback(
     (remote: Character) => {
       saveConflictRef.current = true;
-      hideNotification('character-save-failed');
+      hideNotification(`character-save-rejected-${characterId}`);
       clearSaveRetry();
       setSavePhase('idle');
       const scope = saveScopeRef.current;
@@ -263,6 +267,9 @@ export default function useCharacter(
     setLoadedIdentity(null);
     setLoadError(false);
     setSavePhase('idle');
+    setDraftStored(true);
+    hasSavedRef.current = false;
+    rejectedSaveRef.current = null;
     retryCountRef.current = 0;
     uncertainSaveRef.current = null;
     recoveredDraftsRef.current = [];
@@ -335,7 +342,10 @@ export default function useCharacter(
       clearSaveRetry();
       window.removeEventListener('online', retryLoadOnReconnect);
       hideNotification(`character-conflict-${characterId}`);
-      hideNotification('character-save-failed');
+      hideNotification(`character-save-permission-${characterId}`);
+      hideNotification(`character-save-storage-${characterId}`);
+      hideNotification(`character-save-rejected-${characterId}`);
+      storageNoticeRef.current = false;
     };
   }, [characterId, sessionActorId, loadAttempt, handleFetchedCharacter, offerConflictResolution]);
 
@@ -609,7 +619,8 @@ export default function useCharacter(
     characterRef.current = merged;
     if (!needsSave) {
       retryCountRef.current = 0;
-      hideNotification('character-save-failed');
+      rejectedSaveRef.current = null;
+      hideNotification(`character-save-rejected-${characterId}`);
       acknowledgeRecoveredDrafts();
     }
     if (changed) setCharacter(merged);
@@ -655,7 +666,11 @@ export default function useCharacter(
       const data = Object.fromEntries(SAVED_CHARACTER_FIELDS.map((field) => [field, save.character[field]]));
       writeRevisionRef.current += 1;
       uncertainSaveRef.current = { submitted: data, expectedUpdatedAt: expected_updated_at };
-      journalCharacterSaveSubmission(save.character.id, save.actorId, data, expected_updated_at);
+      if (
+        journalCharacterSaveSubmission(save.character.id, save.actorId, data, expected_updated_at).status ===
+        'unavailable'
+      )
+        setDraftStored(false);
       const resData = await makeRequest(
         'update-character',
         {
@@ -664,7 +679,7 @@ export default function useCharacter(
           ...(expected_updated_at ? { expected_updated_at } : {}),
         },
         false,
-        { expectedActorId: save.actorId }
+        { expectedActorId: save.actorId, throwOnRejection: true }
       );
       const request = { expected_updated_at, submitted: data };
       // makeRequest returns null for every failure (HTTP error, timeout, JSend
@@ -696,11 +711,18 @@ export default function useCharacter(
       clearSaveRetry();
       setSavePhase('idle');
       if (result.forbidden) {
-        // View-only session (e.g. a public sheet). Stop auto-saving entirely —
-        // nothing we send will ever be accepted, and retrying just spams the API.
+        // Public viewers can calculate locally. Only a known editor losing access
+        // needs a warning; neither case should continue sending rejected writes.
         readOnlyRef.current = true;
-        hideNotification('character-save-failed');
         pendingSaveRef.current = null;
+        if (save.character.user_id === save.actorId || hasSavedRef.current)
+          showNotification({
+            id: `character-save-permission-${characterId}`,
+            title: 'Changes not saved',
+            message: 'You no longer have permission to edit this character.',
+            color: 'yellow',
+            autoClose: false,
+          });
         console.warn('Character is view-only for this session; auto-save disabled.');
         return;
       }
@@ -721,7 +743,9 @@ export default function useCharacter(
         // Record the authoritative post-write state (incl. the new updated_at token).
         conflictStreakRef.current = 0;
         retryCountRef.current = 0;
-        hideNotification('character-save-failed');
+        hasSavedRef.current = true;
+        rejectedSaveRef.current = null;
+        hideNotification(`character-save-rejected-${characterId}`);
         lastSyncedRef.current = result.server;
         acknowledgeBufferedCharacterSave(
           save.character.id,
@@ -739,25 +763,35 @@ export default function useCharacter(
       console.error('Character save failed:', error);
       reportClientFailure('save_failed');
       setSavePhase('failed');
-      if (!hasSessionExpiredNotice() && retryCountRef.current === 0)
-        showNotification({
-          id: 'character-save-failed',
-          title: 'Changes not saved',
-          message: (
-            <Group gap='xs'>
-              <Text size='sm'>Retrying automatically.</Text>
-              <Button size='compact-xs' variant='light' onClick={() => retrySaveRef.current()}>
-                Retry now
-              </Button>
-            </Group>
-          ),
-          color: 'yellow',
-          autoClose: false,
-          withCloseButton: true,
-          closeButtonProps: { 'aria-label': 'Dismiss save notice' },
-        });
-      // A bounded backoff also recovers when a flaky network never fires `online`.
       clearSaveRetry();
+      if (error instanceof RequestRejectedError) {
+        // The server explicitly rejected this snapshot. Keep the edit, clear its
+        // uncertain-write journal, and wait for a changed payload before retrying.
+        rejectedSaveRef.current = cloneDeep(save.character);
+        uncertainSaveRef.current = null;
+        const current = characterRef.current;
+        const base = lastSyncedRef.current;
+        if (current && base)
+          setDraftStored(
+            reconcileBufferedCharacterSave(current, save.actorId, base, {
+              requiresCalculation: !canPersistRef.current(),
+            }).status !== 'unavailable'
+          );
+        if (
+          current &&
+          SAVED_CHARACTER_FIELDS.every((field) => characterSaveValuesEqual(current[field], save.character[field]))
+        )
+          showNotification({
+            id: `character-save-rejected-${characterId}`,
+            title: 'Changes not saved',
+            message: 'These changes could not be saved.',
+            color: 'yellow',
+            autoClose: false,
+          });
+        return;
+      }
+      // A connection failure is recoverable while the local draft is safe. Retry
+      // quietly, including when a flaky network never fires an `online` event.
       if (!hasSessionExpiredNotice()) {
         const delay = Math.min(30000, 2000 * 2 ** Math.min(retryCountRef.current++, 4));
         retryTimerRef.current = setTimeout(() => {
@@ -771,6 +805,11 @@ export default function useCharacter(
       // Once the in-flight save resolves, flush the latest pending snapshot (if any).
       const next = pendingSaveRef.current;
       pendingSaveRef.current = null;
+      if (_error instanceof RequestRejectedError && next) {
+        savingRef.current = false;
+        mutateCharacter(characterRef.current ?? next.character);
+        return;
+      }
       if (!_error && next && canPersistRef.current()) {
         setSavePhase('saving');
         mutateCharacterRaw({ ...next, character: characterRef.current ?? next.character });
@@ -780,8 +819,19 @@ export default function useCharacter(
     },
   });
 
-  const mutateCharacter = (snapshot: Character) => {
+  const mutateCharacter = (snapshot: Character): void => {
     if (!canPersist() || !loadedActorRef.current) return;
+    if (
+      rejectedSaveRef.current &&
+      SAVED_CHARACTER_FIELDS.every((field) =>
+        characterSaveValuesEqual(snapshot[field], rejectedSaveRef.current?.[field])
+      )
+    )
+      return;
+    if (rejectedSaveRef.current) {
+      rejectedSaveRef.current = null;
+      hideNotification(`character-save-rejected-${characterId}`);
+    }
     const save = { character: snapshot, actorId: loadedActorRef.current, scope: saveScopeRef.current };
     if (savingRef.current) {
       // Keep the freshest snapshot while the current write owns the server version.
@@ -883,6 +933,25 @@ export default function useCharacter(
     !!uncertainSaveRef.current ||
     !character ||
     SAVED_CHARACTER_FIELDS.some((field) => !characterSaveValuesEqual(character[field], lastSyncedRef.current?.[field]));
+  /** Only warn when pending edits cannot be kept safely through closing the page. */
+  useEffect(() => {
+    const needsNotice =
+      hasLoadedCharacter && !!sessionActorId && !draftStored && hasPendingChanges && !readOnlyRef.current;
+    if (needsNotice === storageNoticeRef.current) return;
+    storageNoticeRef.current = needsNotice;
+    const id = `character-save-storage-${characterId}`;
+    if (!needsNotice) {
+      hideNotification(id);
+      return;
+    }
+    showNotification({
+      id,
+      title: 'Changes not saved',
+      message: 'Keep this page open until saving completes.',
+      color: 'yellow',
+      autoClose: false,
+    });
+  }, [characterId, sessionActorId, hasLoadedCharacter, draftStored, hasPendingChanges, savePhase]);
   const saveState: CharacterSaveState = readOnlyRef.current
     ? 'read-only'
     : saveConflictRef.current

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -23,6 +23,20 @@ const manifestForPlugin: Partial<VitePWAOptions> = {
   includeAssets: ['apple-icon-180.png', 'maskable_icon.png'],
   workbox: {
     maximumFileSizeToCacheInBytes: 15 * 1024 * 1024, // 15 MiB
+    // Developer reports never belong in the offline app. Cache the optional icon set
+    // when it is used, without competing with the initial sheet/content download.
+    globIgnores: ['**/stats.html', '**/game-icons-*.js'],
+    runtimeCaching: [
+      {
+        urlPattern: /\/assets\/game-icons-[^/]+\.js$/,
+        handler: 'CacheFirst',
+        options: {
+          cacheName: 'wg-game-icons',
+          expiration: { maxEntries: 3, maxAgeSeconds: 30 * 24 * 60 * 60 },
+          cacheableResponse: { statuses: [200] },
+        },
+      },
+    ],
   },
   manifest: {
     name: "Wanderer's Guide",
@@ -96,12 +110,21 @@ export default defineConfig({
   plugins: [
     react(),
     visualizer({
-      emitFile: true,
-      filename: 'stats.html',
+      emitFile: false,
+      filename: '.scratch/bundle-stats.html',
     }),
     VitePWA(manifestForPlugin),
   ],
   build: {
+    rollupOptions: {
+      output: {
+        // Give the existing dynamic icon chunk a stable purpose for the cache policy.
+        chunkFileNames: (chunk) =>
+          chunk.moduleIds.some((id) => id.includes('/react-icons/gi/'))
+            ? 'assets/game-icons-[hash].js'
+            : 'assets/[name]-[hash].js',
+      },
+    },
     // Was: a @babel/preset-env pass (targets ios15) running over the whole bundle on top
     // of esbuild — a redundant second transpile. esbuild lowers syntax to the same target
     // in a single pass; 'safari15' preserves the original iOS 15 support intent.


### PR DESCRIPTION
Slow mobile loading could discard useful cached content, calculations repeated lookups for content already loaded, and transient save interruptions produced unnecessary error toasts. Reuse recent content and the active calculation package, retain and retry interrupted edits quietly, and reserve notifications for actionable save failures.

- Give IndexedDB reads and freshness checks separate deadlines. Preserve unverified snapshots' original age and prevent late results from replacing an active calculation.
- Remove the developer report, idle game-icon preload, and unused catalog artwork downloads. The service-worker precache drops from about 18.8 MB to 7.9 MB uncompressed; game icons are cached after use.
- Let workers use the posted package for included IDs and PAGE lists. Preserve scoped cross-book lookups for missing references, without storing fallback results across worker jobs.
- Cache optional INFO+PAGE trait lookup metadata so legacy name filters can calculate from cache while preserving first-by-ID semantics. It adds about 0.7 MB of public trait JSON before compression on a cold cache, with at most 750 ms of extra wait after required content finishes.
- Use the complete page spell catalog in character and creature panels. An early render can no longer cache an empty spell catalog while the character is being restored.
- Retry temporary save failures silently while local drafts remain safe. Keep storage, access, conflict, session, and explicit rejection notifications actionable. Rejected edits stay retained, and corrected edits retry automatically. Normal sheet controls and layout are unchanged.

Validation: 181 infrastructure tests and 203 rules tests pass, including actual worker/controller/content-store boundary tests. TypeScript, lint, documentation links, and the generated-bundle guard pass. All 14 built-app browser scenarios pass, covering cold/cache-outage mobile loading, prepared-spell recovery, interrupted saves, and campaign synchronization. The read-only production backend compatibility gate passes for this exact commit. Full CI passes, including the complete browser suite.

Tradeoffs: a slow freshness check may use content under 24 hours old for that visit. First-time game icons and uncached cross-book references can require a connection. The mobile tests emulate constrained Chromium CPU/network conditions and page reopening; they do not certify physical iOS/Android process eviction.
